### PR TITLE
Added check for x86_64 for Mac OS X.

### DIFF
--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -140,7 +140,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define ARCH_STRING "i386"
 #define Q3_LITTLE_ENDIAN
 #elif defined __x86_64__
-#define ARCH_STRING "x86"
+#define ARCH_STRING "x86_64"
 #define Q3_LITTLE_ENDIAN
 #endif
 


### PR DESCRIPTION
Compiling on Mac OS X with x86_64 architecture fails with preprocessing error from code/qcommon/q_platform.h: "Architecture not supported". This change fixes that.
