### PR TITLE
README and compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ language: c
 
 compiler:
   - gcc
-# These fail because ioquake3 is missing vorbis
-# Re-enable after they add vorbis or OA imports it
-# - i686-w64-mingw32-gcc
-# - x86_64-w64-mingw32-gcc
+  - clang
 
 script: make
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# OpenArena gamecode #
+# OpenArena gamecode 
+[![Build Status](https://travis-ci.org/OpenArena/gamecode.svg?branch=master)](https://travis-ci.org/OpenArena/gamecode)
 
 ## Description ##
 This is the game code part of OpenArena. In mod form it is referred as OpenArenaExpanded (OAX).

--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ See http://openarena.wikia.com/wiki/OpenArena_eXpanded for detailed build instru
 ## Extracting entities ##
 It is possible to extract entity definition for use with GtkRadiant 1.6 like this:
 
-'''
+```
 cd code/game
 ./extract_entities.sh > openarena.def
-'''
+```
 
 Note that these entities will not work with GtkRadiant 1.5 and NetRadiant 1.5 because they use a XML-based format (although there are not that much XML information in it)
 
 ## Links ##
-Development documentation is still located on Google code here: https://code.google.com/p/oax/w/list
+Development documentation is located here: https://github.com/OpenArena/gamecode/wiki
 
 The development board on the OpenArena forum: http://openarena.ws/board/index.php?board=30.0
 


### PR DESCRIPTION
The old README contained a small formatting mistake. The wiki has moved and it does compile with clang, so let us keep it that way.