### PR TITLE
Check the array length rather than the gametype name. 

### DIFF
--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -124,7 +124,7 @@ int untrap_BotGetLevelItemGoal(int start, char *classname, void /* struct bot_go
     while(start>-1) {
         if(!trap_AAS_ValueForBSPEpairKey(start,"gametype",allowedGametypes,MAX_EPAIRKEY))
             return start; //No gametype flag
-        if( gametype >= GT_FFA && gametype < GT_MAX_GAME_TYPE ) {
+        if( gametype >= GT_FFA && gametype < ARRAY_LEN(gametypeNames) ) {
             gametypeName = gametypeNames[gametype];
             if(strstr( allowedGametypes, gametypeName ))
             {

--- a/code/game/g_spawn.c
+++ b/code/game/g_spawn.c
@@ -492,7 +492,7 @@ void G_SpawnGEntityFromSpawnVars( void ) {
 	}
 
 	if( G_SpawnString( "gametype", NULL, &value ) ) {
-		if( g_gametype.integer >= GT_FFA && g_gametype.integer < GT_MAX_GAME_TYPE ) {
+		if( g_gametype.integer >= GT_FFA && g_gametype.integer < ARRAY_LEN(gametypeNames) ) {
 			gametypeName = gametypeNames[g_gametype.integer];
 
 			s = strstr( value, gametypeName );


### PR DESCRIPTION
While implementing possession I discovered that this code was very vulnable. Had I not had my description from 5 years ago I would properly have missed it.