### PR TITLE
Prox mines short fuse in Harvester + g_voteGametypes default updated

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -280,7 +280,7 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &g_maxvotes, "g_maxVotes", MAX_VOTE_COUNT, CVAR_ARCHIVE, 0, qfalse },
 	{ &g_voteNames, "g_voteNames", "/map_restart/nextmap/map/g_gametype/kick/clientkick/g_doWarmup/timelimit/fraglimit/shuffle/", CVAR_ARCHIVE, 0, qfalse }, //clientkick g_doWarmup timelimit fraglimit
 	{ &g_voteBan, "g_voteBan", "0", CVAR_ARCHIVE, 0, qfalse },
-	{ &g_voteGametypes, "g_voteGametypes", "/0/1/3/4/5/6/7/8/9/10/11/12/", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse },
+	{ &g_voteGametypes, "g_voteGametypes", "/0/1/3/4/5/6/7/8/9/10/11/12/13/", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse },
 	{ &g_voteMaxTimelimit, "g_voteMaxTimelimit", "1000", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse },
 	{ &g_voteMinTimelimit, "g_voteMinTimelimit", "0", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse },
 	{ &g_voteMaxFraglimit, "g_voteMaxFraglimit", "0", CVAR_SERVERINFO | CVAR_ARCHIVE, 0, qfalse },

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -189,12 +189,11 @@ static void ProximityMine_Activate( gentity_t *ent )
 		c = NULL;
 	}
 	
-	if (g_gametype.integer == GT_TEAM || g_gametype.integer == GT_DOMINATION || g_gametype.integer == GT_ELIMINATION || g_gametype.integer == GT_DOUBLE_D
-			 || g_gametype.integer == GT_HARVESTER) {
+	if (g_gametype.integer == GT_TEAM || g_gametype.integer == GT_DOMINATION || g_gametype.integer == GT_ELIMINATION || g_gametype.integer == GT_DOUBLE_D) {
 		c = NULL;
 	}
 	
-	if (g_gametype.integer == GT_OBELISK ) {
+	if (g_gametype.integer == GT_OBELISK || g_gametype.integer == GT_HARVESTER) {
 		switch (ent->s.generic1) {
 		case TEAM_RED:
 			c = "team_redobelisk";


### PR DESCRIPTION
Hello, my first pull request ever.

As I expressed on the forum [when I posted the code change preview some days ago](http://openarena.ws/board/index.php?topic=1908.msg54553#msg54553), I think that, apart from the different entity which identifies bases (obelisk instead of flag), Harvester and OneFlag do have similar game mechanics (bring something to enemy base), so if your mines explode early near to your own base in one of the modes, it has got sense to apply the same also to the other one.
I find it more "coherent" this way, even if maybe in these two modes the feature is not as necessary as in "standard" CTF mode.
Also, it's simpler to describe in documentation: _"if you throw prox mines near to your own base, if it's relevant for the gametype, they will explode after a short time."_ without having to specify for which gametypes it's true and for which ones it's not.

Hence, this small change makes your mines explode early near to your own "obelisk" (in this case acting as "skull receptacle") also in Harvester mode, in addition to Overload.

You know that _I do not know C language_ (so please check everything I do), but [looking at the previous change](https://github.com/OpenArena/gamecode/commit/02315f58ea232cdaa49e49e2887fb71355029f6f), this one _looked like so easy_ to be possible even without knowing the language. I just hope that "team_redobelisk" and "team_blueobelisk" mentioned there do actually refer to the _entity names_ specified in the map (which _are the same_ for both Harvester skull receptacles and Overload obelisks), which have those exact names. You can however be sure I will test it as soon as I will be able to grab the nightly build containing the change.

I also updated default g_voteGametypes value, adding "13/" at the end of the value, to include Possession gametype.