### PR TITLE
Be generically portable to new CPUs on all GNU platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 COMPILE_PLATFORM=$(shell uname|sed -e s/_.*//|tr '[:upper:]' '[:lower:]'|sed -e 's/\//_/g')
 
-COMPILE_ARCH=$(shell uname -m | sed -e s/i.86/x86/)
+COMPILE_ARCH=$(shell uname -m | sed -e s/i.86/x86/ | sed -e 's/^arm.*/arm/')
 
 ifeq ($(COMPILE_PLATFORM),sunos)
   # Solaris uname and GNU uname differ

--- a/Makefile
+++ b/Makefile
@@ -300,25 +300,10 @@ endif
 # SETUP AND BUILD -- LINUX
 #############################################################################
 
-## Defaults
-LIB=lib
-
 INSTALL=install
 MKDIR=mkdir
 
 ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
-
-  ifeq ($(ARCH),x86_64)
-    LIB=lib64
-  else
-  ifeq ($(ARCH),ppc64)
-    LIB=lib64
-  else
-  ifeq ($(ARCH),s390x)
-    LIB=lib64
-  endif
-  endif
-  endif
 
   BASE_CFLAGS = -Wall -fno-strict-aliasing -Wimplicit -Wstrict-prototypes \
     -pipe -DUSE_ICON
@@ -799,6 +784,7 @@ else # ifeq netbsd
 #############################################################################
 
 ifeq ($(PLATFORM),irix64)
+  LIB=lib
 
   ARCH=mips
 

--- a/Makefile
+++ b/Makefile
@@ -303,10 +303,14 @@ endif
 INSTALL=install
 MKDIR=mkdir
 
+ifneq (,$(findstring "$(COMPILE_PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
+  TOOLS_CFLAGS += -DARCH_STRING=\"$(COMPILE_ARCH)\"
+endif
+
 ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
 
   BASE_CFLAGS = -Wall -fno-strict-aliasing -Wimplicit -Wstrict-prototypes \
-    -pipe -DUSE_ICON
+    -pipe -DUSE_ICON -DARCH_STRING=\\\"$(ARCH)\\\"
   CLIENT_CFLAGS += $(SDL_CFLAGS)
 
   OPTIMIZEVM = -O3 -funroll-loops -fomit-frame-pointer

--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ LIB=lib
 INSTALL=install
 MKDIR=mkdir
 
-ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu"))
+ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu"))
 
   ifeq ($(ARCH),x86_64)
     LIB=lib64

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -165,34 +165,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define ID_INLINE inline
 #define PATH_SEP '/'
 
-#if defined __i386__
-#define ARCH_STRING "i386"
-#elif defined __x86_64__
-#define ARCH_STRING "x86_64"
-#elif defined __powerpc64__
-#define ARCH_STRING "ppc64"
-#elif defined __powerpc__
-#define ARCH_STRING "ppc"
-#elif defined __s390__
-#define ARCH_STRING "s390"
-#elif defined __s390x__
-#define ARCH_STRING "s390x"
-#elif defined __ia64__
-#define ARCH_STRING "ia64"
-#elif defined __alpha__
-#define ARCH_STRING "alpha"
-#elif defined __sparc__
-#define ARCH_STRING "sparc"
-#elif defined __arm__
-#define ARCH_STRING "arm"
-#elif defined __cris__
-#define ARCH_STRING "cris"
-#elif defined __hppa__
-#define ARCH_STRING "hppa"
-#elif defined __mips__
-#define ARCH_STRING "mips"
-#elif defined __sh__
-#define ARCH_STRING "sh"
+#if !defined(ARCH_STRING)
+# error ARCH_STRING should be defined by the Makefile
 #endif
 
 #if __FLOAT_WORD_ORDER == __BIG_ENDIAN

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -150,11 +150,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 //================================================================= LINUX ===
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD_kernel__)
 
 #include <endian.h>
 
+#if defined(__linux__)
 #define OS_STRING "linux"
+#else
+#define OS_STRING "kFreeBSD"
+#endif
+
 #define ID_INLINE inline
 #define PATH_SEP '/'
 

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -150,14 +150,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 //================================================================= LINUX ===
 
-#if defined(__linux__) || defined(__FreeBSD_kernel__)
+#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__GNU__)
 
 #include <endian.h>
 
 #if defined(__linux__)
 #define OS_STRING "linux"
-#else
+#elif defined(__FreeBSD_kernel__)
 #define OS_STRING "kFreeBSD"
+#else
+#define OS_STRING "GNU"
 #endif
 
 #define ID_INLINE inline


### PR DESCRIPTION
This pull request collects several portability changes originating in Debian that were merged into ioquake3 between 2011 and 2015.

* Treat GNU/kFreeBSD and GNU/Hurd as essentially equivalent to GNU/Linux, allowing compilation on those platforms. OpenArena already had part of the kFreeBSD change due to syncing the Makefile from ioquake3, but not enough to make the build work there.
    * ioquake3 pull request: https://github.com/ioquake/ioq3/pull/4 (that's only the Hurd part, the kFreeBSD parts were merged while ioquake3 was still in svn)
* Treat all CPUs on GNU platforms as essentially equivalent, avoiding needing to add specific support for each new CPU. In most cases the `ARCH_STRING` is just the output of `uname -m`. The only special cases needed are for 32-bit x86 and ARM, where `uname -m` can take multiple values (such as `i586`, `i686`, `armv5tel`, `armv7l`) which we need to normalize to `x86` and `arm` to be compatible across CPUs from the same family. This patch is enough to avoid needing a change like https://github.com/ioquake/ioq3/pull/128 for each new architecture, and in particular provides aarch64 (64-bit ARM) support.
    * ioquake3 pull request: https://github.com/ioquake/ioq3/pull/129

The `ARCH_STRING` is not actually used anywhere in the gamecode, except for raising a `#error` if it isn't defined. I could have deleted it completely, but I thought it was probably better to keep `q_platform.h` consistent with the one in ioquake3.

Please see the commit messages of the individual commits for more information.