### PR TITLE
Added cg_zoomSensitivity for correct sens scaling

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1334,6 +1334,7 @@ extern	vmCvar_t		cg_ignore;
 extern	vmCvar_t		cg_simpleItems;
 extern	vmCvar_t		cg_fov;
 extern	vmCvar_t		cg_zoomFov;
+extern	vmCvar_t		cg_zoomSensitivity;
 extern	vmCvar_t		cg_thirdPersonRange;
 extern	vmCvar_t		cg_thirdPersonAngle;
 extern	vmCvar_t		cg_thirdPerson;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -147,6 +147,7 @@ vmCvar_t cg_ignore;
 vmCvar_t cg_simpleItems;
 vmCvar_t cg_fov;
 vmCvar_t cg_zoomFov;
+vmCvar_t cg_zoomSensitivity;
 vmCvar_t cg_thirdPerson;
 vmCvar_t cg_thirdPersonRange;
 vmCvar_t cg_thirdPersonAngle;
@@ -308,7 +309,8 @@ static cvarTable_t cvarTable[] = {// bk001129
 	{ &cg_ignore, "cg_ignore", "0", 0}, // used for debugging
 	{ &cg_autoswitch, "cg_autoswitch", "1", CVAR_ARCHIVE},
 	{ &cg_drawGun, "cg_drawGun", "1", CVAR_ARCHIVE},
-	{ &cg_zoomFov, "cg_zoomfov", "22.5", CVAR_ARCHIVE},
+	{ &cg_zoomFov, "cg_zoomFov", "22.5", CVAR_ARCHIVE},
+	{ &cg_zoomSensitivity, "cg_zoomSensitivity", "0", CVAR_ARCHIVE},
 	{ &cg_fov, "cg_fov", "90", CVAR_ARCHIVE},
 	{ &cg_viewsize, "cg_viewsize", "100", CVAR_ARCHIVE},
 	{ &cg_viewnudge, "cg_viewnudge", "0", CVAR_ARCHIVE},

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // for a 3D rendering
 #include "cg_local.h"
 
+#define degrees(v) (v * 180.0 / M_PI)
+#define radians(v) (v * M_PI / 180.0)
 
 /*
 =============================================================================
@@ -638,9 +640,9 @@ static int CG_CalcFov( void ) {
 		fov_x = fov_x * 0.93 * (cg.xyspeed * (0.0006) + 1);
 	}
 
-	x = cg.refdef.width / tan( fov_x / 360 * M_PI );
+	x = cg.refdef.width / tan( radians(fov_x) / 2.0 );
 	fov_y = atan2( cg.refdef.height, x );
-	fov_y = fov_y * 360 / M_PI;
+	fov_y = degrees(fov_y) * 2;
 
 	// warp if underwater
 	contents = CG_PointContents( cg.refdef.vieworg, -1 );
@@ -664,7 +666,14 @@ static int CG_CalcFov( void ) {
 		cg.zoomSensitivity = 1;
 	} 
 	else {
-		cg.zoomSensitivity = cg.refdef.fov_y / 75.0;
+		float zoomSensitivity = cg_zoomSensitivity.value;
+		if (zoomSensitivity == 0.0) {
+			// use legacy zoom sensitivity formula
+			cg.zoomSensitivity = cg.refdef.fov_y / 75.0;
+		} else {
+			// use corrected zoom sensitivity formula
+			cg.zoomSensitivity = zoomSensitivity * tan(radians(cg.refdef.fov_x) / 2.0) / tan(radians(cg_fov.value) / 2.0);
+		}
 	}
 
 	return inwater;


### PR DESCRIPTION
The zoom sensitivity scaling formula in OpenArena is `vertical_zoomFov / 75.0`.

This formula is flawed in 2 ways:

1. It assumes that the vertical unzoomed fov is 75. This is eqvivalent to
`cg_fov` being set to ~91 on 4:3 or ~107 on 16:9.

2. It scales the zoom sensitivity linearly using `vertical_zoomfov /
vertical_unzoomedfov`. This is mathematically incorrect which is noticable
through testing.

New cvar called `cg_zoomSensitivity` has been added to solve these problems.
When it is set to 0 (default) it has no effect and the legacy zoom sensitivity
formula is used.

When the cvar is set to anything but 0 the mathemtically correct formula
`tan(zoomFov / 2) / tan(unzoomedFov / 2)` is used. The result of this formula
gets multiplied by `cg_zoomSensitivity`.

When the cvar is set to 0.5 for example it will multiply the result of the
formula with 0.5 which halves the zoom sensitivity. This allows players to
customize their zoom sensitivity according to their preference.