### PR TITLE
vmMain(): add Q_EXPORT macro in definitions

### DIFF
--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -46,7 +46,7 @@ This is the only way control passes into the module.
 This must be the very first function compiled into the .q3vm file
 ================
  */
-intptr_t vmMain(int command, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11) {
+Q_EXPORT intptr_t vmMain(int command, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11) {
 
 	switch (command) {
 		case CG_INIT:

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -437,7 +437,7 @@ This is the only way control passes into the module.
 This must be the very first function compiled into the .q3vm file
 ================
 */
-intptr_t vmMain( int command, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11  )
+Q_EXPORT intptr_t vmMain( int command, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11  )
 {
 	switch ( command ) {
 	case GAME_INIT:

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -148,7 +148,7 @@ void _UI_KeyEvent( int key, qboolean down );
 void _UI_MouseEvent( int dx, int dy );
 void _UI_Refresh( int realtime );
 qboolean _UI_IsFullscreen( void );
-intptr_t vmMain( int command, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11  )
+Q_EXPORT intptr_t vmMain( int command, int arg0, int arg1, int arg2, int arg3, int arg4, int arg5, int arg6, int arg7, int arg8, int arg9, int arg10, int arg11  )
 {
 	switch ( command ) {
 	case UI_GETAPIVERSION:


### PR DESCRIPTION
Without this, the following error happens when trying to run with
native libraries (.so):

```
Sys_LoadGameDll(/path/to/qagamex86_64.so) failed to find vmMain function:
"/path/to/qagamex86_64.so: undefined symbol: vmMain" !
Failed to load DLL /path/to/qagamex86_64.so.
----- Server Shutdown (Server fatal crashed: VM_Create on game failed) -----
```