### PR TITLE
Prevent key game objectives from being disabled.

### DIFF
--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -960,6 +960,14 @@ G_ItemDisabled
 int G_ItemDisabled( gitem_t *item )
 {
 	char name[128];
+	
+	/* Neon_Knight: Disable shouldn't work on key game objectives in online games.
+		You just can't trust people with always do the right thing. And OA shouldn't
+		suffer for that. */
+	if (item->giType == IT_TEAM) {
+		return qfalse;
+	}
+	/* /Neon_Knight */
 	if (!g_runes.integer && item->giType == IT_PERSISTANT_POWERUP) {
 		return qtrue;
 	}


### PR DESCRIPTION
Key game obejctives shouldn't be disabled because they break gamemodes.

If players want to screw the game for themselves, that's fine. But intentionally screwing other people's playing experience IS BAD.