### PR TITLE
[Testing required] droprune: Command to drop the currently held rune.

### DIFF
--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -662,7 +662,14 @@ void Cmd_LevelShot_f( gentity_t *ent ) {
 	trap_SendServerCommand( ent-g_entities, "clientLevelShot" );
 }
 
-
+void Cmd_DropRune_f( gentity_t *ent ) {
+	if (!ent) {
+		return;
+	}
+	if (g_runes.integer >= G_RUNES_ENABLE_TOSS) {
+		TossClientPersistantPowerups(ent);
+	}
+}
 /*
 ==================
 Cmd_LevelShot_f
@@ -2310,8 +2317,11 @@ commands_t cmds[ ] =
 	//KK-OAX
 	{ "freespectator", CMD_NOTEAM, StopFollowing },
 	{ "getmappage", 0, Cmd_GetMappage_f },
-	{ "gc", 0, Cmd_GameCommand_f }
-
+	{ "gc", 0, Cmd_GameCommand_f },
+	
+	/* Neon_Knight: Toss current rune*/
+	{ "droprune", 0, Cmd_DropRune_f },
+	/* /Neon_Knight */
 };
 
 static int numCmds = sizeof( cmds ) / sizeof( cmds[ 0 ] );

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1432,3 +1432,8 @@ qboolean G_UsesTeamFlags(int check);	/* Whether the gametype uses the red and bl
 qboolean G_UsesTheWhiteFlag(int check);	/* Whether the gametype uses the neutral flag. */
 qboolean G_IsARoundBasedGametype(int check);	/* Whether the gametype uses the neutral flag. */
 /* /Neon_Knight */
+
+/* Neon_Knight: Needed for g_runes */
+#define	G_RUNES_ENABLE		1
+#define	G_RUNES_ENABLE_TOSS	2
+/* /Neon_Knight */


### PR DESCRIPTION
This is a command that, baffingly, was absent from TA. I say baffingly because the equivalents (the Runes for the Threewave CTF mods for Q1 and Q2 and Unreal Tournament's Relics) already had keybinds for dropping the currently held rune.

So this keybind does what it says: it drops the rune back to its spawning point.

**[Here's a test pk3.](https://cdn.discordapp.com/attachments/405518544382590987/675451968453476353/z_oax_v2.pk3) (Updated Feb 7, 2020 18:37)**