### PR TITLE
Botfixes and new bot-related cvars

### DIFF
--- a/code/game/ai_chat.c
+++ b/code/game/ai_chat.c
@@ -384,10 +384,18 @@ int BotChat_EnterGame(bot_state_t *bs) {
 
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	//don't chat in teamplay if not allowed
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENTEREXITGAME, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -417,10 +425,18 @@ int BotChat_ExitGame(bot_state_t *bs) {
 
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	//don't chat in teamplay if not allowed.
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
+	// don't chat in tournament mode if not allowed.
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENTEREXITGAME, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -451,13 +467,19 @@ int BotChat_StartLevel(bot_state_t *bs) {
 	if (bot_nochat.integer) return qfalse;
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) {
-	    trap_EA_Command(bs->client, "vtaunt");
-	    return qfalse;
+	//don't chat in teamplay if not allowed
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			trap_EA_Command(bs->client, "vtaunt");
+			return qfalse;
+		}
 	}
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_STARTENDLEVEL, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -483,16 +505,21 @@ int BotChat_EndLevel(bot_state_t *bs) {
 	if (bot_nochat.integer) return qfalse;
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	// teamplay
-	if (TeamPlayIsOn()) 
-	{
-		if (BotIsFirstInRankings(bs)) {
-			trap_EA_Command(bs->client, "vtaunt");
+	// bots won't chat on teamplay if not allowed
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			if (BotIsFirstInRankings(bs)) {
+				trap_EA_Command(bs->client, "vtaunt");
+			}
+			return qtrue;
 		}
-		return qtrue;
 	}
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_STARTENDLEVEL, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -544,7 +571,11 @@ int BotChat_Death(bot_state_t *bs) {
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_DEATH, 0, 1);
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	//if fast chatting is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -563,10 +594,12 @@ int BotChat_Death(bot_state_t *bs) {
 	}
 	else
 	{
-		//teamplay
-		if (TeamPlayIsOn()) {
-			trap_EA_Command(bs->client, "vtaunt");
-			return qtrue;
+		//don't let bot taunt if not allowed
+		if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+			if(!trap_Cvar_VariableIntegerValue("developer")) {
+				trap_EA_Command(bs->client, "vtaunt");
+				return qtrue;
+			}
 		}
 		//
 		if (bs->botdeathtype == MOD_WATER)
@@ -642,8 +675,12 @@ int BotChat_Kill(bot_state_t *bs) {
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_KILL, 0, 1);
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -663,10 +700,12 @@ int BotChat_Kill(bot_state_t *bs) {
 	}
 	else
 	{
-		//don't chat in teamplay
-		if (TeamPlayIsOn()) {
-			trap_EA_Command(bs->client, "vtaunt");
-			return qfalse;			// don't wait
+		//don't chat in teamplay if not allowed
+		if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+			if(!trap_Cvar_VariableIntegerValue("developer")) {
+				trap_EA_Command(bs->client, "vtaunt");
+				return qfalse;			// don't wait
+			}
 		}
 		//
 		if (bs->enemydeathtype == MOD_GAUNTLET) {
@@ -706,10 +745,18 @@ int BotChat_EnemySuicide(bot_state_t *bs) {
 	if (BotNumActivePlayers() <= 1) return qfalse;
 	//
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENEMYSUICIDE, 0, 1);
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	//don't chat in teamplay if not allowed
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -746,10 +793,18 @@ int BotChat_HitTalking(bot_state_t *bs) {
 	if (lasthurt_client < 0 || lasthurt_client >= MAX_CLIENTS) return qfalse;
 	//
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITTALKING, 0, 1);
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	//don't chat in teamplay if not allowed
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -786,10 +841,18 @@ int BotChat_HitNoDeath(bot_state_t *bs) {
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	if (BotNumActivePlayers() <= 1) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITNODEATH, 0, 1);
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	//don't chat in teamplay if not allowed
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -824,10 +887,18 @@ int BotChat_HitNoKill(bot_state_t *bs) {
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	if (BotNumActivePlayers() <= 1) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITNOKILL, 0, 1);
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	//don't chat in teamplay if not allowed
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -860,8 +931,12 @@ int BotChat_Random(bot_state_t *bs) {
 	if (bot_nochat.integer) return qfalse;
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	// don't chat in tournament mode if not allowed
+	if (gametype == GT_TOURNAMENT && !bot_allowTeamChat.integer){
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			return qfalse;
+		}
+	}
 	//don't chat when doing something important :)
 	if (bs->ltgtype == LTG_TEAMHELP ||
 		bs->ltgtype == LTG_TEAMACCOMPANY ||
@@ -885,9 +960,11 @@ int BotChat_Random(bot_state_t *bs) {
 	else {
 		EasyClientName(bs->lastkilledplayer, name, sizeof(name));
 	}
-	if (TeamPlayIsOn()) {
-		trap_EA_Command(bs->client, "vtaunt");
-		return qfalse;			// don't wait
+	if (TeamPlayIsOn() && !bot_allowTeamChat.integer) {
+		if(!trap_Cvar_VariableIntegerValue("developer")) {
+			trap_EA_Command(bs->client, "vtaunt");
+			return qfalse;			// don't wait
+		}
 	}
 	//
 	if (random() < trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_MISC, 0, 1)) {

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -58,7 +58,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 int notleader[MAX_CLIENTS];
 
-#ifdef DEBUG
 /*
 ==================
 BotPrintTeamGoal
@@ -164,7 +163,6 @@ void BotPrintTeamGoal(bot_state_t *bs) {
 		}
 	}
 }
-#endif //DEBUG
 
 /*
 ==================
@@ -605,9 +603,10 @@ void BotMatch_HelpAccompany(bot_state_t *bs, bot_match_t *match) {
 		// remember last ordered task
 		BotRememberLastOrderedTask(bs);
 	}
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -653,9 +652,10 @@ void BotMatch_DefendKeyArea(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -702,9 +702,10 @@ void BotMatch_TakeA(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -753,9 +754,10 @@ void BotMatch_TakeB(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -793,9 +795,10 @@ void BotMatch_GetItem(bot_state_t *bs, bot_match_t *match) {
 	bs->teamgoal_time = FloatTime() + TEAM_GETITEM_TIME;
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -885,9 +888,10 @@ void BotMatch_Camp(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -924,9 +928,10 @@ void BotMatch_Patrol(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -978,9 +983,10 @@ void BotMatch_GetFlag(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1023,9 +1029,10 @@ void BotMatch_AttackEnemyBase(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1065,9 +1072,10 @@ void BotMatch_Harvest(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1109,9 +1117,10 @@ void BotMatch_RushBase(bot_state_t *bs, bot_match_t *match) {
 	bs->rushbaseaway_time = 0;
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1195,9 +1204,10 @@ void BotMatch_ReturnFlag(bot_state_t *bs, bot_match_t *match) {
 	bs->rushbaseaway_time = 0;
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1817,9 +1827,10 @@ void BotMatch_Kill(bot_state_t *bs, bot_match_t *match) {
 	bs->teamgoal_time = FloatTime() + TEAM_KILL_SOMEONE;
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer")){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -142,6 +142,16 @@ void BotPrintTeamGoal(bot_state_t *bs) {
 			BotAI_Print(PRT_MESSAGE, "%s: I'm gonna take care of point B for %1.0f secs\n", netname, t);
 			break;
 		}
+		case LTG_DOMCAPTURE:
+		{
+			BotAI_Print(PRT_MESSAGE, "%s: I'm gonna capture a DOM point for %1.0f secs\n", netname, t);
+			break;
+		}
+		case LTG_DOMROAM:
+		{
+			BotAI_Print(PRT_MESSAGE, "%s: I'm gonna roam the level for %1.0f secs\n", netname, t);
+			break;
+		}
 		default:
 		{
 			if (bs->ctfroam_time > FloatTime()) {
@@ -300,7 +310,7 @@ int NumPlayersOnSameTeam(bot_state_t *bs) {
 
 /*
 ==================
-TeamPlayIsOn
+BotGetPatrolWaypoints
 ==================
 */
 int BotGetPatrolWaypoints(bot_state_t *bs, bot_match_t *match) {
@@ -734,7 +744,9 @@ void BotMatch_TakeB(bot_state_t *bs, bot_match_t *match) {
 	//get the team goal time
 	bs->teamgoal_time = BotGetTime(match);
 	//set the team goal time
-	if (!bs->teamgoal_time) bs->teamgoal_time = FloatTime() + DD_POINTA;
+	if (!bs->teamgoal_time) {
+		bs->teamgoal_time = FloatTime() + DD_POINTA;
+	}
 	//away from defending
 	bs->defendaway_time = 0;
 	//
@@ -958,7 +970,7 @@ void BotMatch_GetFlag(bot_state_t *bs, bot_match_t *match) {
 	//set the team goal time
 	bs->teamgoal_time = FloatTime() + CTF_GETFLAG_TIME;
 	// get an alternate route in ctf
-	if (G_UsesTeamFlags(gametype)) {
+	if (G_UsesTeamFlags(gametype) || gametype == GT_POSSESSION) {
 		//get an alternative route goal towards the enemy base
 		BotGetAlternateRouteGoal(bs, BotOppositeTeam(bs));
 	}
@@ -1924,7 +1936,7 @@ int BotMatchMessage(bot_state_t *bs, char *message) {
 			BotMatch_Patrol(bs, &match);
 			break;
 		}
-		//CTF & 1FCTF
+		//CTF & 1FCTF & Possession
 		case MSG_GETFLAG:				//ctf get the enemy flag
 		{
 			BotMatch_GetFlag(bs, &match);

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -584,37 +584,6 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 		}
 		return qtrue;
 	}
-        //if (bs->ltgtype == LTG_DOMHOLD &&
-	//			bs->defendaway_time < FloatTime()) {
-            //check for bot typing status message
-		/*if (bs->teammessage_time && bs->teammessage_time < FloatTime()) {
-			trap_BotGoalName(bs->teamgoal.number, buf, sizeof(buf));
-			BotAI_BotInitialChat(bs, "dd_start_pointb", buf, NULL);
-			trap_BotEnterChat(bs->cs, 0, CHAT_TEAM);
-			//BotVoiceChatOnly(bs, -1, VOICECHAT_ONDEFENSE);
-			bs->teammessage_time = 0;
-		}*/
-		//set the bot goal
-	//	memcpy(goal, &bs->teamgoal, sizeof(bot_goal_t));
-		//if very close... go away for some time
-	//	VectorSubtract(goal->origin, bs->origin, dir);
-	//	if (VectorLengthSquared(dir) < Square(30)) {
-			/*trap_BotResetAvoidReach(bs->ms);
-			bs->defendaway_time = FloatTime() + 3 + 3 * random();
-			if (BotHasPersistantPowerupAndWeapon(bs)) {
-				bs->defendaway_range = 100;
-			}
-			else {
-				bs->defendaway_range = 350;
-			}*/
-          //              memcpy(&bs->teamgoal, &dom_points_bot[((rand()) % (level.domination_points_count))], sizeof(bot_goal_t));
-            //            BotAlternateRoute(bs, &bs->teamgoal);
-              //          BotSetTeamStatus(bs);
-
-		//}
-		//return qtrue;
-
-       // }
 	//if defending a key area
 	if (bs->ltgtype == LTG_DEFENDKEYAREA && !retreat &&
 				bs->defendaway_time < FloatTime()) {
@@ -836,7 +805,6 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 		memcpy(goal, &bs->curpatrolpoint->goal, sizeof(bot_goal_t));
 		return qtrue;
 	}
-#ifdef CTF
 	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
 		//if going for enemy flag
 		if (bs->ltgtype == LTG_GETFLAG) {
@@ -920,9 +888,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			BotAlternateRoute(bs, goal);
 			return qtrue;
 		}
-	}
-#endif //CTF
-	else if (gametype == GT_1FCTF) {
+	} else if (gametype == GT_1FCTF) {
 		if (bs->ltgtype == LTG_GETFLAG) {
 			//check for bot typing status message
 			if (bs->teammessage_time && bs->teammessage_time < FloatTime()) {
@@ -1005,8 +971,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			//just roam around
 			return BotGetItemLongTermGoal(bs, tfl, goal);
 		}
-	}
-	else if (gametype == GT_OBELISK) {
+	} else if (gametype == GT_OBELISK) {
 		if (bs->ltgtype == LTG_ATTACKENEMYBASE &&
 				bs->attackaway_time < FloatTime()) {
 
@@ -1043,8 +1008,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			//just move towards the obelisk
 			return qtrue;
 		}
-	}
-	else if (gametype == GT_HARVESTER) {
+	} else if (gametype == GT_HARVESTER) {
 		//if rushing to the base
 		if (bs->ltgtype == LTG_RUSHBASE) {
 			switch(BotTeam(bs)) {
@@ -1116,8 +1080,57 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			}
 			return qtrue;
 		}
+	} else if (gametype == GT_POSSESSION) {
+		if (bs->teammessage_time && bs->teammessage_time < FloatTime()) {
+			BotAI_BotInitialChat(bs, "captureflag_start", NULL);
+			trap_BotEnterChat(bs->cs, 0, CHAT_TEAM);
+			BotVoiceChatOnly(bs, -1, VOICECHAT_ONGETFLAG);
+			bs->teammessage_time = 0;
+		}
+		memcpy(goal, &ctf_neutralflag, sizeof(bot_goal_t));
+		//if touching the flag
+		if (trap_BotTouchingGoal(bs->origin, goal)) {
+			bs->ltgtype = 0;
+		}
+		//stop after 3 minutes
+		if (bs->teamgoal_time < FloatTime()) {
+			bs->ltgtype = 0;
+		}
+		return qtrue;
+	} else if (gametype == GT_DOMINATION) {
+		switch (bs->ltgtype) {
+			case LTG_DOMCAPTURE:
+				if(bs->defendaway_time < FloatTime()) {
+					//check for bot typing status message
+					if (bs->teammessage_time && bs->teammessage_time < FloatTime()) {
+						trap_BotGoalName(bs->teamgoal.number, buf, sizeof(buf));
+						BotAI_BotInitialChat(bs, "dom_start_point", buf, NULL);
+						trap_BotEnterChat(bs->cs, 0, CHAT_TEAM);
+						bs->teammessage_time = 0;
+					}
+					//set the bot goal
+					memcpy(goal, &bs->teamgoal, sizeof(bot_goal_t));
+					//if very close... go away for some time
+					VectorSubtract(goal->origin, bs->origin, dir);
+					if (VectorLengthSquared(dir) < Square(30)) {
+						trap_BotResetAvoidReach(bs->ms);
+						bs->defendaway_time = FloatTime() + 3 + 3 * random();
+						if (BotHasPersistantPowerupAndWeapon(bs)) {
+							bs->defendaway_range = 100;
+						}
+						else {
+							bs->defendaway_range = 350;
+						}
+						memcpy(&bs->teamgoal, &dom_points_bot[((rand()) % (level.domination_points_count))], sizeof(bot_goal_t));
+						BotAlternateRoute(bs, &bs->teamgoal);
+						BotSetTeamStatus(bs);
+					}
+				}
+				break;
+			case LTG_DOMROAM:
+				break;
+		}
 	}
-//#endif
 	//normal goal stuff
 	return BotGetItemLongTermGoal(bs, tfl, goal);
 }

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -438,11 +438,19 @@ void BotSetTeamStatus(bot_state_t *bs) {
 				teamtask = TEAMTASK_OFFENSE;
 			else
 				teamtask = TEAMTASK_DEFENSE;
+			break;
 		case LTG_POINTB:
 			if (BotTeam(bs) == TEAM_RED)
 				teamtask = TEAMTASK_OFFENSE;
 			else
 				teamtask = TEAMTASK_DEFENSE;
+			break;
+		case LTG_DOMCAPTURE:
+			teamtask = TEAMTASK_OFFENSE;
+			break;
+		case LTG_DOMROAM:
+			teamtask = TEAMTASK_PATROL;
+			break;
 		default:
 			teamtask = TEAMTASK_PATROL;
 			break;
@@ -819,35 +827,6 @@ void BotCTFRetreatGoals(bot_state_t *bs) {
 
 /*
 ==================
-BotDomSeekGoals
-==================
- */
-
-/*void BotDomSeekGoals(bot_state_t *bs) {
-	int index;
-	bs->ltgtype = LTG_DOMHOLD; //For debugging we are forcing roam
-    
-	index=0;
-	//dom_points_bot[i]
-    
-	if(bs->ltgtype == LTG_DOMHOLD) {
-		//index = 0;
-		index = ((rand()) % (level.domination_points_count));
-	}
-    
-	//if(bs->ltgtype == LTG_DOMROAM) {
-        
-	//}
-        
-	memcpy(&bs->teamgoal, &dom_points_bot[index], sizeof(bot_goal_t));
-
-	BotAlternateRoute(bs, &bs->teamgoal);
-
-	BotSetTeamStatus(bs);
-}*/
-
-/*
-==================
 BotDDSeekGoals
 ==================
  */
@@ -881,16 +860,67 @@ void BotDDSeekGoals(bot_state_t *bs) {
 			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_OFFENSE));
 		else
 			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_DEFENSE));
-	} else
-		if (bs->ltgtype == LTG_POINTB) {
+	} else if (bs->ltgtype == LTG_POINTB) {
 		memcpy(&bs->teamgoal, &ctf_blueflag, sizeof (bot_goal_t));
 		if (BotTeam(bs) == TEAM_RED)
 			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_OFFENSE));
 		else
 			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_DEFENSE));
 	}
+}
 
+/*
+==================
+BotDomSeekGoals
+==================
+ */
 
+void BotDomSeekGoals(bot_state_t *bs) {
+	int currentPoint;
+	if(trap_Cvar_VariableIntegerValue("developer") == 0) {
+		bs->ltgtype = LTG_DOMROAM; //For debugging we are forcing roam
+	}
+	// The control point the bot cares about.
+	if (!trap_Cvar_VariableIntegerValue("ai_domCurrentPoint")) {
+		BotDomCurrentPoint();
+	}
+	currentPoint = (int)trap_Cvar_VariableIntegerValue("ai_domCurrentPoint");
+
+	if (bs->ltgtype == LTG_DOMCAPTURE)
+		memcpy(&bs->teamgoal, &dom_points_bot[currentPoint], sizeof (bot_goal_t));
+
+	if (rand() % 2 == 0)
+		bs->ltgtype = LTG_DOMCAPTURE;
+	else
+		bs->ltgtype = LTG_DOMROAM;
+
+	if (bs->ltgtype == LTG_DOMCAPTURE) {
+		memcpy(&bs->teamgoal, &dom_points_bot[currentPoint], sizeof (bot_goal_t));
+		if (BotTeam(bs) == TEAM_BLUE && (level.pointStatusDom[currentPoint] == TEAM_RED || level.pointStatusDom[currentPoint] == TEAM_NONE)) {
+			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_OFFENSE));
+		} else if (BotTeam(bs) == TEAM_BLUE && (level.pointStatusDom[currentPoint] == TEAM_BLUE)) {
+			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_DEFENSE));
+		} else if (BotTeam(bs) == TEAM_RED && (level.pointStatusDom[currentPoint] == TEAM_BLUE || level.pointStatusDom[currentPoint] == TEAM_NONE)) {
+			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_OFFENSE));
+		} else if (BotTeam(bs) == TEAM_RED && (level.pointStatusDom[currentPoint] == TEAM_RED)) {
+			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_DEFENSE));
+		} else {
+			BotSetUserInfo(bs, "teamtask", va("%d", TEAMTASK_PATROL));
+			BotDomCurrentPoint();
+		}
+	}
+}
+
+/*
+==================
+BotDomCurrentPoint
+
+Saves a
+==================
+ */
+void BotDomCurrentPoint(void) {
+	int index = rand() % level.domination_points_count;
+	trap_Cvar_Set("ai_domCurrentPoint", va("%i",index));
 }
 
 /*
@@ -1442,8 +1472,8 @@ void BotTeamGoals(bot_state_t *bs, int retreat) {
 	if (gametype == GT_DOUBLE_D) //Don't care about retreat
 		BotDDSeekGoals(bs);
 
-	//if(gametype == GT_DOMINATION) //Don't care about retreat
-	//	BotDomSeekGoals(bs);
+	if(gametype == GT_DOMINATION) //Don't care about retreat
+		BotDomSeekGoals(bs);
 
 	// reset the order time which is used to see if
 	// we decided to refuse an order

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -799,9 +799,10 @@ void BotCTFSeekGoals(bot_state_t *bs) {
 		BotSetTeamStatus(bs);
 	}
 	bs->owndecision_time = FloatTime() + 5;
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1137,9 +1138,10 @@ void Bot1FCTFSeekGoals(bot_state_t *bs) {
 		BotSetTeamStatus(bs);
 	}
 	bs->owndecision_time = FloatTime() + 5;
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -82,6 +82,7 @@ vmCvar_t bot_nochat;
 vmCvar_t bot_testrchat;
 vmCvar_t bot_challenge;
 vmCvar_t bot_predictobstacles;
+vmCvar_t bot_allowTeamChat;
 vmCvar_t g_spSkill;
 
 extern vmCvar_t bot_developer;
@@ -5433,6 +5434,7 @@ void BotSetupDeathmatchAI(void) {
 	trap_Cvar_Register(&bot_testrchat, "bot_testrchat", "0", 0);
 	trap_Cvar_Register(&bot_challenge, "bot_challenge", "0", 0);
 	trap_Cvar_Register(&bot_predictobstacles, "bot_predictobstacles", "1", 0);
+	trap_Cvar_Register(&bot_allowTeamChat, "bot_allowTeamChat", "1", 0);
 	trap_Cvar_Register(&g_spSkill, "g_spSkill", "2", 0);
 	//
 	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {

--- a/code/game/ai_dmq3.h
+++ b/code/game/ai_dmq3.h
@@ -173,6 +173,10 @@ int ClientOnSameTeamFromName(bot_state_t *bs, char *name);
 int BotPointAreaNum(vec3_t origin);
 //
 void BotMapScripts(bot_state_t *bs);
+// DD and DOM goal seek functions
+void BotDDSeekGoals(bot_state_t *bs);
+void BotDomSeekGoals(bot_state_t *bs);
+void BotDomCurrentPoint(void);
 
 //ctf flags
 #define CTF_FLAG_NONE		0
@@ -200,3 +204,4 @@ extern bot_goal_t ctf_neutralflag;
 extern bot_goal_t redobelisk;
 extern bot_goal_t blueobelisk;
 extern bot_goal_t neutralobelisk;
+extern bot_goal_t dom_points_bot[MAX_DOMINATION_POINTS];

--- a/code/game/ai_dmq3.h
+++ b/code/game/ai_dmq3.h
@@ -191,6 +191,8 @@ extern vmCvar_t bot_fastchat;
 extern vmCvar_t bot_nochat;
 extern vmCvar_t bot_testrchat;
 extern vmCvar_t bot_challenge;
+/* Neon_Knight: Because the bots should have freedom of expression, lol! */
+extern vmCvar_t bot_allowTeamChat;
 
 extern bot_goal_t ctf_redflag;
 extern bot_goal_t ctf_blueflag;

--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -1453,6 +1453,7 @@ int BotAIStartFrame(int time) {
 	trap_Cvar_Update(&bot_saveroutingcache);
 	trap_Cvar_Update(&bot_pause);
 	trap_Cvar_Update(&bot_report);
+	trap_Cvar_Update(&bot_allowTeamChat);
 
 	if (bot_report.integer) {
 //		BotTeamplayReport();

--- a/code/game/ai_main.h
+++ b/code/game/ai_main.h
@@ -61,9 +61,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //Long term DD goals
 #define LTG_POINTA				16	//Take/Defend point A
 #define LTG_POINTB				17	//Take/Defend point B
-//Long term DD goals
-#define LTG_DOMROAM                             18      //Go for a non taken point.
-#define LTG_DOMHOLD                             19      //Pick a point and hold it.
+//Long term DOM goals
+#define LTG_DOMROAM					18	//Go for a non taken point.
+#define LTG_DOMCAPTURE				19	//Pick a point and hold it.
 //some goal dedication times
 #define TEAM_HELP_TIME				60	//1 minute teamplay help time
 #define TEAM_ACCOMPANY_TIME			600	//10 minutes teamplay accompany time

--- a/code/game/ai_vcmd.c
+++ b/code/game/ai_vcmd.c
@@ -101,9 +101,10 @@ void BotVoiceChat_GetFlag(bot_state_t *bs, int client, int mode) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -151,9 +152,10 @@ void BotVoiceChat_Offense(bot_state_t *bs, int client, int mode) {
 		// remember last ordered task
 		BotRememberLastOrderedTask(bs);
 	}
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -198,9 +200,10 @@ void BotVoiceChat_Defend(bot_state_t *bs, int client, int mode) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -230,9 +233,10 @@ void BotVoiceChat_Patrol(bot_state_t *bs, int client, int mode) {
 	BotVoiceChatOnly(bs, -1, VOICECHAT_ONPATROL);
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -286,9 +290,10 @@ void BotVoiceChat_Camp(bot_state_t *bs, int client, int mode) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -340,9 +345,10 @@ void BotVoiceChat_FollowMe(bot_state_t *bs, int client, int mode) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -356,9 +362,10 @@ void BotVoiceChat_FollowFlagCarrier(bot_state_t *bs, int client, int mode) {
 	carrier = BotTeamFlagCarrier(bs);
 	if (carrier >= 0)
 		BotVoiceChat_FollowMe(bs, carrier, mode);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -383,9 +390,10 @@ void BotVoiceChat_ReturnFlag(bot_state_t *bs, int client, int mode) {
 	bs->teamgoal_time = FloatTime() + CTF_RETURNFLAG_TIME;
 	bs->rushbaseaway_time = 0;
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Print messages in Developer mode.
+	if(trap_Cvar_VariableIntegerValue("developer") != 0){
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*


### PR DESCRIPTION
Resume of the branch:

- New cvar: **bot_allowTeamChat**, allows the bots to output regular FFA chatlines in team games. The cvar is disabled in Developer mode.
- Improvements to the AI in Domination, Possession, Double Domination and other gametypes so they play more as intended.
- Developer mode now uses the bots to output helpful messages instead of regular botchat.