### PR TITLE
Teamgame comparison cleanup.

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1576,7 +1576,7 @@ static void CG_DrawUpperRight(stereoFrame_t stereoFrame) {
 
 	y = 0;
 
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype) && cg_drawTeamOverlay.integer == 1) {
+	if (CG_IsATeamGametype(cgs.gametype) && cg_drawTeamOverlay.integer == 1) {
 		y = CG_DrawTeamOverlay(y, qtrue, qtrue);
 	}
 	/*if ( cgs.gametype == GT_DOUBLE_D ) {
@@ -1659,7 +1659,7 @@ static float CG_DrawScores(float y) {
 	y1 = y;
 
 	// draw from the right side to left
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		x = 640;
 		color[0] = 0.0f;
 		color[1] = 0.0f;
@@ -1744,9 +1744,7 @@ static float CG_DrawScores(float y) {
 			CG_DrawSmallString(x, y - 28, s, 1.0F);
 		}
 
-
-
-		if (CG_IsATeamGametype(cgs.gametype)) {
+		if (CG_UsesKeyObjectives(cgs.gametype)) {
 			v = cgs.capturelimit;
 		} else {
 			v = cgs.fraglimit;
@@ -1944,7 +1942,7 @@ static void CG_DrawLowerRight(void) {
 
 	y = 480 - ICON_SIZE;
 
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype) && cg_drawTeamOverlay.integer == 2) {
+	if (CG_IsATeamGametype(cgs.gametype) && cg_drawTeamOverlay.integer == 2) {
 		y = CG_DrawTeamOverlay(y, qtrue, qfalse);
 	}
 
@@ -1999,7 +1997,7 @@ static void CG_DrawLowerLeft(void) {
 
 	y = 480 - ICON_SIZE;
 
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype) && cg_drawTeamOverlay.integer == 3) {
+	if (CG_IsATeamGametype(cgs.gametype) && cg_drawTeamOverlay.integer == 3) {
 		y = CG_DrawTeamOverlay(y, qfalse, qfalse);
 	}
 
@@ -2959,7 +2957,7 @@ static void CG_DrawSpectator(void) {
 	CG_DrawBigString(320 - 9 * 8, 440, "SPECTATOR", 1.0F);
 	if (cgs.gametype == GT_TOURNAMENT) {
 		CG_DrawBigString(320 - 15 * 8, 460, "waiting to play", 1.0F);
-	} else if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	} else if (CG_IsATeamGametype(cgs.gametype)) {
 		CG_DrawBigString(320 - 39 * 8, 460, "press ESC and use the JOIN menu to play", 1.0F);
 	}
 }
@@ -3074,7 +3072,7 @@ static qboolean CG_DrawScoreboard(void) {
 
 
 	if (menuScoreboard == NULL) {
-		if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype)) {
 			menuScoreboard = Menus_FindByName("teamscore_menu");
 		} else {
 			menuScoreboard = Menus_FindByName("score_menu");
@@ -3523,7 +3521,7 @@ static void CG_Draw2D(stereoFrame_t stereoFrame) {
 			CG_DrawReward();
 		}
 
-		if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype)) {
 #ifndef MISSIONPACK
 			CG_DrawTeamInfo();
 #endif

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -1167,7 +1167,7 @@ static void CG_RegisterGraphics(void) {
 		cgs.media.blueCubeIcon = trap_R_RegisterShader("icons/skull_blue");
 	}
 
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		cgs.media.redOverlay = trap_R_RegisterShader("playeroverlays/playerSuit1_Red");
 		cgs.media.blueOverlay = trap_R_RegisterShader("playeroverlays/playerSuit1_Blue");
 	} else {
@@ -1235,8 +1235,7 @@ static void CG_RegisterGraphics(void) {
 	cgs.media.redKamikazeShader = trap_R_RegisterShader("models/weaphits/kamikred");
 	cgs.media.dustPuffShader = trap_R_RegisterShader("hasteSmokePuff");
 
-	if ((CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) ||
-			cg_buildScript.integer) {
+	if (CG_IsATeamGametype(cgs.gametype) || cg_buildScript.integer) {
 
 		cgs.media.friendShader = trap_R_RegisterShader("sprites/foe");
 		cgs.media.redQuadShader = trap_R_RegisterShader("powerups/blueflag");
@@ -2043,7 +2042,7 @@ void CG_SetScoreSelection(void *p) {
 		return;
 	}
 
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		int feeder = FEEDER_REDTEAM_LIST;
 		i = red;
 		if (cg.scores[cg.selectedScore].team == TEAM_BLUE) {
@@ -2060,7 +2059,7 @@ void CG_SetScoreSelection(void *p) {
 
 static clientInfo_t * CG_InfoFromScoreIndex(int index, int team, int *scoreIndex) {
 	int i, count;
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		count = 0;
 		for (i = 0; i < cg.numScores; i++) {
 			if (cg.scores[i].team == team) {
@@ -2167,7 +2166,7 @@ static qhandle_t CG_FeederItemImage(float feederID, int index) {
 }
 
 static void CG_FeederSelection(float feederID, int index) {
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		int i, count;
 		int team = (feederID == FEEDER_REDTEAM_LIST) ? TEAM_RED : TEAM_BLUE;
 		count = 0;

--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -1109,13 +1109,13 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_ANYTEAMGAME) {
-		if(CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+		if(CG_IsATeamGametype(cgs.gametype)) {
 			return qtrue;
 		}
 	}
 
 	if (flags & CG_SHOW_ANYNONTEAMGAME) {
-		if(!(CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype))) {
+		if(!CG_IsATeamGametype(cgs.gametype)) {
 			return qtrue;
 		}
 	}

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -466,7 +466,7 @@ static qboolean CG_FindClientModelFile(char *filename, int length, clientInfo_t 
 	char *team, *charactersFolder;
 	int i;
 
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		switch (ci->team) {
 			case TEAM_BLUE:
 			{
@@ -495,7 +495,7 @@ static qboolean CG_FindClientModelFile(char *filename, int length, clientInfo_t 
 			if (CG_FileExists(filename)) {
 				return qtrue;
 			}
-			if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+			if (CG_IsATeamGametype(cgs.gametype)) {
 				if (i == 0 && teamName && *teamName) {
 					//								"models/players/characters/sergei/stroggs/lower_red.skin"
 					Com_sprintf(filename, length, "models/players/%s%s/%s%s_%s.%s", charactersFolder, modelName, teamName, base, team, ext);
@@ -538,7 +538,7 @@ static qboolean CG_FindClientHeadFile(char *filename, int length, clientInfo_t *
 	char *team, *headsFolder;
 	int i;
 
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		switch (ci->team) {
 			case TEAM_BLUE:
 			{
@@ -571,7 +571,7 @@ static qboolean CG_FindClientHeadFile(char *filename, int length, clientInfo_t *
 			if (CG_FileExists(filename)) {
 				return qtrue;
 			}
-			if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+			if (CG_IsATeamGametype(cgs.gametype)) {
 				if (i == 0 && teamName && *teamName) {
 					Com_sprintf(filename, length, "models/players/%s%s/%s%s_%s.%s", headsFolder, headModelName, teamName, base, team, ext);
 				} else {
@@ -857,7 +857,7 @@ static void CG_LoadClientInfo(int clientNum, clientInfo_t *ci) {
 
 	teamname[0] = 0;
 #ifdef MISSIONPACK
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		if (ci->team == TEAM_BLUE) {
 			Q_strncpyz(teamname, cg_blueTeamName.string, sizeof (teamname));
 		} else {
@@ -875,7 +875,7 @@ static void CG_LoadClientInfo(int clientNum, clientInfo_t *ci) {
 		}
 
 		// fall back to default team name
-		if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype)) {
 			// keep skin name
 			if (ci->team == TEAM_BLUE) {
 				Q_strncpyz(teamname, DEFAULT_BLUETEAM_NAME, sizeof (teamname));
@@ -908,7 +908,7 @@ static void CG_LoadClientInfo(int clientNum, clientInfo_t *ci) {
 
 	// sounds
 	dir = ci->modelName;
-	fallback = (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) ? DEFAULT_TEAM_MODEL : DEFAULT_MODEL;
+	fallback = (CG_IsATeamGametype(cgs.gametype)) ? DEFAULT_TEAM_MODEL : DEFAULT_MODEL;
 
 	for (i = 0; i < MAX_CUSTOM_SOUNDS; i++) {
 		s = cg_customSoundNames[i];
@@ -989,7 +989,7 @@ static qboolean CG_ScanForExistingClientInfo(clientInfo_t *ci) {
 				&& Q_strequal(ci->headSkinName, match->headSkinName)
 				&& Q_strequal(ci->blueTeam, match->blueTeam)
 				&& Q_strequal(ci->redTeam, match->redTeam)
-				&& (!(CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) || ci->team == match->team)) {
+				&& (!CG_IsATeamGametype(cgs.gametype) || ci->team == match->team)) {
 			// this clientinfo is identical, so use it's handles
 
 			ci->deferred = qfalse;
@@ -1025,7 +1025,7 @@ static void CG_SetDeferredClientInfo(int clientNum, clientInfo_t *ci) {
 		}
 		if (!Q_strequal(ci->skinName, match->skinName) ||
 				!Q_strequal(ci->modelName, match->modelName) ||
-				(CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype) && ci->team != match->team)) {
+				(CG_IsATeamGametype(cgs.gametype) && ci->team != match->team)) {
 			continue;
 		}
 		// just load the real info cause it uses the same models and skins
@@ -1034,14 +1034,14 @@ static void CG_SetDeferredClientInfo(int clientNum, clientInfo_t *ci) {
 	}
 
 	// if we are in teamplay, only grab a model if the skin is correct
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		for (i = 0; i < cgs.maxclients; i++) {
 			match = &cgs.clientinfo[ i ];
 			if (!match->infoValid || match->deferred) {
 				continue;
 			}
 			if (!Q_strequal(ci->skinName, match->skinName) ||
-					(CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype) && ci->team != match->team)) {
+					(CG_IsATeamGametype(cgs.gametype) && ci->team != match->team)) {
 				continue;
 			}
 			ci->deferred = qtrue;
@@ -1153,7 +1153,7 @@ void CG_NewClientInfo(int clientNum) {
 
 		/* Neon_Knight: Missionpack checks, if != 0, enables this. */
 		if (cg_missionpackChecks.integer) {
-			if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+			if (CG_IsATeamGametype(cgs.gametype)) {
 				Q_strncpyz(newInfo.modelName, DEFAULT_TEAM_MODEL, sizeof ( newInfo.modelName));
 				Q_strncpyz(newInfo.skinName, "default", sizeof ( newInfo.skinName));
 			}
@@ -1169,7 +1169,7 @@ void CG_NewClientInfo(int clientNum) {
 			Q_strncpyz(newInfo.modelName, modelStr, sizeof ( newInfo.modelName));
 		}
 		/* /Neon_Knight */
-		if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype)) {
 			// keep skin name
 			slash = strchr(v, '/');
 			if (slash) {
@@ -1200,7 +1200,7 @@ void CG_NewClientInfo(int clientNum) {
 
 		/* Neon_Knight: Missionpack checks, if != 0, enables this. */
 		if (cg_missionpackChecks.integer) {
-			if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+			if (CG_IsATeamGametype(cgs.gametype)) {
 				Q_strncpyz(newInfo.headModelName, DEFAULT_TEAM_MODEL, sizeof ( newInfo.headModelName));
 				Q_strncpyz(newInfo.headSkinName, "default", sizeof ( newInfo.headSkinName));
 			}
@@ -1217,7 +1217,7 @@ void CG_NewClientInfo(int clientNum) {
 		}
 		/* /Neon_Knight */
 
-		if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype)) {
 			// keep skin name
 			slash = strchr(v, '/');
 			if (slash) {
@@ -2250,7 +2250,7 @@ static void CG_PlayerSprites(centity_t *cent) {
 	team = cgs.clientinfo[ cent->currentState.clientNum ].team;
 	if (!(cent->currentState.eFlags & EF_DEAD) &&
 			cg.snap->ps.persistant[PERS_TEAM] == team &&
-			CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+			CG_IsATeamGametype(cgs.gametype)) {
 		if (cg_drawFriend.integer) {
 			CG_PlayerFloatSprite(cent, cgs.media.friendShader);
 		}

--- a/code/cgame/cg_playerstate.c
+++ b/code/cgame/cg_playerstate.c
@@ -432,7 +432,7 @@ void CG_CheckLocalSounds( playerState_t *ps, playerState_t *ops ) {
 		if ( !cg.warmup ) {
 			// never play lead changes during warmup
 			if ( ps->persistant[PERS_RANK] != ops->persistant[PERS_RANK] ) {
-				if (!(CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype))) {
+				if (!CG_IsATeamGametype(cgs.gametype)) {
 					if (  ps->persistant[PERS_RANK] == 0 ) {
 						CG_AddBufferedSound(cgs.media.takenLeadSound);
 					} else if ( ps->persistant[PERS_RANK] == RANK_TIED_FLAG && cgs.gametype != GT_POSSESSION ) {

--- a/code/cgame/cg_scoreboard.c
+++ b/code/cgame/cg_scoreboard.c
@@ -190,7 +190,7 @@ static void CG_DrawClientScore(int y, score_t *score, float *color, float fade, 
 		localClient = qtrue;
 
 		if ((cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR) ||
-				(CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype))) {
+				CG_IsATeamGametype(cgs.gametype)) {
 			// Sago: I think this means that it doesn't matter if two players are tied in team game - only team score counts
 			rank = -1;
 		} else {
@@ -324,7 +324,7 @@ qboolean CG_DrawOldScoreboard(void) {
 	}
 
 	// current rank
-	if (!(CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype))) {
+	if (!CG_IsATeamGametype(cgs.gametype)) {
 		if (cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR) {
 			s = va("%s place with %i",
 					CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1),
@@ -374,7 +374,7 @@ qboolean CG_DrawOldScoreboard(void) {
 
 	localClient = qfalse;
 
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		//
 		// teamplay scoreboard
 		//
@@ -505,7 +505,7 @@ void CG_DrawOldTourneyScoreboard(void) {
 	// print the two scores
 
 	y = 160;
-	if (CG_IsATeamGametype(cgs.gametype) && CG_UsesKeyObjectives(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype)) {
 		//
 		// teamplay scoreboard
 		//

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -2254,7 +2254,7 @@ TeamPlayIsOn
 ==================
  */
 int TeamPlayIsOn(void) {
-	return (G_IsATeamGametype(gametype) && G_UsesKeyObjectives(gametype));
+	return G_IsATeamGametype(gametype);
 }
 
 /*
@@ -2840,7 +2840,7 @@ int BotSameTeam(bot_state_t *bs, int entnum) {
 		//BotAI_Print(PRT_ERROR, "BotSameTeam: client out of range\n");
 		return qfalse;
 	}
-	if (G_IsATeamGametype(gametype) && G_UsesKeyObjectives(gametype)) {
+	if (G_IsATeamGametype(gametype)) {
 		/*Sago: I don't know why they decided to check the configstring instead of the real value.
 		 For some reason bots sometimes gets a wrong config string when chaning gametypes.
 		 Now we check the real value: */

--- a/code/game/ai_team.c
+++ b/code/game/ai_team.c
@@ -2112,7 +2112,7 @@ void BotTeamAI(bot_state_t *bs) {
         if (bot_nochat.integer>2) return;
 
 	//
-	if (!(G_IsATeamGametype(gametype) && G_UsesKeyObjectives(gametype)))
+	if (!G_IsATeamGametype(gametype))
 		return;
 	// make sure we've got a valid team leader
 	if (!BotValidTeamLeader(bs)) {

--- a/code/game/g_bot.c
+++ b/code/game/g_bot.c
@@ -671,7 +671,7 @@ static void G_AddBot( const char *name, float skill, const char *team, int delay
 
 	// initialize the bot settings
 	if( !team || !*team ) {
-		if(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+		if(G_IsATeamGametype(g_gametype.integer)) {
 			if( PickTeam(clientNum) == TEAM_RED) {
 				team = "red";
 			}

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -1200,7 +1200,7 @@ void ClientUserinfoChanged( int clientNum ) {
 	client->ps.stats[STAT_MAX_HEALTH] = client->pers.maxHealth;
 
 	// set model
-	if(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if(G_IsATeamGametype(g_gametype.integer)) {
 		Q_strncpyz( model, Info_ValueForKey (userinfo, "team_model"), sizeof( model ) );
 		Q_strncpyz( headModel, Info_ValueForKey (userinfo, "team_headmodel"), sizeof( headModel ) );
 	} else {
@@ -1209,7 +1209,7 @@ void ClientUserinfoChanged( int clientNum ) {
 	}
 
 	// bots set their team a few frames later
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer) && g_entities[clientNum].r.svFlags & SVF_BOT) {
+	if (G_IsATeamGametype(g_gametype.integer) && g_entities[clientNum].r.svFlags & SVF_BOT) {
 		s = Info_ValueForKey( userinfo, "team" );
 		if ( Q_strequal( s, "red" ) || Q_strequal( s, "r" ) ) {
 			team = TEAM_RED;
@@ -1225,7 +1225,7 @@ void ClientUserinfoChanged( int clientNum ) {
 		team = client->sess.sessionTeam;
 	}
 
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		client->pers.teamInfo = qtrue;
 	} else {
 		s = Info_ValueForKey( userinfo, "teamoverlay" );
@@ -1242,7 +1242,7 @@ void ClientUserinfoChanged( int clientNum ) {
 	teamLeader = client->sess.teamLeader;
 
 	// colors
-	if(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer) && g_instantgib.integer) {
+	if(G_IsATeamGametype(g_gametype.integer) && g_instantgib.integer) {
 		switch(team) {
 			case TEAM_RED:
 				c1[0] = COLOR_BLUE;
@@ -1409,7 +1409,7 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 		trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " connected\n\"", client->pers.netname) );
 	}
 
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer) && client->sess.sessionTeam != TEAM_SPECTATOR ) {
+	if (G_IsATeamGametype(g_gametype.integer) && client->sess.sessionTeam != TEAM_SPECTATOR ) {
 		BroadcastTeamChange( client, -1 );
 	}
 
@@ -1522,7 +1522,7 @@ void ClientBegin( int clientNum ) {
 	countFree = TeamCount(-1,TEAM_FREE);
 	countRed = TeamCount(-1,TEAM_RED);
 	countBlue = TeamCount(-1,TEAM_BLUE);
-	if(!(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)))
+	if(!G_IsATeamGametype(g_gametype.integer))
 	{
 		if(countFree>level.teamSize)
 			level.teamSize=countFree;

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -776,7 +776,7 @@ void SetTeam( gentity_t *ent, char *s ) {
 		team = TEAM_SPECTATOR;
 		specState = SPECTATOR_FREE;
 	} 
-	else if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	else if (G_IsATeamGametype(g_gametype.integer)) {
 		// if running a team game, assign player to one of the teams
 		specState = SPECTATOR_NOT;
 		if ( Q_strequal( s, "red" ) || Q_strequal( s, "r" ) ) {
@@ -1190,7 +1190,7 @@ void G_Say( gentity_t *ent, gentity_t *target, int mode, const char *chatText ) 
 
     if ((ent->r.svFlags & SVF_BOT) && trap_Cvar_VariableValue( "bot_nochat" )>1) return;
 
-	if ( !(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) && mode == SAY_TEAM ) {
+	if ( !G_IsATeamGametype(g_gametype.integer) && mode == SAY_TEAM ) {
 		mode = SAY_ALL;
 	}
 
@@ -1212,7 +1212,7 @@ void G_Say( gentity_t *ent, gentity_t *target, int mode, const char *chatText ) 
 		color = COLOR_CYAN;
 		break;
 	case SAY_TELL:
-		if (target && target->inuse && target->client && G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer) &&
+		if (target && target->inuse && target->client && G_IsATeamGametype(g_gametype.integer) &&
 			target->client->sess.sessionTeam == ent->client->sess.sessionTeam &&
 			Team_GetLocationMsg(ent, location, sizeof(location)))
 			Com_sprintf (name, sizeof(name), EC"[%s%c%c"EC"] (%s)"EC": ", ent->client->pers.netname, Q_COLOR_ESCAPE, COLOR_WHITE, location );
@@ -1350,7 +1350,7 @@ void G_Voice( gentity_t *ent, gentity_t *target, int mode, const char *id, qbool
 	int			j;
 	gentity_t	*other;
 
-	if ( !(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) && mode == SAY_TEAM ) {
+	if ( !G_IsATeamGametype(g_gametype.integer) && mode == SAY_TEAM ) {
 		mode = SAY_ALL;
 	}
 
@@ -1510,7 +1510,7 @@ static void Cmd_VoiceTaunt_f( gentity_t *ent ) {
 		}
 	}
 
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		// praise a team mate who just got a reward
 		for(i = 0; i < MAX_CLIENTS; i++) {
 			who = g_entities + i;

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -88,7 +88,7 @@ int Pickup_Powerup( gentity_t *ent, gentity_t *other )
 
 		// if same team in team game, no sound
 		// cannot use OnSameTeam as it expects to g_entities, not clients
-		if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer) && other->client->sess.sessionTeam == client->sess.sessionTeam  ) {
+		if (G_IsATeamGametype(g_gametype.integer) && other->client->sess.sessionTeam == client->sess.sessionTeam  ) {
 			continue;
 		}
 

--- a/code/game/g_killspree.c
+++ b/code/game/g_killspree.c
@@ -288,7 +288,7 @@ void G_RunStreakLogic( gentity_t *attacker, gentity_t *victim )
 		&& ( attacker != victim ) ) {
 
 		//Check the gametype--If FFA enabled, everybody's on the same team. 
-		if(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+		if(G_IsATeamGametype(g_gametype.integer)) {
 			//If they are on the same team we don't want to count it towards a killing spree. 
 			if( OnSameTeam( victim, attacker ) ) {
 				return;

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -848,8 +848,7 @@ void G_InitGame( int levelTime, int randomSeed, int restart )
 	G_FindTeams();
 
 	// make sure we have flags for CTF, etc
-	if ( g_gametype.integer == GT_POSSESSION ||
-	        (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer))) {
+	if (G_UsesKeyObjectives(g_gametype.integer)) {
 		G_CheckTeamItems();
 	}
 
@@ -1281,7 +1280,7 @@ void CalculateRanks( void )
 	       sizeof(level.sortedClients[0]), SortRanks );
 
 	// set the rank value for all clients that are connected and not spectators
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		// in team games, rank is just the order of the teams, 0=red, 1=blue, 2=tied
 		for ( i = 0;  i < level.numConnectedClients; i++ ) {
 			cl = &level.clients[ level.sortedClients[i] ];
@@ -1320,7 +1319,7 @@ void CalculateRanks( void )
 	}
 
 	// set the CS_SCORES1/2 configstrings, which will be visible to everyone
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		trap_SetConfigstring( CS_SCORES1, va("%i", level.teamScores[TEAM_RED] ) );
 		trap_SetConfigstring( CS_SCORES2, va("%i", level.teamScores[TEAM_BLUE] ) );
 	}
@@ -1444,7 +1443,7 @@ static void SendVictoryChallenge( void )
 	default:
 		return;
 	};
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		//Team games
 		for ( i = 0 ; i < level.maxclients ; i++ ) {
 			cl = &level.clients[i];
@@ -1850,7 +1849,7 @@ void LogExit( const char *string )
 		numSorted = 32;
 	}
 
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		G_LogPrintf( "red:%i  blue:%i\n",
 		             level.teamScores[TEAM_RED], level.teamScores[TEAM_BLUE] );
 	}
@@ -1999,14 +1998,14 @@ qboolean ScoreIsTied( void )
 	}
 
 	//Sago: In Elimination and Oneway Flag Capture teams must win by two points.
-	if ( g_gametype.integer == GT_ELIMINATION ||
+	if ( (G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer)) ||
 	        (g_gametype.integer == GT_CTF_ELIMINATION && g_elimination_ctf_oneway.integer)) {
 		return (level.teamScores[TEAM_RED] == level.teamScores[TEAM_BLUE] ||
 		        level.teamScores[TEAM_RED] == level.teamScores[TEAM_BLUE]+1 ||
 		        level.teamScores[TEAM_RED] == level.teamScores[TEAM_BLUE]-1);
 	}
 
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		return level.teamScores[TEAM_RED] == level.teamScores[TEAM_BLUE];
 	}
 

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -142,7 +142,7 @@ void ProximityMine_Trigger( gentity_t *trigger, gentity_t *other, trace_t *trace
 	}
 
 
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		// don't trigger same team mines
 		if (trigger->parent->s.generic1 == other->client->sess.sessionTeam) {
 			return;

--- a/code/game/g_rankings.c
+++ b/code/game/g_rankings.c
@@ -105,7 +105,7 @@ void G_RankRunFrame()
 				break;
 			case QGR_STATUS_ACTIVE:
 				if( (ent->client->sess.sessionTeam == TEAM_SPECTATOR || (client->isEliminated)) &&
-					!(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) )
+					!(G_IsATeamGametype(g_gametype.integer)) )
 				{
 					SetTeam( ent, "free" );
 				}

--- a/code/game/g_session.c
+++ b/code/game/g_session.c
@@ -109,7 +109,7 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
 	sess = &client->sess;
 
 	// initial team determination
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		if ( g_teamAutoJoin.integer && !(g_entities[ client - level.clients ].r.svFlags & SVF_BOT) ) {
 			sess->sessionTeam = PickTeam( -1 );
 			BroadcastTeamChange( client, -1 );

--- a/code/game/g_spawn.c
+++ b/code/game/g_spawn.c
@@ -452,7 +452,7 @@ void G_SpawnGEntityFromSpawnVars( void ) {
 		}
 	}
 	// check for "notteam" flag
-	if (G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer)) {
 		G_SpawnInt( "notteam", "0", &i );
 		if ( i ) {
 			G_FreeEntity( ent );

--- a/code/game/g_team.c
+++ b/code/game/g_team.c
@@ -231,7 +231,7 @@ qboolean OnSameTeam( const gentity_t *ent1, const gentity_t *ent2 )
 		return qfalse;
 	}
 
-	if (!(G_IsATeamGametype(g_gametype.integer) && G_UsesKeyObjectives(g_gametype.integer))) {
+	if (!G_IsATeamGametype(g_gametype.integer)) {
 		return qfalse;
 	}
 

--- a/code/q3_ui/ui_addbots.c
+++ b/code/q3_ui/ui_addbots.c
@@ -333,7 +333,7 @@ static void UI_AddBotsMenu_Init( void ) {
 	addBotsMenuInfo.team.generic.y			= y;
 	addBotsMenuInfo.team.generic.name		= "Team: ";
 	addBotsMenuInfo.team.generic.id			= ID_TEAM;
-	if(UI_IsATeamGametype(gametype) && UI_UsesKeyObjectives(gametype)) {
+	if(UI_IsATeamGametype(gametype)) {
 		addBotsMenuInfo.team.itemnames		= teamNames2;
 	}
 	else {

--- a/code/q3_ui/ui_ingame.c
+++ b/code/q3_ui/ui_ingame.c
@@ -236,7 +236,7 @@ void InGame_MenuInit( void ) {
 	s_ingame.teamorders.string				= "TEAM ORDERS";
 	s_ingame.teamorders.color				= color_red;
 	s_ingame.teamorders.style				= UI_CENTER|UI_SMALLFONT;
-	if(!(UI_IsATeamGametype(gametype) && UI_UsesKeyObjectives(gametype))) {
+	if(!UI_IsATeamGametype(gametype)) {
 		s_ingame.teamorders.generic.flags |= QMF_GRAYED;
 	}
 	else {

--- a/code/q3_ui/ui_startserver.c
+++ b/code/q3_ui/ui_startserver.c
@@ -877,7 +877,7 @@ static qboolean BotAlreadySelected( const char *checkName ) {
 		if( s_serveroptions.playerType[n].curvalue != 1 ) {
 			continue;
 		}
-		if(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype) &&
+		if(UI_IsATeamGametype(s_serveroptions.gametype) &&
 			(s_serveroptions.playerTeam[n].curvalue != s_serveroptions.playerTeam[s_serveroptions.newBotIndex].curvalue ) ) {
 			continue;
 		}
@@ -1070,7 +1070,7 @@ static void ServerOptions_Start( void ) {
 		if( s_serveroptions.playerNameBuffers[n][0] == '-' ) {
 			continue;
 		}
-		if(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype)) {
+		if(UI_IsATeamGametype(s_serveroptions.gametype)) {
 			Com_sprintf( buf, sizeof(buf), "addbot %s %i %s\n", s_serveroptions.playerNameBuffers[n], skill,
 				playerTeam_list[s_serveroptions.playerTeam[n].curvalue] );
 		}
@@ -1081,7 +1081,7 @@ static void ServerOptions_Start( void ) {
 	}
 
 	// set player's team
-	if( /*dedicated == 0 &&*/ UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype)) {
+	if( UI_IsATeamGametype(s_serveroptions.gametype)) {
 		trap_Cmd_ExecuteText( EXEC_APPEND, va( "wait 5; team %s\n", playerTeam_list[s_serveroptions.playerTeam[0].curvalue] ) );
 	}
 }
@@ -1108,7 +1108,7 @@ static void ServerOptions_InitPlayerItems( void ) {
 		s_serveroptions.playerType[n].curvalue = v;
 	}
 
-	if(s_serveroptions.multiplayer && !(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype))) {
+	if(s_serveroptions.multiplayer && !UI_IsATeamGametype(s_serveroptions.gametype)) {
 		for( n = 8; n < PLAYER_SLOTS; n++ ) {
 			s_serveroptions.playerType[n].curvalue = 2;
 		}
@@ -1122,7 +1122,7 @@ static void ServerOptions_InitPlayerItems( void ) {
 	Q_CleanStr( s_serveroptions.playerNameBuffers[0] );
 
 	// init teams
-	if(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype)) {
+	if(UI_IsATeamGametype(s_serveroptions.gametype)) {
 		for( n = 0; n < (PLAYER_SLOTS / 2); n++ ) {
 			s_serveroptions.playerTeam[n].curvalue = 0;
 		}
@@ -1162,7 +1162,7 @@ static void ServerOptions_SetPlayerItems( void ) {
 	}
 
 	// teams
-	if(!(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype))) {
+	if(!UI_IsATeamGametype(s_serveroptions.gametype)) {
 		return;
 	}
 	for( n = start; n < PLAYER_SLOTS; n++ ) {
@@ -1344,7 +1344,7 @@ static void ServerOptions_InitBotNames( void ) {
 	char		bots[MAX_INFO_STRING];
 
 	//this SHOULD work
-	if(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype)) {
+	if(UI_IsATeamGametype(s_serveroptions.gametype)) {
 		Q_strncpyz( s_serveroptions.playerNameBuffers[1], "gargoyle", 16 );
 		Q_strncpyz( s_serveroptions.playerNameBuffers[2], "kyonshi", 16 );
 		Q_strncpyz( s_serveroptions.playerNameBuffers[3], "grism", 16 );
@@ -1701,7 +1701,8 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 	s_serveroptions.timelimit.field.widthInChars = 3;
 	s_serveroptions.timelimit.field.maxchars     = 3;
 
-	if(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype) && !(UI_IsARoundBasedGametype(s_serveroptions.gametype) && UI_IsATeamGametype(s_serveroptions.gametype))) {
+	if(UI_IsATeamGametype(s_serveroptions.gametype) &&
+			!UI_IsARoundBasedGametype(s_serveroptions.gametype)) {
 		y += BIGCHAR_HEIGHT+2;
 		s_serveroptions.friendlyfire.generic.type     = MTYPE_RADIOBUTTON;
 		s_serveroptions.friendlyfire.generic.flags    = QMF_PULSEIFFOCUS|QMF_SMALLFONT;
@@ -1879,7 +1880,7 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 			Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.playerType[n] );
 		}
 		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.playerName[n] );
-		if(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype)) {
+		if(UI_IsATeamGametype(s_serveroptions.gametype)) {
 			Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.playerTeam[n] );
 		}
 	}
@@ -1891,7 +1892,8 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.flaglimit );
 	}
 	Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.timelimit );
-	if(UI_IsATeamGametype(s_serveroptions.gametype) && UI_UsesKeyObjectives(s_serveroptions.gametype) && !(UI_IsARoundBasedGametype(s_serveroptions.gametype) && UI_IsATeamGametype(s_serveroptions.gametype))) {
+	if(UI_IsATeamGametype(s_serveroptions.gametype) &&
+			!UI_IsARoundBasedGametype(s_serveroptions.gametype)) {
 		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.friendlyfire );
 	}
 	Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.pure );

--- a/code/q3_ui/ui_teamorders.c
+++ b/code/q3_ui/ui_teamorders.c
@@ -548,7 +548,7 @@ void UI_TeamOrdersMenu_f( void )
 	// make sure it's a team game
 	trap_GetConfigString( CS_SERVERINFO, info, sizeof(info) );
 	teamOrdersMenuInfo.gametype = atoi( Info_ValueForKey( info, "g_gametype" ) );
-	if(!(UI_IsATeamGametype(teamOrdersMenuInfo.gametype) && UI_UsesKeyObjectives(teamOrdersMenuInfo.gametype))) {
+	if(!UI_IsATeamGametype(teamOrdersMenuInfo.gametype)) {
 		return;
 	}
 

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -2969,25 +2969,25 @@ static qboolean UI_OwnerDrawVisible(int flags)
 			flags &= ~UI_SHOW_DEMOAVAILABLE;
 		}
 		if (flags & UI_SHOW_ANYTEAMOBJECTIVEGAME) {
-			if (!(UI_UsesKeyObjectives(uiInfo.gameTypes[ui_gameType.integer].gtEnum) && UI_IsATeamGametype(uiInfo.gameTypes[ui_gameType.integer].gtEnum))) {
+			if (!UI_IsATeamGametype(uiInfo.gameTypes[ui_gameType.integer].gtEnum)) {
 				vis = qfalse;
 			}
 			flags &= ~UI_SHOW_ANYTEAMOBJECTIVEGAME;
 		}
 		if (flags & UI_SHOW_ANYNONTEAMOBJECTIVEGAME) {
-			if (UI_UsesKeyObjectives(uiInfo.gameTypes[ui_gameType.integer].gtEnum) && UI_IsATeamGametype(uiInfo.gameTypes[ui_gameType.integer].gtEnum)) {
+			if (UI_IsATeamGametype(uiInfo.gameTypes[ui_gameType.integer].gtEnum)) {
 				vis = qfalse;
 			}
 			flags &= ~UI_SHOW_ANYNONTEAMOBJECTIVEGAME;
 		}
 		if (flags & UI_SHOW_NETANYTEAMOBJECTIVEGAME) {
-			if (!(UI_UsesKeyObjectives(uiInfo.gameTypes[ui_netGameType.integer].gtEnum) && UI_IsATeamGametype(uiInfo.gameTypes[ui_netGameType.integer].gtEnum))) {
+			if (!UI_IsATeamGametype(uiInfo.gameTypes[ui_netGameType.integer].gtEnum)) {
 				vis = qfalse;
 			}
 			flags &= ~UI_SHOW_NETANYTEAMOBJECTIVEGAME;
 		}
 		if (flags & UI_SHOW_NETANYNONTEAMOBJECTIVEGAME) {
-			if (UI_UsesKeyObjectives(uiInfo.gameTypes[ui_netGameType.integer].gtEnum) && UI_IsATeamGametype(uiInfo.gameTypes[ui_netGameType.integer].gtEnum)) {
+			if (UI_IsATeamGametype(uiInfo.gameTypes[ui_netGameType.integer].gtEnum)) {
 				vis = qfalse;
 			}
 			flags &= ~UI_SHOW_NETANYNONTEAMOBJECTIVEGAME;


### PR DESCRIPTION
There were many checks which asked if a gametype not only is team-based but also if it uses key game objectives. These checks excluded Team Deathmatch and Elimination from any feature that those modes could make good use of. Among the listed fixes:

* Team overlay draw.
* Players starting as spectators.
* Team scoreboard.
* Team info.
* Team players' identification as Red or Blue team members.
* Application of team shaders.
* MPUI/UI3: Team feeders, score calculation, and other team-based features.
* Proper display of player skins.
* Team AI thinking.