### PR TITLE
New cvar: cg_drawMinedMessageInstantly. Fuses into a single message t…

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -3285,10 +3285,8 @@ static void CG_DrawProxWarning( void ) {
 
 	proxTick = 10 - ((cg.time - proxTime) / 1000);
 
-	if (proxTick > 0 && proxTick <= 5) {
-		Com_sprintf(s, sizeof(s), "INTERNAL COMBUSTION IN: %i", proxTick);
-	} else {
-		Com_sprintf(s, sizeof(s), "YOU HAVE BEEN MINED");
+	if (proxTick > 0) {
+		Com_sprintf(s, sizeof(s), "YOU HAVE BEEN MINED\rINTERNAL COMBUSTION IN: %i", proxTick);
 	}
 
 	w = CG_DrawStrlen( s ) * BIGCHAR_WIDTH;

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1483,6 +1483,8 @@ extern vmCvar_t cg_missionpackChecks;
 /* /Neon_Knight */
 extern vmCvar_t cg_leiChibi;
 
+extern vmCvar_t		cg_drawMinedMessageInstantly;
+
 //unlagged - cg_unlagged.c
 void CG_PredictWeaponEffects( centity_t *cent );
 //void CG_AddBoundingBox( centity_t *cent );


### PR DESCRIPTION
…he "You have been mined" and "Internal combustion" messages for players hit with a proxy mine.