### PR TITLE
Unifying format criteria for cvars in every module.

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1289,212 +1289,199 @@ extern	weaponInfo_t	cg_weapons[MAX_WEAPONS];
 extern	itemInfo_t		cg_items[MAX_ITEMS];
 extern	markPoly_t		cg_markPolys[MAX_MARK_POLYS];
 
-extern	vmCvar_t		cg_centertime;
-extern	vmCvar_t		cg_runpitch;
-extern	vmCvar_t		cg_runroll;
-extern	vmCvar_t		cg_bob;
-extern	vmCvar_t		cg_bobup;
-extern	vmCvar_t		cg_bobpitch;
-extern	vmCvar_t		cg_bobroll;
-extern	vmCvar_t		cg_bobmodel;	// leilei
-extern	vmCvar_t		cg_kickScale;
-extern	vmCvar_t		cg_swingSpeed;
-extern	vmCvar_t		cg_shadows;
-extern	vmCvar_t		cg_gibs;
-extern	vmCvar_t		cg_drawTimer;
-extern	vmCvar_t		cg_drawFPS;
-extern	vmCvar_t		cg_drawSnapshot;
-extern	vmCvar_t		cg_draw3dIcons;
-extern	vmCvar_t		cg_drawIcons;
-extern	vmCvar_t		cg_drawAmmoWarning;
-extern	vmCvar_t		cg_drawCrosshair;
-extern	vmCvar_t		cg_drawCrosshairNames;
-extern	vmCvar_t		cg_drawRewards;
-extern	vmCvar_t		cg_drawTeamOverlay;
-extern	vmCvar_t		cg_teamOverlayUserinfo;
-extern	vmCvar_t		cg_crosshairX;
-extern	vmCvar_t		cg_crosshairY;
-extern	vmCvar_t		cg_crosshairSize;
-extern	vmCvar_t		cg_crosshairHealth;
-extern	vmCvar_t		cg_drawStatus;
-extern	vmCvar_t		cg_draw2D;
-extern	vmCvar_t		cg_animSpeed;
-extern	vmCvar_t		cg_debugAnim;
-extern	vmCvar_t		cg_debugPosition;
-extern	vmCvar_t		cg_debugEvents;
-extern	vmCvar_t		cg_railTrailTime;
-extern	vmCvar_t		cg_errorDecay;
-extern	vmCvar_t		cg_nopredict;
-extern	vmCvar_t		cg_noPlayerAnims;
-extern	vmCvar_t		cg_showmiss;
-extern	vmCvar_t		cg_footsteps;
-extern	vmCvar_t		cg_addMarks;
-extern	vmCvar_t		cg_brassTime;
-extern	vmCvar_t		cg_gun_frame;
-extern	vmCvar_t		cg_gun_x;
-extern	vmCvar_t		cg_gun_y;
-extern	vmCvar_t		cg_gun_z;
-extern	vmCvar_t		cg_drawGun;
-extern	vmCvar_t		cg_viewsize;
-extern	vmCvar_t		cg_viewnudge;	// leilei
-extern	vmCvar_t		cg_tracerChance;
-extern	vmCvar_t		cg_tracerWidth;
-extern	vmCvar_t		cg_tracerLength;
-extern	vmCvar_t		cg_autoswitch;
-extern	vmCvar_t		cg_ignore;
-extern	vmCvar_t		cg_simpleItems;
-extern	vmCvar_t		cg_fov;
-extern	vmCvar_t		cg_zoomFov;
-extern	vmCvar_t		cg_thirdPersonRange;
-extern	vmCvar_t		cg_thirdPersonAngle;
-extern	vmCvar_t		cg_thirdPerson;
-extern	vmCvar_t		cg_lagometer;
-extern	vmCvar_t		cg_drawAttacker;
-extern	vmCvar_t		cg_drawSpeed;
-extern	vmCvar_t		cg_synchronousClients;
-extern	vmCvar_t		cg_teamChatTime;
-extern	vmCvar_t		cg_teamChatHeight;
-extern	vmCvar_t		cg_stats;
-extern	vmCvar_t 		cg_forceModel;
-extern	vmCvar_t 		cg_buildScript;
-extern	vmCvar_t		cg_paused;
-extern	vmCvar_t		cg_blood;
-extern	vmCvar_t		cg_predictItems;
-extern	vmCvar_t		cg_deferPlayers;
-extern	vmCvar_t		cg_drawFriend;
-extern	vmCvar_t		cg_teamChatsOnly;
-extern	vmCvar_t		cg_noVoiceChats;
-extern	vmCvar_t		cg_noVoiceText;
-extern  vmCvar_t		cg_scorePlum;
-extern	vmCvar_t		cg_obituaryOutput;
+extern vmCvar_t cg_centertime;
+extern vmCvar_t cg_runpitch;
+extern vmCvar_t cg_runroll;
+extern vmCvar_t cg_bob;
+extern vmCvar_t cg_bobup;
+extern vmCvar_t cg_bobpitch;
+extern vmCvar_t cg_bobroll;
+extern vmCvar_t cg_bobmodel;	// leilei
+extern vmCvar_t cg_kickScale;
+extern vmCvar_t cg_swingSpeed;
+extern vmCvar_t cg_shadows;
+extern vmCvar_t cg_gibs;
+extern vmCvar_t cg_drawTimer;
+extern vmCvar_t cg_drawFPS;
+extern vmCvar_t cg_drawSnapshot;
+extern vmCvar_t cg_draw3dIcons;
+extern vmCvar_t cg_drawIcons;
+extern vmCvar_t cg_drawAmmoWarning;
+extern vmCvar_t cg_drawCrosshair;
+extern vmCvar_t cg_drawCrosshairNames;
+extern vmCvar_t cg_drawRewards;
+extern vmCvar_t cg_drawTeamOverlay;
+extern vmCvar_t cg_teamOverlayUserinfo;
+extern vmCvar_t cg_crosshairX;
+extern vmCvar_t cg_crosshairY;
+extern vmCvar_t cg_crosshairSize;
+extern vmCvar_t cg_crosshairHealth;
+extern vmCvar_t cg_drawStatus;
+extern vmCvar_t cg_draw2D;
+extern vmCvar_t cg_animSpeed;
+extern vmCvar_t cg_debugAnim;
+extern vmCvar_t cg_debugPosition;
+extern vmCvar_t cg_debugEvents;
+extern vmCvar_t cg_railTrailTime;
+extern vmCvar_t cg_errorDecay;
+extern vmCvar_t cg_nopredict;
+extern vmCvar_t cg_noPlayerAnims;
+extern vmCvar_t cg_showmiss;
+extern vmCvar_t cg_footsteps;
+extern vmCvar_t cg_addMarks;
+extern vmCvar_t cg_brassTime;
+extern vmCvar_t cg_gun_frame;
+extern vmCvar_t cg_gun_x;
+extern vmCvar_t cg_gun_y;
+extern vmCvar_t cg_gun_z;
+extern vmCvar_t cg_drawGun;
+extern vmCvar_t cg_viewsize;
+extern vmCvar_t cg_viewnudge;	// leilei
+extern vmCvar_t cg_tracerChance;
+extern vmCvar_t cg_tracerWidth;
+extern vmCvar_t cg_tracerLength;
+extern vmCvar_t cg_autoswitch;
+extern vmCvar_t cg_ignore;
+extern vmCvar_t cg_simpleItems;
+extern vmCvar_t cg_fov;
+extern vmCvar_t cg_zoomFov;
+extern vmCvar_t cg_thirdPersonRange;
+extern vmCvar_t cg_thirdPersonAngle;
+extern vmCvar_t cg_thirdPerson;
+extern vmCvar_t cg_lagometer;
+extern vmCvar_t cg_drawAttacker;
+extern vmCvar_t cg_drawSpeed;
+extern vmCvar_t cg_synchronousClients;
+extern vmCvar_t cg_teamChatTime;
+extern vmCvar_t cg_teamChatHeight;
+extern vmCvar_t cg_stats;
+extern vmCvar_t cg_forceModel;
+extern vmCvar_t cg_buildScript;
+extern vmCvar_t cg_paused;
+extern vmCvar_t cg_blood;
+extern vmCvar_t cg_predictItems;
+extern vmCvar_t cg_deferPlayers;
+extern vmCvar_t cg_drawFriend;
+extern vmCvar_t cg_teamChatsOnly;
+extern vmCvar_t cg_noVoiceChats;
+extern vmCvar_t cg_noVoiceText;
+extern vmCvar_t cg_scorePlum;
+extern vmCvar_t cg_obituaryOutput;
 //unlagged - smooth clients #2
 // this is done server-side now
-//extern	vmCvar_t		cg_smoothClients;
+//extern vmCvar_t cg_smoothClients;
 //unlagged - smooth clients #2
-extern	vmCvar_t		pmove_fixed;
-extern	vmCvar_t		pmove_msec;
-extern	vmCvar_t		pmove_float;
-//extern	vmCvar_t		cg_pmove_fixed;
-extern	vmCvar_t		cg_cameraOrbit;
-extern	vmCvar_t		cg_cameraOrbitDelay;
-extern	vmCvar_t		cg_timescaleFadeEnd;
-extern	vmCvar_t		cg_timescaleFadeSpeed;
-extern	vmCvar_t		cg_timescale;
-//extern	vmCvar_t		cg_cameraMode;
-
-extern  vmCvar_t		cg_smallFont;
-extern  vmCvar_t		cg_bigFont;
-extern	vmCvar_t		cg_noTaunt;
-extern	vmCvar_t		cg_noProjectileTrail;
-extern	vmCvar_t		cg_oldRail;
-extern	vmCvar_t		cg_oldRocket;
-
-extern	vmCvar_t		cg_leiEnhancement;			// LEILEI'S LINE!
-extern	vmCvar_t		cg_leiGoreNoise;			// LEILEI'S LINE!
-extern	vmCvar_t		cg_leiBrassNoise;			// LEILEI'S LINE!
-extern	vmCvar_t		cg_leiSuperGoreyAwesome;	// LEILEI'S LINE!
-extern	vmCvar_t		cg_muzzleflashStyle;		// Leilei
-extern	vmCvar_t		cg_leiDebug;
-extern	vmCvar_t		cg_deathcam;
-extern	vmCvar_t		cg_cameramode;
-extern	vmCvar_t		cg_cameraEyes;
-extern	vmCvar_t		cg_cameraEyes_Fwd;
-extern	vmCvar_t		cg_cameraEyes_Up;
-
-extern	vmCvar_t		cg_modelEyes_Up;
-extern	vmCvar_t		cg_modelEyes_Right;
-extern	vmCvar_t		cg_modelEyes_Fwd;
-
-extern	vmCvar_t		cg_oldPlasma;
-extern	vmCvar_t		cg_trueLightning;
-extern	vmCvar_t		cg_music;
+extern vmCvar_t pmove_fixed;
+extern vmCvar_t pmove_msec;
+extern vmCvar_t pmove_float;
+//extern vmCvar_t cg_pmove_fixed;
+extern vmCvar_t cg_cameraOrbit;
+extern vmCvar_t cg_cameraOrbitDelay;
+extern vmCvar_t cg_timescaleFadeEnd;
+extern vmCvar_t cg_timescaleFadeSpeed;
+extern vmCvar_t cg_timescale;
+//extern vmCvar_t cg_cameraMode;
+extern vmCvar_t cg_smallFont;
+extern vmCvar_t cg_bigFont;
+extern vmCvar_t cg_noTaunt;
+extern vmCvar_t cg_noProjectileTrail;
+extern vmCvar_t cg_oldRail;
+extern vmCvar_t cg_oldRocket;
+extern vmCvar_t cg_leiEnhancement;			// LEILEI'S LINE!
+extern vmCvar_t cg_leiGoreNoise;			// LEILEI'S LINE!
+extern vmCvar_t cg_leiBrassNoise;			// LEILEI'S LINE!
+extern vmCvar_t cg_leiSuperGoreyAwesome;	// LEILEI'S LINE!
+extern vmCvar_t cg_muzzleflashStyle;		// Leilei
+extern vmCvar_t cg_leiDebug;
+extern vmCvar_t cg_deathcam;
+extern vmCvar_t cg_cameramode;
+extern vmCvar_t cg_cameraEyes;
+extern vmCvar_t cg_cameraEyes_Fwd;
+extern vmCvar_t cg_cameraEyes_Up;
+extern vmCvar_t cg_modelEyes_Up;
+extern vmCvar_t cg_modelEyes_Right;
+extern vmCvar_t cg_modelEyes_Fwd;
+extern vmCvar_t cg_oldPlasma;
+extern vmCvar_t cg_trueLightning;
+extern vmCvar_t cg_music;
 #ifdef MISSIONPACK
-extern	vmCvar_t		cg_redTeamName;
-extern	vmCvar_t		cg_blueTeamName;
-extern	vmCvar_t		cg_currentSelectedPlayer;
-extern	vmCvar_t		cg_currentSelectedPlayerName;
-extern	vmCvar_t		cg_singlePlayer;
-extern	vmCvar_t		cg_singlePlayerActive;
-extern  vmCvar_t		cg_recordSPDemo;
-extern  vmCvar_t		cg_recordSPDemoName;
+extern vmCvar_t cg_redTeamName;
+extern vmCvar_t cg_blueTeamName;
+extern vmCvar_t cg_currentSelectedPlayer;
+extern vmCvar_t cg_currentSelectedPlayerName;
+extern vmCvar_t cg_singlePlayer;
+extern vmCvar_t cg_singlePlayerActive;
+extern vmCvar_t cg_recordSPDemo;
+extern vmCvar_t cg_recordSPDemoName;
 #endif
 //Sago: Moved outside
-extern	vmCvar_t		cg_obeliskRespawnDelay;
-extern	vmCvar_t		cg_enableDust;
-extern	vmCvar_t		cg_enableBreath;
-
-extern	vmCvar_t		cg_enableQ;		// leilei
-extern	vmCvar_t		cg_enableFS;		// leilei
-
+extern vmCvar_t cg_obeliskRespawnDelay;
+extern vmCvar_t cg_enableDust;
+extern vmCvar_t cg_enableBreath;
+extern vmCvar_t cg_enableQ;		// leilei
+extern vmCvar_t cg_enableFS;		// leilei
 //unlagged - client options
-extern	vmCvar_t		cg_delag;
-//extern	vmCvar_t		cg_debugDelag;
-//extern	vmCvar_t		cg_drawBBox;
-extern	vmCvar_t		cg_cmdTimeNudge;
-extern	vmCvar_t		sv_fps;
-extern	vmCvar_t		cg_projectileNudge;
-extern	vmCvar_t		cg_optimizePrediction;
-extern	vmCvar_t		cl_timeNudge;
-//extern	vmCvar_t		cg_latentSnaps;
-//extern	vmCvar_t		cg_latentCmds;
-//extern	vmCvar_t		cg_plOut;
+extern vmCvar_t cg_delag;
+//extern vmCvar_t cg_debugDelag;
+//extern vmCvar_t cg_drawBBox;
+extern vmCvar_t cg_cmdTimeNudge;
+extern vmCvar_t sv_fps;
+extern vmCvar_t cg_projectileNudge;
+extern vmCvar_t cg_optimizePrediction;
+extern vmCvar_t cl_timeNudge;
+//extern vmCvar_t cg_latentSnaps;
+//extern vmCvar_t cg_latentCmds;
+//extern vmCvar_t cg_plOut;
 //unlagged - client options
-
 //extra CVARS elimination
-extern	vmCvar_t		cg_alwaysWeaponBar;
-extern	vmCvar_t		cg_hitsound;
-extern  vmCvar_t                cg_voip_teamonly;
-extern  vmCvar_t                cg_voteflags;
-extern  vmCvar_t                cg_cyclegrapple;
-extern  vmCvar_t                cg_vote_custom_commands;
-
-extern  vmCvar_t                cg_autovertex;
-
+extern vmCvar_t cg_alwaysWeaponBar;
+extern vmCvar_t cg_hitsound;
+extern vmCvar_t cg_voip_teamonly;
+extern vmCvar_t cg_voteflags;
+extern vmCvar_t cg_cyclegrapple;
+extern vmCvar_t cg_vote_custom_commands;
+extern vmCvar_t cg_autovertex;
 //Cvar to adjust the size of the fragmessage
-extern	vmCvar_t		cg_fragmsgsize;
-
-extern	vmCvar_t		cg_crosshairPulse;
-extern	vmCvar_t		cg_differentCrosshairs;
-extern	vmCvar_t		cg_ch1;
-extern	vmCvar_t		cg_ch1size;
-extern	vmCvar_t		cg_ch2;
-extern	vmCvar_t		cg_ch2size;
-extern	vmCvar_t		cg_ch3;
-extern	vmCvar_t		cg_ch3size;
-extern	vmCvar_t		cg_ch4;
-extern	vmCvar_t		cg_ch4size;
-extern	vmCvar_t		cg_ch5;
-extern	vmCvar_t		cg_ch5size;
-extern	vmCvar_t		cg_ch6;
-extern	vmCvar_t		cg_ch6size;
-extern	vmCvar_t		cg_ch7;
-extern	vmCvar_t		cg_ch7size;
-extern	vmCvar_t		cg_ch8;
-extern	vmCvar_t		cg_ch8size;
-extern	vmCvar_t		cg_ch9;
-extern	vmCvar_t		cg_ch9size;
-extern	vmCvar_t		cg_ch10;
-extern	vmCvar_t		cg_ch10size;
-extern	vmCvar_t		cg_ch11;
-extern	vmCvar_t		cg_ch11size;
-extern	vmCvar_t		cg_ch12;
-extern	vmCvar_t		cg_ch12size;
-extern	vmCvar_t		cg_ch13;
-extern	vmCvar_t		cg_ch13size;
-
-extern	vmCvar_t                cg_crosshairColorRed;
-extern	vmCvar_t                cg_crosshairColorGreen;
-extern	vmCvar_t                cg_crosshairColorBlue;
-
-extern vmCvar_t			cg_weaponBarStyle;
-
-extern vmCvar_t                 cg_weaponOrder;
-extern vmCvar_t			cg_chatBeep;
-extern vmCvar_t			cg_teamChatBeep;
-
+extern vmCvar_t cg_fragmsgsize;
+extern vmCvar_t cg_crosshairPulse;
+extern vmCvar_t cg_differentCrosshairs;
+extern vmCvar_t cg_ch1;
+extern vmCvar_t cg_ch1size;
+extern vmCvar_t cg_ch2;
+extern vmCvar_t cg_ch2size;
+extern vmCvar_t cg_ch3;
+extern vmCvar_t cg_ch3size;
+extern vmCvar_t cg_ch4;
+extern vmCvar_t cg_ch4size;
+extern vmCvar_t cg_ch5;
+extern vmCvar_t cg_ch5size;
+extern vmCvar_t cg_ch6;
+extern vmCvar_t cg_ch6size;
+extern vmCvar_t cg_ch7;
+extern vmCvar_t cg_ch7size;
+extern vmCvar_t cg_ch8;
+extern vmCvar_t cg_ch8size;
+extern vmCvar_t cg_ch9;
+extern vmCvar_t cg_ch9size;
+extern vmCvar_t cg_ch10;
+extern vmCvar_t cg_ch10size;
+extern vmCvar_t cg_ch11;
+extern vmCvar_t cg_ch11size;
+extern vmCvar_t cg_ch12;
+extern vmCvar_t cg_ch12size;
+extern vmCvar_t cg_ch13;
+extern vmCvar_t cg_ch13size;
+extern vmCvar_t cg_crosshairColorRed;
+extern vmCvar_t cg_crosshairColorGreen;
+extern vmCvar_t cg_crosshairColorBlue;
+extern vmCvar_t cg_weaponBarStyle;
+extern vmCvar_t cg_weaponOrder;
+extern vmCvar_t cg_chatBeep;
+extern vmCvar_t cg_teamChatBeep;
 /* Neon_Knight: Toggleable missionpack checks. */
-extern vmCvar_t			cg_missionpackChecks;
+extern vmCvar_t cg_missionpackChecks;
 /* /Neon_Knight */
+extern vmCvar_t cg_leiChibi;
 
 //unlagged - cg_unlagged.c
 void CG_PredictWeaponEffects( centity_t *cent );

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -175,10 +175,10 @@ vmCvar_t cg_scorePlum;
 vmCvar_t cg_obituaryOutput;
 //unlagged - smooth clients #2
 // this is done server-side now
-//vmCvar_t 	cg_smoothClients;
+//vmCvar_t cg_smoothClients;
 //unlagged - smooth clients #2
 vmCvar_t pmove_fixed;
-//vmCvar_t	cg_pmove_fixed;
+//vmCvar_t cg_pmove_fixed;
 vmCvar_t pmove_msec;
 vmCvar_t pmove_float;
 vmCvar_t cg_pmove_msec;
@@ -237,16 +237,16 @@ vmCvar_t cg_enableQ;
 
 //unlagged - client options
 vmCvar_t cg_delag;
-//vmCvar_t	cg_debugDelag;
-//vmCvar_t	cg_drawBBox;
+//vmCvar_t cg_debugDelag;
+//vmCvar_t cg_drawBBox;
 vmCvar_t cg_cmdTimeNudge;
 vmCvar_t sv_fps;
 vmCvar_t cg_projectileNudge;
 vmCvar_t cg_optimizePrediction;
 vmCvar_t cl_timeNudge;
-//vmCvar_t	cg_latentSnaps;
-//vmCvar_t	cg_latentCmds;
-//vmCvar_t	cg_plOut;
+//vmCvar_t cg_latentSnaps;
+//vmCvar_t cg_latentCmds;
+//vmCvar_t cg_plOut;
 //unlagged - client options
 
 //elimination addition

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -2507,8 +2507,6 @@ int CG_LightVerts(vec3_t normal, int numVerts, polyVert_t *verts) {
 CG_Player
 ===============
  */
-extern vmCvar_t cg_leiChibi;
-
 void CG_Player(centity_t *cent) {
 	clientInfo_t *ci;
 	refEntity_t legs;

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1030,171 +1030,151 @@ extern	gentity_t		g_entities[MAX_GENTITIES];
 #define	FOFS(x) ((size_t)&(((gentity_t *)0)->x))
 
 //CVARS 
-extern	vmCvar_t	g_gametype;
-extern	vmCvar_t	g_dedicated;
-extern	vmCvar_t	g_cheats;
-extern	vmCvar_t	g_maxclients;			// allow this many total, including spectators
-extern	vmCvar_t	g_maxGameClients;		// allow this many active
-extern	vmCvar_t	g_restarted;
-
-extern	vmCvar_t	g_dmflags;
-extern	vmCvar_t	g_videoflags;
-extern	vmCvar_t	g_elimflags;
-extern	vmCvar_t	g_voteflags;
-extern	vmCvar_t	g_fraglimit;
-extern	vmCvar_t	g_timelimit;
-extern	vmCvar_t	g_capturelimit;
-extern	vmCvar_t	g_friendlyFire;
-extern	vmCvar_t	g_password;
-extern	vmCvar_t	g_needpass;
-extern	vmCvar_t	g_gravity;
-extern	vmCvar_t	g_gravityModifier;
-extern  vmCvar_t        g_damageModifier;
-extern	vmCvar_t	g_speed;
-extern	vmCvar_t	g_knockback;
-extern	vmCvar_t	g_quadfactor;
-extern	vmCvar_t	g_forcerespawn;
-extern	vmCvar_t	g_respawntime;
-extern	vmCvar_t	g_inactivity;
-extern	vmCvar_t	g_debugMove;
-extern	vmCvar_t	g_debugAlloc;
-extern	vmCvar_t	g_debugDamage;
-extern	vmCvar_t	g_weaponRespawn;
-extern	vmCvar_t	g_weaponTeamRespawn;
-extern	vmCvar_t	g_synchronousClients;
-extern	vmCvar_t	g_motd;
-extern	vmCvar_t	g_motdfile;
-extern  vmCvar_t        g_votemaps;
-extern  vmCvar_t        g_votecustom;
-extern	vmCvar_t	g_warmup;
-extern	vmCvar_t	g_doWarmup;
-extern	vmCvar_t	g_blood;
-extern	vmCvar_t	g_allowVote;
-extern	vmCvar_t	g_teamAutoJoin;
-extern	vmCvar_t	g_teamForceBalance;
-extern	vmCvar_t	g_banIPs;
-extern	vmCvar_t	g_filterBan;
-extern	vmCvar_t	g_obeliskHealth;
-extern	vmCvar_t	g_obeliskRegenPeriod;
-extern	vmCvar_t	g_obeliskRegenAmount;
-extern	vmCvar_t	g_obeliskRespawnDelay;
-extern	vmCvar_t	g_cubeTimeout;
-extern	vmCvar_t	g_smoothClients;
-extern	vmCvar_t	pmove_fixed;
-extern	vmCvar_t	pmove_msec;
-extern	vmCvar_t	pmove_float;
-extern	vmCvar_t	g_rankings;
+extern vmCvar_t g_gametype;
+extern vmCvar_t g_dedicated;
+extern vmCvar_t g_cheats;
+extern vmCvar_t g_maxclients;			// allow this many total, including spectators
+extern vmCvar_t g_maxGameClients;		// allow this many active
+extern vmCvar_t g_restarted;
+extern vmCvar_t g_dmflags;
+extern vmCvar_t g_videoflags;
+extern vmCvar_t g_elimflags;
+extern vmCvar_t g_voteflags;
+extern vmCvar_t g_fraglimit;
+extern vmCvar_t g_timelimit;
+extern vmCvar_t g_capturelimit;
+extern vmCvar_t g_friendlyFire;
+extern vmCvar_t g_password;
+extern vmCvar_t g_needpass;
+extern vmCvar_t g_gravity;
+extern vmCvar_t g_gravityModifier;
+extern vmCvar_t g_damageModifier;
+extern vmCvar_t g_speed;
+extern vmCvar_t g_knockback;
+extern vmCvar_t g_quadfactor;
+extern vmCvar_t g_forcerespawn;
+extern vmCvar_t g_respawntime;
+extern vmCvar_t g_inactivity;
+extern vmCvar_t g_debugMove;
+extern vmCvar_t g_debugAlloc;
+extern vmCvar_t g_debugDamage;
+extern vmCvar_t g_weaponRespawn;
+extern vmCvar_t g_weaponTeamRespawn;
+extern vmCvar_t g_synchronousClients;
+extern vmCvar_t g_motd;
+extern vmCvar_t g_motdfile;
+extern vmCvar_t g_votemaps;
+extern vmCvar_t g_votecustom;
+extern vmCvar_t g_warmup;
+extern vmCvar_t g_doWarmup;
+extern vmCvar_t g_blood;
+extern vmCvar_t g_allowVote;
+extern vmCvar_t g_teamAutoJoin;
+extern vmCvar_t g_teamForceBalance;
+extern vmCvar_t g_banIPs;
+extern vmCvar_t g_filterBan;
+extern vmCvar_t g_obeliskHealth;
+extern vmCvar_t g_obeliskRegenPeriod;
+extern vmCvar_t g_obeliskRegenAmount;
+extern vmCvar_t g_obeliskRespawnDelay;
+extern vmCvar_t g_cubeTimeout;
+extern vmCvar_t g_smoothClients;
+extern vmCvar_t pmove_fixed;
+extern vmCvar_t pmove_msec;
+extern vmCvar_t pmove_float;
+extern vmCvar_t g_rankings;
 #ifdef MISSIONPACK
-extern	vmCvar_t	g_singlePlayer;
-extern	vmCvar_t	g_redteam;
-extern	vmCvar_t	g_blueteam;
+extern vmCvar_t g_singlePlayer;
+extern vmCvar_t g_redteam;
+extern vmCvar_t g_blueteam;
 #endif
-extern	vmCvar_t	g_enableDust;
-extern	vmCvar_t	g_enableBreath;
-extern	vmCvar_t	g_proxMineTimeout;
-extern	vmCvar_t	g_localTeamPref;
-extern	vmCvar_t	g_music;
-extern  vmCvar_t        g_spawnprotect;
-
+extern vmCvar_t g_enableDust;
+extern vmCvar_t g_enableBreath;
+extern vmCvar_t g_proxMineTimeout;
+extern vmCvar_t g_localTeamPref;
+extern vmCvar_t g_music;
+extern vmCvar_t g_spawnprotect;
 //elimination:
-extern	vmCvar_t	g_elimination_selfdamage;
-extern	vmCvar_t	g_elimination_startHealth;
-extern	vmCvar_t	g_elimination_startArmor;
-extern	vmCvar_t	g_elimination_bfg;
-extern	vmCvar_t	g_elimination_roundtime;
-extern	vmCvar_t	g_elimination_warmup;
-extern	vmCvar_t	g_elimination_activewarmup;
-extern  vmCvar_t        g_elimination_allgametypes;
-extern	vmCvar_t	g_elimination_machinegun;
-extern	vmCvar_t	g_elimination_shotgun;
-extern	vmCvar_t	g_elimination_grenade;
-extern	vmCvar_t	g_elimination_rocket;
-extern	vmCvar_t	g_elimination_railgun;
-extern	vmCvar_t	g_elimination_lightning;
-extern	vmCvar_t	g_elimination_plasmagun;
-extern	vmCvar_t	g_elimination_chain;
-extern	vmCvar_t	g_elimination_mine;
-extern	vmCvar_t	g_elimination_nail;
-
+extern vmCvar_t g_elimination_selfdamage;
+extern vmCvar_t g_elimination_startHealth;
+extern vmCvar_t g_elimination_startArmor;
+extern vmCvar_t g_elimination_bfg;
+extern vmCvar_t g_elimination_roundtime;
+extern vmCvar_t g_elimination_warmup;
+extern vmCvar_t g_elimination_activewarmup;
+extern vmCvar_t g_elimination_allgametypes;
+extern vmCvar_t g_elimination_machinegun;
+extern vmCvar_t g_elimination_shotgun;
+extern vmCvar_t g_elimination_grenade;
+extern vmCvar_t g_elimination_rocket;
+extern vmCvar_t g_elimination_railgun;
+extern vmCvar_t g_elimination_lightning;
+extern vmCvar_t g_elimination_plasmagun;
+extern vmCvar_t g_elimination_chain;
+extern vmCvar_t g_elimination_mine;
+extern vmCvar_t g_elimination_nail;
 //If lockspectator: 0=no limit, 1 = cannot follow enemy, 2 = must follow friend
-extern  vmCvar_t        g_elimination_lockspectator;
-
-extern vmCvar_t		g_rockets;
-
+extern vmCvar_t g_elimination_lockspectator;
+extern vmCvar_t g_rockets;
 //new in elimination Beta2
-extern vmCvar_t		g_instantgib;
-extern vmCvar_t		g_vampire;
-extern vmCvar_t		g_vampireMaxHealth;
+extern vmCvar_t g_instantgib;
+extern vmCvar_t g_vampire;
+extern vmCvar_t g_vampireMaxHealth;
 //new in elimination Beta3
-extern vmCvar_t		g_regen;
-
-extern vmCvar_t		g_lms_lives;
-
-extern vmCvar_t		g_lms_mode; //How do we score: 0 = One Survivor get a point, 1 = same but without overtime, 2 = one point for each player killed (+overtime), 3 = same without overtime
-
-extern vmCvar_t		g_elimination_ctf_oneway;	//Only attack in one direction (level.eliminationSides+level.roundNumber)%2 == 0 red attacks
-
-extern vmCvar_t         g_awardpushing; //The server can decide if players are awarded for pushing people in lave etc.
-
+extern vmCvar_t g_regen;
+extern vmCvar_t g_lms_lives;
+extern vmCvar_t g_lms_mode; //How do we score: 0 = One Survivor get a point, 1 = same but without overtime, 2 = one point for each player killed (+overtime), 3 = same without overtime
+extern vmCvar_t g_elimination_ctf_oneway;	//Only attack in one direction (level.eliminationSides+level.roundNumber)%2 == 0 red attacks
+extern vmCvar_t g_awardpushing; //The server can decide if players are awarded for pushing people in lave etc.
 extern vmCvar_t g_runes;
-
-extern vmCvar_t        g_catchup; //Favors the week players
-
-extern vmCvar_t         g_autonextmap; //Autochange map
-extern vmCvar_t         g_mappools; //mappools to be used for autochange
-
-extern vmCvar_t        g_voteNames;
-extern vmCvar_t        g_voteBan;
-extern vmCvar_t        g_voteGametypes;
-extern vmCvar_t        g_voteMinTimelimit;
-extern vmCvar_t        g_voteMaxTimelimit;
-extern vmCvar_t        g_voteMinFraglimit;
-extern vmCvar_t        g_voteMaxFraglimit;
-extern vmCvar_t        g_maxvotes;
-
-extern vmCvar_t        g_humanplayers;
-
+extern vmCvar_t g_catchup; //Favors the week players
+extern vmCvar_t g_autonextmap; //Autochange map
+extern vmCvar_t g_mappools; //mappools to be used for autochange
+extern vmCvar_t g_voteNames;
+extern vmCvar_t g_voteBan;
+extern vmCvar_t g_voteGametypes;
+extern vmCvar_t g_voteMinTimelimit;
+extern vmCvar_t g_voteMaxTimelimit;
+extern vmCvar_t g_voteMinFraglimit;
+extern vmCvar_t g_voteMaxFraglimit;
+extern vmCvar_t g_maxvotes;
+extern vmCvar_t g_humanplayers;
 //used for voIP
-extern vmCvar_t         g_redTeamClientNumbers;
-extern vmCvar_t         g_blueTeamClientNumbers;
-
+extern vmCvar_t g_redTeamClientNumbers;
+extern vmCvar_t g_blueTeamClientNumbers;
 //unlagged - server options
 // some new server-side variables
-extern	vmCvar_t	g_delagHitscan;
-extern	vmCvar_t	g_truePing;
+extern vmCvar_t g_delagHitscan;
+extern vmCvar_t g_truePing;
 // this is for convenience - using "sv_fps.integer" is nice :)
-extern	vmCvar_t	sv_fps;
-extern  vmCvar_t        g_lagLightning;
+extern vmCvar_t sv_fps;
+extern vmCvar_t g_lagLightning;
 //unlagged - server options
 //KK-OAX Killing Sprees
-extern  vmCvar_t    g_sprees; //Used for specifiying the config file
-extern  vmCvar_t    g_altExcellent; //Turns on Multikills instead of Excellent
-extern  vmCvar_t    g_spreeDiv; // Interval of a "streak" that form the spree triggers
+extern vmCvar_t g_sprees; //Used for specifiying the config file
+extern vmCvar_t g_altExcellent; //Turns on Multikills instead of Excellent
+extern vmCvar_t g_spreeDiv; // Interval of a "streak" that form the spree triggers
 //KK-OAX Command/Chat Flooding/Spamming
-extern  vmCvar_t    g_floodMaxDemerits;
-extern  vmCvar_t    g_floodMinTime;
+extern vmCvar_t g_floodMaxDemerits;
+extern vmCvar_t g_floodMinTime;
 //KK-OAX Admin
-extern  vmCvar_t    g_admin;
-extern  vmCvar_t    g_adminLog;
-extern  vmCvar_t    g_adminParseSay;
-extern  vmCvar_t    g_adminNameProtect;
-extern  vmCvar_t    g_adminTempBan;
-extern  vmCvar_t    g_adminMaxBan;
+extern vmCvar_t g_admin;
+extern vmCvar_t g_adminLog;
+extern vmCvar_t g_adminParseSay;
+extern vmCvar_t g_adminNameProtect;
+extern vmCvar_t g_adminTempBan;
+extern vmCvar_t g_adminMaxBan;
 //KK-OAX Admin-Like
-extern  vmCvar_t    g_specChat;
-extern  vmCvar_t    g_publicAdminMessages;
-
-extern  vmCvar_t    g_maxWarnings;
-extern  vmCvar_t    g_warningExpire;
-
-extern  vmCvar_t    g_minNameChangePeriod;
-extern  vmCvar_t    g_maxNameChanges;
-
-extern  vmCvar_t    g_grapple;
-extern  vmCvar_t    g_harvesterFromBodies;
-
-extern  vmCvar_t    g_ddCaptureTime;
-extern  vmCvar_t    g_ddRespawnDelay;
+extern vmCvar_t g_specChat;
+extern vmCvar_t g_publicAdminMessages;
+extern vmCvar_t g_maxWarnings;
+extern vmCvar_t g_warningExpire;
+extern vmCvar_t g_minNameChangePeriod;
+extern vmCvar_t g_maxNameChanges;
+extern vmCvar_t g_grapple;
+extern vmCvar_t g_harvesterFromBodies;
+extern vmCvar_t g_ddCaptureTime;
+extern vmCvar_t g_ddRespawnDelay;
 
 void	trap_Printf( const char *fmt );
 void	trap_Error( const char *fmt ) __attribute__((noreturn));

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 level_locals_t	level;
 
 typedef struct {
-	vmCvar_t	*vmCvar;
+	vmCvar_t *vmCvar;
 	char		*cvarName;
 	char		*defaultString;
 	int			cvarFlags;
@@ -39,181 +39,164 @@ typedef struct {
 gentity_t		g_entities[MAX_GENTITIES];
 gclient_t		g_clients[MAX_CLIENTS];
 
-vmCvar_t	g_gametype;
-vmCvar_t	g_dmflags;
-vmCvar_t        g_videoflags;
-vmCvar_t	g_elimflags;
-vmCvar_t	g_voteflags;
-vmCvar_t	g_fraglimit;
-vmCvar_t	g_timelimit;
-vmCvar_t	g_capturelimit;
-vmCvar_t	g_friendlyFire;
-vmCvar_t	g_password;
-vmCvar_t	g_needpass;
-vmCvar_t	g_maxclients;
-vmCvar_t	g_maxGameClients;
-vmCvar_t	g_dedicated;
-vmCvar_t	g_speed;
-vmCvar_t	g_gravity;
-vmCvar_t	g_gravityModifier;
-vmCvar_t        g_damageModifier;
-vmCvar_t	g_cheats;
-vmCvar_t	g_knockback;
-vmCvar_t	g_quadfactor;
-vmCvar_t	g_forcerespawn;
-vmCvar_t	g_respawntime;
-vmCvar_t	g_inactivity;
-vmCvar_t	g_debugMove;
-vmCvar_t	g_debugDamage;
-vmCvar_t	g_debugAlloc;
-vmCvar_t	g_weaponRespawn;
-vmCvar_t	g_weaponTeamRespawn;
-vmCvar_t	g_motd;
-vmCvar_t        g_motdfile;
-vmCvar_t        g_votemaps;
-vmCvar_t        g_votecustom;
-vmCvar_t	g_synchronousClients;
-vmCvar_t	g_warmup;
-vmCvar_t	g_doWarmup;
-vmCvar_t	g_restarted;
-vmCvar_t	g_logfile;
-vmCvar_t	g_logfileSync;
-vmCvar_t	g_blood;
-vmCvar_t	g_podiumDist;
-vmCvar_t	g_podiumDrop;
-vmCvar_t	g_allowVote;
-vmCvar_t	g_teamAutoJoin;
-vmCvar_t	g_teamForceBalance;
-vmCvar_t	g_banIPs;
-vmCvar_t	g_filterBan;
-vmCvar_t	g_smoothClients;
-vmCvar_t	pmove_fixed;
-vmCvar_t	pmove_msec;
-vmCvar_t        pmove_float;
-vmCvar_t	g_rankings;
-vmCvar_t	g_listEntity;
-vmCvar_t	g_localTeamPref;
-vmCvar_t	g_obeliskHealth;
-vmCvar_t	g_obeliskRegenPeriod;
-vmCvar_t	g_obeliskRegenAmount;
-vmCvar_t	g_obeliskRespawnDelay;
-vmCvar_t	g_cubeTimeout;
+vmCvar_t g_gametype;
+vmCvar_t g_dmflags;
+vmCvar_t g_videoflags;
+vmCvar_t g_elimflags;
+vmCvar_t g_voteflags;
+vmCvar_t g_fraglimit;
+vmCvar_t g_timelimit;
+vmCvar_t g_capturelimit;
+vmCvar_t g_friendlyFire;
+vmCvar_t g_password;
+vmCvar_t g_needpass;
+vmCvar_t g_maxclients;
+vmCvar_t g_maxGameClients;
+vmCvar_t g_dedicated;
+vmCvar_t g_speed;
+vmCvar_t g_gravity;
+vmCvar_t g_gravityModifier;
+vmCvar_t g_damageModifier;
+vmCvar_t g_cheats;
+vmCvar_t g_knockback;
+vmCvar_t g_quadfactor;
+vmCvar_t g_forcerespawn;
+vmCvar_t g_respawntime;
+vmCvar_t g_inactivity;
+vmCvar_t g_debugMove;
+vmCvar_t g_debugDamage;
+vmCvar_t g_debugAlloc;
+vmCvar_t g_weaponRespawn;
+vmCvar_t g_weaponTeamRespawn;
+vmCvar_t g_motd;
+vmCvar_t g_motdfile;
+vmCvar_t g_votemaps;
+vmCvar_t g_votecustom;
+vmCvar_t g_synchronousClients;
+vmCvar_t g_warmup;
+vmCvar_t g_doWarmup;
+vmCvar_t g_restarted;
+vmCvar_t g_logfile;
+vmCvar_t g_logfileSync;
+vmCvar_t g_blood;
+vmCvar_t g_podiumDist;
+vmCvar_t g_podiumDrop;
+vmCvar_t g_allowVote;
+vmCvar_t g_teamAutoJoin;
+vmCvar_t g_teamForceBalance;
+vmCvar_t g_banIPs;
+vmCvar_t g_filterBan;
+vmCvar_t g_smoothClients;
+vmCvar_t pmove_fixed;
+vmCvar_t pmove_msec;
+vmCvar_t pmove_float;
+vmCvar_t g_rankings;
+vmCvar_t g_listEntity;
+vmCvar_t g_localTeamPref;
+vmCvar_t g_obeliskHealth;
+vmCvar_t g_obeliskRegenPeriod;
+vmCvar_t g_obeliskRegenAmount;
+vmCvar_t g_obeliskRespawnDelay;
+vmCvar_t g_cubeTimeout;
 #ifdef MISSIONPACK
-vmCvar_t	g_redteam;
-vmCvar_t	g_blueteam;
-vmCvar_t	g_singlePlayer;
+vmCvar_t g_redteam;
+vmCvar_t g_blueteam;
+vmCvar_t g_singlePlayer;
 #endif
-vmCvar_t	g_enableDust;
-vmCvar_t	cg_enableQ;		// leilei
-vmCvar_t	g_enableFS;		// leilei
-vmCvar_t	g_enableBreath;
-vmCvar_t	g_proxMineTimeout;
-vmCvar_t	g_music;
-vmCvar_t	g_spawnprotect;
+vmCvar_t g_enableDust;
+vmCvar_t cg_enableQ;		// leilei
+vmCvar_t g_enableFS;		// leilei
+vmCvar_t g_enableBreath;
+vmCvar_t g_proxMineTimeout;
+vmCvar_t g_music;
+vmCvar_t g_spawnprotect;
 //Following for elimination:
-vmCvar_t	g_elimination_selfdamage;
-vmCvar_t	g_elimination_startHealth;
-vmCvar_t	g_elimination_startArmor;
-vmCvar_t	g_elimination_bfg;
-vmCvar_t	g_elimination_roundtime;
-vmCvar_t	g_elimination_warmup;
-vmCvar_t	g_elimination_activewarmup;
-vmCvar_t	g_elimination_allgametypes;
-vmCvar_t	g_elimination_machinegun;
-vmCvar_t	g_elimination_shotgun;
-vmCvar_t	g_elimination_grenade;
-vmCvar_t	g_elimination_rocket;
-vmCvar_t	g_elimination_railgun;
-vmCvar_t	g_elimination_lightning;
-vmCvar_t	g_elimination_plasmagun;
-vmCvar_t	g_elimination_chain;
-vmCvar_t	g_elimination_mine;
-vmCvar_t	g_elimination_nail;
-
-vmCvar_t	g_elimination_lockspectator;
-
-vmCvar_t	g_rockets;
-
+vmCvar_t g_elimination_selfdamage;
+vmCvar_t g_elimination_startHealth;
+vmCvar_t g_elimination_startArmor;
+vmCvar_t g_elimination_bfg;
+vmCvar_t g_elimination_roundtime;
+vmCvar_t g_elimination_warmup;
+vmCvar_t g_elimination_activewarmup;
+vmCvar_t g_elimination_allgametypes;
+vmCvar_t g_elimination_machinegun;
+vmCvar_t g_elimination_shotgun;
+vmCvar_t g_elimination_grenade;
+vmCvar_t g_elimination_rocket;
+vmCvar_t g_elimination_railgun;
+vmCvar_t g_elimination_lightning;
+vmCvar_t g_elimination_plasmagun;
+vmCvar_t g_elimination_chain;
+vmCvar_t g_elimination_mine;
+vmCvar_t g_elimination_nail;
+vmCvar_t g_elimination_lockspectator;
+vmCvar_t g_rockets;
 //dmn_clowns suggestions (with my idea of implementing):
-vmCvar_t	g_instantgib;
-vmCvar_t	g_vampire;
-vmCvar_t	g_vampireMaxHealth;
+vmCvar_t g_instantgib;
+vmCvar_t g_vampire;
+vmCvar_t g_vampireMaxHealth;
 //Regen
-vmCvar_t	g_regen;
-vmCvar_t	g_lms_lives;
-vmCvar_t	g_lms_mode;
-vmCvar_t	g_elimination_ctf_oneway;
-vmCvar_t        g_awardpushing; //The server can decide if players are awarded for pushing people in lave etc.
+vmCvar_t g_regen;
+vmCvar_t g_lms_lives;
+vmCvar_t g_lms_mode;
+vmCvar_t g_elimination_ctf_oneway;
+vmCvar_t g_awardpushing; //The server can decide if players are awarded for pushing people in lave etc.
 vmCvar_t g_runes; //Allow missionpack style persistant powerups?
-
-vmCvar_t        g_catchup; //Favors the week players
-
-vmCvar_t         g_autonextmap; //Autochange map
-vmCvar_t         g_mappools; //mappools to be used for autochange
-
-vmCvar_t        g_voteNames;
-vmCvar_t        g_voteBan;
-vmCvar_t        g_voteGametypes;
-vmCvar_t        g_voteMinTimelimit;
-vmCvar_t        g_voteMaxTimelimit;
-vmCvar_t        g_voteMinFraglimit;
-vmCvar_t        g_voteMaxFraglimit;
-vmCvar_t        g_maxvotes;
-
-vmCvar_t        g_humanplayers;
-
+vmCvar_t g_catchup; //Favors the week players
+vmCvar_t g_autonextmap; //Autochange map
+vmCvar_t g_mappools; //mappools to be used for autochange
+vmCvar_t g_voteNames;
+vmCvar_t g_voteBan;
+vmCvar_t g_voteGametypes;
+vmCvar_t g_voteMinTimelimit;
+vmCvar_t g_voteMaxTimelimit;
+vmCvar_t g_voteMinFraglimit;
+vmCvar_t g_voteMaxFraglimit;
+vmCvar_t g_maxvotes;
+vmCvar_t g_humanplayers;
 //used for voIP
-vmCvar_t         g_redTeamClientNumbers;
-vmCvar_t         g_blueTeamClientNumbers;
-
+vmCvar_t g_redTeamClientNumbers;
+vmCvar_t g_blueTeamClientNumbers;
 //unlagged - server options
-vmCvar_t	g_delagHitscan;
-vmCvar_t	g_truePing;
-vmCvar_t	sv_fps;
-vmCvar_t        g_lagLightning; //Adds a little lag to the lightninggun to make it less powerfull
+vmCvar_t g_delagHitscan;
+vmCvar_t g_truePing;
+vmCvar_t sv_fps;
+vmCvar_t g_lagLightning; //Adds a little lag to the lightninggun to make it less powerfull
 //unlagged - server options
 //KK-OAX
-vmCvar_t        g_sprees;
-vmCvar_t        g_altExcellent;
-vmCvar_t        g_spreeDiv;
-
+vmCvar_t g_sprees;
+vmCvar_t g_altExcellent;
+vmCvar_t g_spreeDiv;
 //Command/Chat spamming/flooding
-vmCvar_t        g_floodMaxDemerits;
-vmCvar_t        g_floodMinTime;
-
+vmCvar_t g_floodMaxDemerits;
+vmCvar_t g_floodMinTime;
 //Admin
-vmCvar_t        g_admin;
-vmCvar_t        g_adminLog;
-vmCvar_t        g_adminParseSay;
-vmCvar_t        g_adminNameProtect;
-vmCvar_t        g_adminTempBan;
-vmCvar_t        g_adminMaxBan;
-vmCvar_t        g_specChat;
-vmCvar_t        g_publicAdminMessages;
-
-vmCvar_t        g_maxWarnings;
-vmCvar_t        g_warningExpire;
-
-vmCvar_t        g_minNameChangePeriod;
-vmCvar_t        g_maxNameChanges;
-
-vmCvar_t        g_timestamp_startgame;
-
-vmCvar_t		g_execute_gametype_script;
-vmCvar_t		g_emptyCommand;
-vmCvar_t		g_emptyTime;
-
-vmCvar_t		g_grapple;
-vmCvar_t		g_harvesterFromBodies;
+vmCvar_t g_admin;
+vmCvar_t g_adminLog;
+vmCvar_t g_adminParseSay;
+vmCvar_t g_adminNameProtect;
+vmCvar_t g_adminTempBan;
+vmCvar_t g_adminMaxBan;
+vmCvar_t g_specChat;
+vmCvar_t g_publicAdminMessages;
+vmCvar_t g_maxWarnings;
+vmCvar_t g_warningExpire;
+vmCvar_t g_minNameChangePeriod;
+vmCvar_t g_maxNameChanges;
+vmCvar_t g_timestamp_startgame;
+vmCvar_t g_execute_gametype_script;
+vmCvar_t g_emptyCommand;
+vmCvar_t g_emptyTime;
+vmCvar_t g_grapple;
+vmCvar_t g_harvesterFromBodies;
 /* Neon_Knight: Double Domination-specific cvars */
-vmCvar_t		g_ddCaptureTime;
-vmCvar_t		g_ddRespawnDelay;
-
+vmCvar_t g_ddCaptureTime;
+vmCvar_t g_ddRespawnDelay;
 
 mapinfo_result_t mapinfo;
 
 // bk001129 - made static to avoid aliasing
-static cvarTable_t		gameCvarTable[] = {
+static cvarTable_t gameCvarTable[] = {
 	// don't override the cheat state set by the system
 	{ &g_cheats, "sv_cheats", "", 0, 0, qfalse },
 

--- a/code/q3_ui/ui_local.h
+++ b/code/q3_ui/ui_local.h
@@ -38,97 +38,78 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 typedef void (*voidfunc_f)(void);
 
-extern vmCvar_t	ui_ffa_fraglimit;
-extern vmCvar_t	ui_ffa_timelimit;
-
-extern vmCvar_t	ui_tourney_fraglimit;
-extern vmCvar_t	ui_tourney_timelimit;
-
-extern vmCvar_t	ui_team_fraglimit;
-extern vmCvar_t	ui_team_timelimit;
-extern vmCvar_t	ui_team_friendly;
-
-extern vmCvar_t	ui_ctf_capturelimit;
-extern vmCvar_t	ui_ctf_timelimit;
-extern vmCvar_t	ui_ctf_friendly;
-
-extern vmCvar_t	ui_1fctf_capturelimit;
-extern vmCvar_t	ui_1fctf_timelimit;
-extern vmCvar_t	ui_1fctf_friendly;
-
-extern vmCvar_t	ui_overload_capturelimit;
-extern vmCvar_t	ui_overload_timelimit;
-extern vmCvar_t	ui_overload_friendly;
-
-extern vmCvar_t	ui_harvester_capturelimit;
-extern vmCvar_t	ui_harvester_timelimit;
-extern vmCvar_t	ui_harvester_friendly;
-
-extern vmCvar_t	ui_elimination_capturelimit;
-extern vmCvar_t	ui_elimination_timelimit;
-
-extern vmCvar_t	ui_ctf_elimination_capturelimit;
-extern vmCvar_t	ui_ctf_elimination_timelimit;
-
-extern vmCvar_t	ui_lms_fraglimit;
-extern vmCvar_t	ui_lms_timelimit;
-
-extern vmCvar_t	ui_dd_capturelimit;
-extern vmCvar_t	ui_dd_timelimit;
-extern vmCvar_t	ui_dd_friendly;
-
-extern vmCvar_t	ui_dom_capturelimit;
-extern vmCvar_t	ui_dom_timelimit;
-extern vmCvar_t	ui_dom_friendly;
-
-extern vmCvar_t	ui_pos_scorelimit;
-extern vmCvar_t	ui_pos_timelimit;
-
-extern vmCvar_t	ui_arenasFile;
-extern vmCvar_t	ui_botsFile;
-extern vmCvar_t	ui_spScores1;
-extern vmCvar_t	ui_spScores2;
-extern vmCvar_t	ui_spScores3;
-extern vmCvar_t	ui_spScores4;
-extern vmCvar_t	ui_spScores5;
-extern vmCvar_t	ui_spAwards;
-extern vmCvar_t	ui_spVideos;
-extern vmCvar_t	ui_spSkill;
-
-extern vmCvar_t	ui_spSelection;
-
-extern vmCvar_t	ui_browserMaster;
-extern vmCvar_t	ui_browserGameType;
-extern vmCvar_t	ui_browserSortKey;
-extern vmCvar_t	ui_browserShowFull;
-extern vmCvar_t	ui_browserShowEmpty;
-
-extern vmCvar_t	ui_brassTime;
-extern vmCvar_t	ui_drawCrosshair;
-extern vmCvar_t	ui_drawCrosshairNames;
-extern vmCvar_t	ui_marks;
-
-extern vmCvar_t	ui_server1;
-extern vmCvar_t	ui_server2;
-extern vmCvar_t	ui_server3;
-extern vmCvar_t	ui_server4;
-extern vmCvar_t	ui_server5;
-extern vmCvar_t	ui_server6;
-extern vmCvar_t	ui_server7;
-extern vmCvar_t	ui_server8;
-extern vmCvar_t	ui_server9;
-extern vmCvar_t	ui_server10;
-extern vmCvar_t	ui_server11;
-extern vmCvar_t	ui_server12;
-extern vmCvar_t	ui_server13;
-extern vmCvar_t	ui_server14;
-extern vmCvar_t	ui_server15;
-extern vmCvar_t	ui_server16;
-
-//extern vmCvar_t	ui_cdkey;
-//extern vmCvar_t	ui_cdkeychecked;
+extern vmCvar_t ui_ffa_fraglimit;
+extern vmCvar_t ui_ffa_timelimit;
+extern vmCvar_t ui_tourney_fraglimit;
+extern vmCvar_t ui_tourney_timelimit;
+extern vmCvar_t ui_team_fraglimit;
+extern vmCvar_t ui_team_timelimit;
+extern vmCvar_t ui_team_friendly;
+extern vmCvar_t ui_ctf_capturelimit;
+extern vmCvar_t ui_ctf_timelimit;
+extern vmCvar_t ui_ctf_friendly;
+extern vmCvar_t ui_1fctf_capturelimit;
+extern vmCvar_t ui_1fctf_timelimit;
+extern vmCvar_t ui_1fctf_friendly;
+extern vmCvar_t ui_overload_capturelimit;
+extern vmCvar_t ui_overload_timelimit;
+extern vmCvar_t ui_overload_friendly;
+extern vmCvar_t ui_harvester_capturelimit;
+extern vmCvar_t ui_harvester_timelimit;
+extern vmCvar_t ui_harvester_friendly;
+extern vmCvar_t ui_elimination_capturelimit;
+extern vmCvar_t ui_elimination_timelimit;
+extern vmCvar_t ui_ctf_elimination_capturelimit;
+extern vmCvar_t ui_ctf_elimination_timelimit;
+extern vmCvar_t ui_lms_fraglimit;
+extern vmCvar_t ui_lms_timelimit;
+extern vmCvar_t ui_dd_capturelimit;
+extern vmCvar_t ui_dd_timelimit;
+extern vmCvar_t ui_dd_friendly;
+extern vmCvar_t ui_dom_capturelimit;
+extern vmCvar_t ui_dom_timelimit;
+extern vmCvar_t ui_dom_friendly;
+extern vmCvar_t ui_pos_scorelimit;
+extern vmCvar_t ui_pos_timelimit;
+extern vmCvar_t ui_arenasFile;
+extern vmCvar_t ui_botsFile;
+extern vmCvar_t ui_spScores1;
+extern vmCvar_t ui_spScores2;
+extern vmCvar_t ui_spScores3;
+extern vmCvar_t ui_spScores4;
+extern vmCvar_t ui_spScores5;
+extern vmCvar_t ui_spAwards;
+extern vmCvar_t ui_spVideos;
+extern vmCvar_t ui_spSkill;
+extern vmCvar_t ui_spSelection;
+extern vmCvar_t ui_browserMaster;
+extern vmCvar_t ui_browserGameType;
+extern vmCvar_t ui_browserSortKey;
+extern vmCvar_t ui_browserShowFull;
+extern vmCvar_t ui_browserShowEmpty;
+extern vmCvar_t ui_brassTime;
+extern vmCvar_t ui_drawCrosshair;
+extern vmCvar_t ui_drawCrosshairNames;
+extern vmCvar_t ui_marks;
+extern vmCvar_t ui_server1;
+extern vmCvar_t ui_server2;
+extern vmCvar_t ui_server3;
+extern vmCvar_t ui_server4;
+extern vmCvar_t ui_server5;
+extern vmCvar_t ui_server6;
+extern vmCvar_t ui_server7;
+extern vmCvar_t ui_server8;
+extern vmCvar_t ui_server9;
+extern vmCvar_t ui_server10;
+extern vmCvar_t ui_server11;
+extern vmCvar_t ui_server12;
+extern vmCvar_t ui_server13;
+extern vmCvar_t ui_server14;
+extern vmCvar_t ui_server15;
+extern vmCvar_t ui_server16;
+//extern vmCvar_t ui_cdkey;
+//extern vmCvar_t ui_cdkeychecked;
 extern vmCvar_t ui_setupchecked;
-
 //new in beta 23:
 extern vmCvar_t ui_browserOnlyHumans;
 

--- a/code/q3_ui/ui_main.c
+++ b/code/q3_ui/ui_main.c
@@ -93,110 +93,89 @@ cvars
 */
 
 typedef struct {
-	vmCvar_t	*vmCvar;
+	vmCvar_t *vmCvar;
 	char		*cvarName;
 	char		*defaultString;
 	int			cvarFlags;
 } cvarTable_t;
 
-vmCvar_t	ui_ffa_fraglimit;
-vmCvar_t	ui_ffa_timelimit;
-
-vmCvar_t	ui_tourney_fraglimit;
-vmCvar_t	ui_tourney_timelimit;
-
-vmCvar_t	ui_team_fraglimit;
-vmCvar_t	ui_team_timelimit;
-vmCvar_t	ui_team_friendly;
-
-vmCvar_t	ui_ctf_capturelimit;
-vmCvar_t	ui_ctf_timelimit;
-vmCvar_t	ui_ctf_friendly;
-
-vmCvar_t	ui_1fctf_capturelimit;
-vmCvar_t	ui_1fctf_timelimit;
-vmCvar_t	ui_1fctf_friendly;
-
-vmCvar_t	ui_overload_capturelimit;
-vmCvar_t	ui_overload_timelimit;
-vmCvar_t	ui_overload_friendly;
-
-vmCvar_t	ui_harvester_capturelimit;
-vmCvar_t	ui_harvester_timelimit;
-vmCvar_t	ui_harvester_friendly;
-
-vmCvar_t	ui_elimination_capturelimit;
-vmCvar_t	ui_elimination_timelimit;
-
-vmCvar_t	ui_ctf_elimination_capturelimit;
-vmCvar_t	ui_ctf_elimination_timelimit;
-
-vmCvar_t	ui_lms_fraglimit;
-vmCvar_t	ui_lms_timelimit;
-
-vmCvar_t	ui_dd_capturelimit;
-vmCvar_t	ui_dd_timelimit;
-vmCvar_t	ui_dd_friendly;
-
-vmCvar_t	ui_dom_capturelimit;
-vmCvar_t	ui_dom_timelimit;
-vmCvar_t	ui_dom_friendly;
-
-vmCvar_t	ui_pos_scorelimit;
-vmCvar_t	ui_pos_timelimit;
-
-vmCvar_t	ui_arenasFile;
-vmCvar_t	ui_botsFile;
-vmCvar_t	ui_spScores1;
-vmCvar_t	ui_spScores2;
-vmCvar_t	ui_spScores3;
-vmCvar_t	ui_spScores4;
-vmCvar_t	ui_spScores5;
-vmCvar_t	ui_spAwards;
-vmCvar_t	ui_spVideos;
-vmCvar_t	ui_spSkill;
-
-vmCvar_t	ui_spSelection;
-
-vmCvar_t	ui_browserMaster;
-vmCvar_t	ui_browserGameType;
-vmCvar_t	ui_browserSortKey;
-vmCvar_t	ui_browserShowFull;
-vmCvar_t	ui_browserShowEmpty;
-
-vmCvar_t	ui_brassTime;
-vmCvar_t	ui_drawCrosshair;
-vmCvar_t	ui_drawCrosshairNames;
-vmCvar_t	ui_marks;
-
-vmCvar_t	ui_server1;
-vmCvar_t	ui_server2;
-vmCvar_t	ui_server3;
-vmCvar_t	ui_server4;
-vmCvar_t	ui_server5;
-vmCvar_t	ui_server6;
-vmCvar_t	ui_server7;
-vmCvar_t	ui_server8;
-vmCvar_t	ui_server9;
-vmCvar_t	ui_server10;
-vmCvar_t	ui_server11;
-vmCvar_t	ui_server12;
-vmCvar_t	ui_server13;
-vmCvar_t	ui_server14;
-vmCvar_t	ui_server15;
-vmCvar_t	ui_server16;
-
-//vmCvar_t	ui_cdkeychecked;
-
+vmCvar_t ui_ffa_fraglimit;
+vmCvar_t ui_ffa_timelimit;
+vmCvar_t ui_tourney_fraglimit;
+vmCvar_t ui_tourney_timelimit;
+vmCvar_t ui_team_fraglimit;
+vmCvar_t ui_team_timelimit;
+vmCvar_t ui_team_friendly;
+vmCvar_t ui_ctf_capturelimit;
+vmCvar_t ui_ctf_timelimit;
+vmCvar_t ui_ctf_friendly;
+vmCvar_t ui_1fctf_capturelimit;
+vmCvar_t ui_1fctf_timelimit;
+vmCvar_t ui_1fctf_friendly;
+vmCvar_t ui_overload_capturelimit;
+vmCvar_t ui_overload_timelimit;
+vmCvar_t ui_overload_friendly;
+vmCvar_t ui_harvester_capturelimit;
+vmCvar_t ui_harvester_timelimit;
+vmCvar_t ui_harvester_friendly;
+vmCvar_t ui_elimination_capturelimit;
+vmCvar_t ui_elimination_timelimit;
+vmCvar_t ui_ctf_elimination_capturelimit;
+vmCvar_t ui_ctf_elimination_timelimit;
+vmCvar_t ui_lms_fraglimit;
+vmCvar_t ui_lms_timelimit;
+vmCvar_t ui_dd_capturelimit;
+vmCvar_t ui_dd_timelimit;
+vmCvar_t ui_dd_friendly;
+vmCvar_t ui_dom_capturelimit;
+vmCvar_t ui_dom_timelimit;
+vmCvar_t ui_dom_friendly;
+vmCvar_t ui_pos_scorelimit;
+vmCvar_t ui_pos_timelimit;
+vmCvar_t ui_arenasFile;
+vmCvar_t ui_botsFile;
+vmCvar_t ui_spScores1;
+vmCvar_t ui_spScores2;
+vmCvar_t ui_spScores3;
+vmCvar_t ui_spScores4;
+vmCvar_t ui_spScores5;
+vmCvar_t ui_spAwards;
+vmCvar_t ui_spVideos;
+vmCvar_t ui_spSkill;
+vmCvar_t ui_spSelection;
+vmCvar_t ui_browserMaster;
+vmCvar_t ui_browserGameType;
+vmCvar_t ui_browserSortKey;
+vmCvar_t ui_browserShowFull;
+vmCvar_t ui_browserShowEmpty;
+vmCvar_t ui_brassTime;
+vmCvar_t ui_drawCrosshair;
+vmCvar_t ui_drawCrosshairNames;
+vmCvar_t ui_marks;
+vmCvar_t ui_server1;
+vmCvar_t ui_server2;
+vmCvar_t ui_server3;
+vmCvar_t ui_server4;
+vmCvar_t ui_server5;
+vmCvar_t ui_server6;
+vmCvar_t ui_server7;
+vmCvar_t ui_server8;
+vmCvar_t ui_server9;
+vmCvar_t ui_server10;
+vmCvar_t ui_server11;
+vmCvar_t ui_server12;
+vmCvar_t ui_server13;
+vmCvar_t ui_server14;
+vmCvar_t ui_server15;
+vmCvar_t ui_server16;
+//vmCvar_t ui_cdkeychecked;
 //new in beta 23:
 vmCvar_t        ui_browserOnlyHumans;
-
 //new in beta 37:
 vmCvar_t        ui_setupchecked;
 
-
 // bk001129 - made static to avoid aliasing.
-static cvarTable_t		cvarTable[] = {
+static cvarTable_t cvarTable[] = {
 	{ &ui_ffa_fraglimit, "ui_ffa_fraglimit", "20", CVAR_ARCHIVE },
 	{ &ui_ffa_timelimit, "ui_ffa_timelimit", "0", CVAR_ARCHIVE },
 

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -32,147 +32,170 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // global display context
 
-extern vmCvar_t	ui_ffa_fraglimit;
-extern vmCvar_t	ui_ffa_timelimit;
-
-extern vmCvar_t	ui_tourney_fraglimit;
-extern vmCvar_t	ui_tourney_timelimit;
-
-extern vmCvar_t	ui_team_fraglimit;
-extern vmCvar_t	ui_team_timelimit;
-extern vmCvar_t	ui_team_friendly;
-
-extern vmCvar_t	ui_ctf_capturelimit;
-extern vmCvar_t	ui_ctf_timelimit;
-extern vmCvar_t	ui_ctf_friendly;
-
-extern vmCvar_t	ui_1fctf_capturelimit;
-extern vmCvar_t	ui_1fctf_timelimit;
-extern vmCvar_t	ui_1fctf_friendly;
-
-extern vmCvar_t	ui_overload_capturelimit;
-extern vmCvar_t	ui_overload_timelimit;
-extern vmCvar_t	ui_overload_friendly;
-
-extern vmCvar_t	ui_harvester_capturelimit;
-extern vmCvar_t	ui_harvester_timelimit;
-extern vmCvar_t	ui_harvester_friendly;
-
-extern vmCvar_t	ui_elimination_capturelimit;
-extern vmCvar_t	ui_elimination_timelimit;
-
-extern vmCvar_t	ui_ctf_elimination_capturelimit;
-extern vmCvar_t	ui_ctf_elimination_timelimit;
-
-extern vmCvar_t	ui_lms_fraglimit;
-extern vmCvar_t	ui_lms_timelimit;
-
-extern vmCvar_t	ui_dd_capturelimit;
-extern vmCvar_t	ui_dd_timelimit;
-extern vmCvar_t	ui_dd_friendly;
-
-extern vmCvar_t	ui_dom_capturelimit;
-extern vmCvar_t	ui_dom_timelimit;
-extern vmCvar_t	ui_dom_friendly;
-
-extern vmCvar_t	ui_pos_scorelimit;
-extern vmCvar_t	ui_pos_timelimit;
-
-extern vmCvar_t	ui_arenasFile;
-extern vmCvar_t	ui_botsFile;
-extern vmCvar_t	ui_spScores1;
-extern vmCvar_t	ui_spScores2;
-extern vmCvar_t	ui_spScores3;
-extern vmCvar_t	ui_spScores4;
-extern vmCvar_t	ui_spScores5;
-extern vmCvar_t	ui_spAwards;
-extern vmCvar_t	ui_spVideos;
-extern vmCvar_t	ui_spSkill;
-
-extern vmCvar_t	ui_spSelection;
-
-extern vmCvar_t	ui_browserMaster;
-extern vmCvar_t	ui_browserGameType;
-extern vmCvar_t	ui_browserSortKey;
-extern vmCvar_t	ui_browserShowFull;
-extern vmCvar_t	ui_browserShowEmpty;
-
-extern vmCvar_t	ui_brassTime;
-extern vmCvar_t	ui_drawCrosshair;
-extern vmCvar_t	ui_drawCrosshairNames;
-extern vmCvar_t	ui_marks;
-
-extern vmCvar_t	ui_server1;
-extern vmCvar_t	ui_server2;
-extern vmCvar_t	ui_server3;
-extern vmCvar_t	ui_server4;
-extern vmCvar_t	ui_server5;
-extern vmCvar_t	ui_server6;
-extern vmCvar_t	ui_server7;
-extern vmCvar_t	ui_server8;
-extern vmCvar_t	ui_server9;
-extern vmCvar_t	ui_server10;
-extern vmCvar_t	ui_server11;
-extern vmCvar_t	ui_server12;
-extern vmCvar_t	ui_server13;
-extern vmCvar_t	ui_server14;
-extern vmCvar_t	ui_server15;
-extern vmCvar_t	ui_server16;
-
-extern vmCvar_t	ui_cdkey;
-extern vmCvar_t	ui_cdkeychecked;
-
-extern vmCvar_t	ui_captureLimit;
-extern vmCvar_t	ui_fragLimit;
-extern vmCvar_t	ui_gameType;
-extern vmCvar_t	ui_netGameType;
-extern vmCvar_t	ui_actualNetGameType;
-extern vmCvar_t	ui_joinGameType;
-extern vmCvar_t	ui_netSource;
-extern vmCvar_t	ui_serverFilterType;
-extern vmCvar_t	ui_dedicated;
-extern vmCvar_t	ui_opponentName;
-extern vmCvar_t	ui_menuFiles;
-extern vmCvar_t	ui_introFiles;
-extern vmCvar_t	ui_currentTier;
-extern vmCvar_t	ui_currentMap;
-extern vmCvar_t	ui_currentNetMap;
-extern vmCvar_t	ui_mapIndex;
-extern vmCvar_t	ui_currentOpponent;
-extern vmCvar_t	ui_selectedPlayer;
-extern vmCvar_t	ui_selectedPlayerName;
-extern vmCvar_t	ui_lastServerRefresh_0;
-extern vmCvar_t	ui_lastServerRefresh_1;
-extern vmCvar_t	ui_lastServerRefresh_2;
-extern vmCvar_t	ui_lastServerRefresh_3;
-extern vmCvar_t	ui_singlePlayerActive;
-extern vmCvar_t	ui_scoreAccuracy;
-extern vmCvar_t	ui_scoreImpressives;
-extern vmCvar_t	ui_scoreExcellents;
-extern vmCvar_t	ui_scoreDefends;
-extern vmCvar_t	ui_scoreAssists;
-extern vmCvar_t	ui_scoreGauntlets;
-extern vmCvar_t	ui_scoreScore;
-extern vmCvar_t	ui_scorePerfect;
-extern vmCvar_t	ui_scoreTeam;
-extern vmCvar_t	ui_scoreBase;
-extern vmCvar_t	ui_scoreTimeBonus;
-extern vmCvar_t	ui_scoreSkillBonus;
-extern vmCvar_t	ui_scoreShutoutBonus;
-extern vmCvar_t	ui_scoreTime;
-extern vmCvar_t	ui_smallFont;
-extern vmCvar_t	ui_bigFont;
+extern vmCvar_t ui_ffa_fraglimit;
+extern vmCvar_t ui_ffa_timelimit;
+extern vmCvar_t ui_tourney_fraglimit;
+extern vmCvar_t ui_tourney_timelimit;
+extern vmCvar_t ui_team_fraglimit;
+extern vmCvar_t ui_team_timelimit;
+extern vmCvar_t ui_team_friendly;
+extern vmCvar_t ui_ctf_capturelimit;
+extern vmCvar_t ui_ctf_timelimit;
+extern vmCvar_t ui_ctf_friendly;
+extern vmCvar_t ui_1fctf_capturelimit;
+extern vmCvar_t ui_1fctf_timelimit;
+extern vmCvar_t ui_1fctf_friendly;
+extern vmCvar_t ui_overload_capturelimit;
+extern vmCvar_t ui_overload_timelimit;
+extern vmCvar_t ui_overload_friendly;
+extern vmCvar_t ui_harvester_capturelimit;
+extern vmCvar_t ui_harvester_timelimit;
+extern vmCvar_t ui_harvester_friendly;
+extern vmCvar_t ui_elimination_capturelimit;
+extern vmCvar_t ui_elimination_timelimit;
+extern vmCvar_t ui_ctf_elimination_capturelimit;
+extern vmCvar_t ui_ctf_elimination_timelimit;
+extern vmCvar_t ui_lms_fraglimit;
+extern vmCvar_t ui_lms_timelimit;
+extern vmCvar_t ui_dd_capturelimit;
+extern vmCvar_t ui_dd_timelimit;
+extern vmCvar_t ui_dd_friendly;
+extern vmCvar_t ui_dom_capturelimit;
+extern vmCvar_t ui_dom_timelimit;
+extern vmCvar_t ui_dom_friendly;
+extern vmCvar_t ui_pos_scorelimit;
+extern vmCvar_t ui_pos_timelimit;
+extern vmCvar_t ui_arenasFile;
+extern vmCvar_t ui_botsFile;
+extern vmCvar_t ui_spScores1;
+extern vmCvar_t ui_spScores2;
+extern vmCvar_t ui_spScores3;
+extern vmCvar_t ui_spScores4;
+extern vmCvar_t ui_spScores5;
+extern vmCvar_t ui_spAwards;
+extern vmCvar_t ui_spVideos;
+extern vmCvar_t ui_spSkill;
+extern vmCvar_t ui_spSelection;
+extern vmCvar_t ui_browserMaster;
+extern vmCvar_t ui_browserGameType;
+extern vmCvar_t ui_browserSortKey;
+extern vmCvar_t ui_browserShowFull;
+extern vmCvar_t ui_browserShowEmpty;
+extern vmCvar_t ui_brassTime;
+extern vmCvar_t ui_drawCrosshair;
+extern vmCvar_t ui_drawCrosshairNames;
+extern vmCvar_t ui_marks;
+extern vmCvar_t ui_server1;
+extern vmCvar_t ui_server2;
+extern vmCvar_t ui_server3;
+extern vmCvar_t ui_server4;
+extern vmCvar_t ui_server5;
+extern vmCvar_t ui_server6;
+extern vmCvar_t ui_server7;
+extern vmCvar_t ui_server8;
+extern vmCvar_t ui_server9;
+extern vmCvar_t ui_server10;
+extern vmCvar_t ui_server11;
+extern vmCvar_t ui_server12;
+extern vmCvar_t ui_server13;
+extern vmCvar_t ui_server14;
+extern vmCvar_t ui_server15;
+extern vmCvar_t ui_server16;
+extern vmCvar_t ui_cdkey;
+extern vmCvar_t ui_cdkeychecked;
+extern vmCvar_t ui_captureLimit;
+extern vmCvar_t ui_fragLimit;
+extern vmCvar_t ui_gameType;
+extern vmCvar_t ui_netGameType;
+extern vmCvar_t ui_actualNetGameType;
+extern vmCvar_t ui_joinGameType;
+extern vmCvar_t ui_netSource;
+extern vmCvar_t ui_serverFilterType;
+extern vmCvar_t ui_dedicated;
+extern vmCvar_t ui_opponentName;
+extern vmCvar_t ui_menuFiles;
+extern vmCvar_t ui_introFiles;
+extern vmCvar_t ui_currentTier;
+extern vmCvar_t ui_currentMap;
+extern vmCvar_t ui_currentNetMap;
+extern vmCvar_t ui_mapIndex;
+extern vmCvar_t ui_currentOpponent;
+extern vmCvar_t ui_selectedPlayer;
+extern vmCvar_t ui_selectedPlayerName;
+extern vmCvar_t ui_lastServerRefresh_0;
+extern vmCvar_t ui_lastServerRefresh_1;
+extern vmCvar_t ui_lastServerRefresh_2;
+extern vmCvar_t ui_lastServerRefresh_3;
+extern vmCvar_t ui_singlePlayerActive;
+extern vmCvar_t ui_scoreAccuracy;
+extern vmCvar_t ui_scoreImpressives;
+extern vmCvar_t ui_scoreExcellents;
+extern vmCvar_t ui_scoreDefends;
+extern vmCvar_t ui_scoreAssists;
+extern vmCvar_t ui_scoreGauntlets;
+extern vmCvar_t ui_scoreScore;
+extern vmCvar_t ui_scorePerfect;
+extern vmCvar_t ui_scoreTeam;
+extern vmCvar_t ui_scoreBase;
+extern vmCvar_t ui_scoreTimeBonus;
+extern vmCvar_t ui_scoreSkillBonus;
+extern vmCvar_t ui_scoreShutoutBonus;
+extern vmCvar_t ui_scoreTime;
+extern vmCvar_t ui_smallFont;
+extern vmCvar_t ui_bigFont;
 extern vmCvar_t ui_serverStatusTimeOut;
-
 extern vmCvar_t ui_humansonly;
-
-extern vmCvar_t	ui_introPlayed;
-
-extern vmCvar_t	ui_colors;
-
+extern vmCvar_t ui_introPlayed;
+extern vmCvar_t ui_colors;
 /* Neon_Knight: Additional missionpack check */
-extern vmCvar_t	ui_missionpackChecks;
+extern vmCvar_t ui_missionpackChecks;
 /* /Neon_Knight */
+extern vmCvar_t ui_findPlayer;
+extern vmCvar_t ui_Q3Model;
+extern vmCvar_t ui_hudFiles;
+extern vmCvar_t ui_recordSPDemo;
+extern vmCvar_t ui_realCaptureLimit;
+extern vmCvar_t ui_realWarmUp;
+// Changed RD
+extern vmCvar_t ui_LowerAnim;
+extern vmCvar_t ui_UpperAnim;
+extern vmCvar_t ui_Weapon;
+extern vmCvar_t ui_PlayerViewAngleYaw;
+extern vmCvar_t ui_PlayerViewAnglePitch;
+extern vmCvar_t ui_PlayerMoveAngleYaw;
+extern vmCvar_t ui_PlayerMoveAnglePitch;
+extern vmCvar_t ui_SaveGame;
+extern vmCvar_t ui_LoadGame;
+extern vmCvar_t ui_CustomServer;
+extern vmCvar_t ui_HostName;
+extern vmCvar_t ui_SpecialGame;
+extern vmCvar_t ui_TeamMembers;
+extern vmCvar_t ui_loading;
+extern vmCvar_t ui_transitionkey;
+extern vmCvar_t ui_applychanges;
+extern vmCvar_t Save_Loading;
+extern vmCvar_t persid;
+extern vmCvar_t gameover; // ai script
+// end changed RD
+// leilei
+extern vmCvar_t ui_new;
+extern vmCvar_t ui_leidebug;
+extern vmCvar_t ui_debug;
+extern vmCvar_t ui_initialized;
+extern vmCvar_t ui_teamArenaFirstRun;
+extern vmCvar_t ui_redteam;
+extern vmCvar_t ui_redteam1;
+extern vmCvar_t ui_redteam2;
+extern vmCvar_t ui_redteam3;
+extern vmCvar_t ui_redteam4;
+extern vmCvar_t ui_redteam5;
+extern vmCvar_t ui_blueteam;
+extern vmCvar_t ui_blueteam1;
+extern vmCvar_t ui_blueteam2;
+extern vmCvar_t ui_blueteam3;
+extern vmCvar_t ui_blueteam4;
+extern vmCvar_t ui_blueteam5;
+extern vmCvar_t ui_teamName;
 
 //
 // ui_qmenu.c

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -138,11 +138,6 @@ This is the only way control passes into the module.
 This must be the very first function compiled into the .qvm file
 ================
 */
-vmCvar_t  ui_new;
-vmCvar_t  ui_leidebug;
-vmCvar_t  ui_debug;
-vmCvar_t  ui_initialized;
-vmCvar_t  ui_teamArenaFirstRun;
 
 void _UI_Init( qboolean, int randomSeed );
 void _UI_Shutdown( void );
@@ -6998,191 +6993,173 @@ cvars
 */
 
 typedef struct {
-	vmCvar_t	*vmCvar;
+	vmCvar_t *vmCvar;
 	char		*cvarName;
 	char		*defaultString;
 	int			cvarFlags;
 } cvarTable_t;
 
-vmCvar_t	ui_ffa_fraglimit;
-vmCvar_t	ui_ffa_timelimit;
-
-vmCvar_t	ui_tourney_fraglimit;
-vmCvar_t	ui_tourney_timelimit;
-
-vmCvar_t	ui_team_fraglimit;
-vmCvar_t	ui_team_timelimit;
-vmCvar_t	ui_team_friendly;
-
-vmCvar_t	ui_ctf_capturelimit;
-vmCvar_t	ui_ctf_timelimit;
-vmCvar_t	ui_ctf_friendly;
-
-vmCvar_t	ui_1fctf_capturelimit;
-vmCvar_t	ui_1fctf_timelimit;
-vmCvar_t	ui_1fctf_friendly;
-
-vmCvar_t	ui_overload_capturelimit;
-vmCvar_t	ui_overload_timelimit;
-vmCvar_t	ui_overload_friendly;
-
-vmCvar_t	ui_harvester_capturelimit;
-vmCvar_t	ui_harvester_timelimit;
-vmCvar_t	ui_harvester_friendly;
-
-vmCvar_t	ui_elimination_capturelimit;
-vmCvar_t	ui_elimination_timelimit;
-
-vmCvar_t	ui_ctf_elimination_capturelimit;
-vmCvar_t	ui_ctf_elimination_timelimit;
-
-vmCvar_t	ui_lms_fraglimit;
-vmCvar_t	ui_lms_timelimit;
-
-vmCvar_t	ui_dd_capturelimit;
-vmCvar_t	ui_dd_timelimit;
-vmCvar_t	ui_dd_friendly;
-
-vmCvar_t	ui_dom_capturelimit;
-vmCvar_t	ui_dom_timelimit;
-vmCvar_t	ui_dom_friendly;
-
-vmCvar_t	ui_pos_scorelimit;
-vmCvar_t	ui_pos_timelimit;
-
-vmCvar_t	ui_arenasFile;
-vmCvar_t	ui_botsFile;
-vmCvar_t	ui_spScores1;
-vmCvar_t	ui_spScores2;
-vmCvar_t	ui_spScores3;
-vmCvar_t	ui_spScores4;
-vmCvar_t	ui_spScores5;
-vmCvar_t	ui_spAwards;
-vmCvar_t	ui_spVideos;
-vmCvar_t	ui_spSkill;
-
-vmCvar_t	ui_spSelection;
-
-vmCvar_t	ui_browserMaster;
-vmCvar_t	ui_browserGameType;
-vmCvar_t	ui_browserSortKey;
-vmCvar_t	ui_browserShowFull;
-vmCvar_t	ui_browserShowEmpty;
-
-vmCvar_t	ui_brassTime;
-vmCvar_t	ui_drawCrosshair;
-vmCvar_t	ui_drawCrosshairNames;
-vmCvar_t	ui_marks;
-
-vmCvar_t	ui_server1;
-vmCvar_t	ui_server2;
-vmCvar_t	ui_server3;
-vmCvar_t	ui_server4;
-vmCvar_t	ui_server5;
-vmCvar_t	ui_server6;
-vmCvar_t	ui_server7;
-vmCvar_t	ui_server8;
-vmCvar_t	ui_server9;
-vmCvar_t	ui_server10;
-vmCvar_t	ui_server11;
-vmCvar_t	ui_server12;
-vmCvar_t	ui_server13;
-vmCvar_t	ui_server14;
-vmCvar_t	ui_server15;
-vmCvar_t	ui_server16;
-
-vmCvar_t	ui_cdkeychecked;
-
-vmCvar_t	ui_redteam;
-vmCvar_t	ui_redteam1;
-vmCvar_t	ui_redteam2;
-vmCvar_t	ui_redteam3;
-vmCvar_t	ui_redteam4;
-vmCvar_t	ui_redteam5;
-vmCvar_t	ui_blueteam;
-vmCvar_t	ui_blueteam1;
-vmCvar_t	ui_blueteam2;
-vmCvar_t	ui_blueteam3;
-vmCvar_t	ui_blueteam4;
-vmCvar_t	ui_blueteam5;
-vmCvar_t	ui_teamName;
-vmCvar_t	ui_dedicated;
-vmCvar_t	ui_gameType;
-vmCvar_t	ui_netGameType;
-vmCvar_t	ui_actualNetGameType;
-vmCvar_t	ui_joinGameType;
-vmCvar_t	ui_netSource;
-vmCvar_t	ui_serverFilterType;
-vmCvar_t	ui_opponentName;
-vmCvar_t	ui_menuFiles;
-vmCvar_t	ui_currentTier;
-vmCvar_t	ui_currentMap;
-vmCvar_t	ui_currentNetMap;
-vmCvar_t	ui_mapIndex;
-vmCvar_t	ui_currentOpponent;
-vmCvar_t	ui_selectedPlayer;
-vmCvar_t	ui_selectedPlayerName;
-vmCvar_t	ui_lastServerRefresh_0;
-vmCvar_t	ui_lastServerRefresh_1;
-vmCvar_t	ui_lastServerRefresh_2;
-vmCvar_t	ui_lastServerRefresh_3;
-vmCvar_t	ui_singlePlayerActive;
-vmCvar_t	ui_scoreAccuracy;
-vmCvar_t	ui_scoreImpressives;
-vmCvar_t	ui_scoreExcellents;
-vmCvar_t	ui_scoreCaptures;
-vmCvar_t	ui_scoreDefends;
-vmCvar_t	ui_scoreAssists;
-vmCvar_t	ui_scoreGauntlets;
-vmCvar_t	ui_scoreScore;
-vmCvar_t	ui_scorePerfect;
-vmCvar_t	ui_scoreTeam;
-vmCvar_t	ui_scoreBase;
-vmCvar_t	ui_scoreTimeBonus;
-vmCvar_t	ui_scoreSkillBonus;
-vmCvar_t	ui_scoreShutoutBonus;
-vmCvar_t	ui_scoreTime;
-vmCvar_t	ui_captureLimit;
-vmCvar_t	ui_fragLimit;
-vmCvar_t	ui_smallFont;
-vmCvar_t	ui_bigFont;
-vmCvar_t	ui_findPlayer;
-vmCvar_t	ui_Q3Model;
-vmCvar_t	ui_hudFiles;
-vmCvar_t	ui_recordSPDemo;
-vmCvar_t	ui_realCaptureLimit;
-vmCvar_t	ui_realWarmUp;
-vmCvar_t	ui_serverStatusTimeOut;
+vmCvar_t ui_ffa_fraglimit;
+vmCvar_t ui_ffa_timelimit;
+vmCvar_t ui_tourney_fraglimit;
+vmCvar_t ui_tourney_timelimit;
+vmCvar_t ui_team_fraglimit;
+vmCvar_t ui_team_timelimit;
+vmCvar_t ui_team_friendly;
+vmCvar_t ui_ctf_capturelimit;
+vmCvar_t ui_ctf_timelimit;
+vmCvar_t ui_ctf_friendly;
+vmCvar_t ui_1fctf_capturelimit;
+vmCvar_t ui_1fctf_timelimit;
+vmCvar_t ui_1fctf_friendly;
+vmCvar_t ui_overload_capturelimit;
+vmCvar_t ui_overload_timelimit;
+vmCvar_t ui_overload_friendly;
+vmCvar_t ui_harvester_capturelimit;
+vmCvar_t ui_harvester_timelimit;
+vmCvar_t ui_harvester_friendly;
+vmCvar_t ui_elimination_capturelimit;
+vmCvar_t ui_elimination_timelimit;
+vmCvar_t ui_ctf_elimination_capturelimit;
+vmCvar_t ui_ctf_elimination_timelimit;
+vmCvar_t ui_lms_fraglimit;
+vmCvar_t ui_lms_timelimit;
+vmCvar_t ui_dd_capturelimit;
+vmCvar_t ui_dd_timelimit;
+vmCvar_t ui_dd_friendly;
+vmCvar_t ui_dom_capturelimit;
+vmCvar_t ui_dom_timelimit;
+vmCvar_t ui_dom_friendly;
+vmCvar_t ui_pos_scorelimit;
+vmCvar_t ui_pos_timelimit;
+vmCvar_t ui_arenasFile;
+vmCvar_t ui_botsFile;
+vmCvar_t ui_spScores1;
+vmCvar_t ui_spScores2;
+vmCvar_t ui_spScores3;
+vmCvar_t ui_spScores4;
+vmCvar_t ui_spScores5;
+vmCvar_t ui_spAwards;
+vmCvar_t ui_spVideos;
+vmCvar_t ui_spSkill;
+vmCvar_t ui_spSelection;
+vmCvar_t ui_browserMaster;
+vmCvar_t ui_browserGameType;
+vmCvar_t ui_browserSortKey;
+vmCvar_t ui_browserShowFull;
+vmCvar_t ui_browserShowEmpty;
+vmCvar_t ui_brassTime;
+vmCvar_t ui_drawCrosshair;
+vmCvar_t ui_drawCrosshairNames;
+vmCvar_t ui_marks;
+vmCvar_t ui_server1;
+vmCvar_t ui_server2;
+vmCvar_t ui_server3;
+vmCvar_t ui_server4;
+vmCvar_t ui_server5;
+vmCvar_t ui_server6;
+vmCvar_t ui_server7;
+vmCvar_t ui_server8;
+vmCvar_t ui_server9;
+vmCvar_t ui_server10;
+vmCvar_t ui_server11;
+vmCvar_t ui_server12;
+vmCvar_t ui_server13;
+vmCvar_t ui_server14;
+vmCvar_t ui_server15;
+vmCvar_t ui_server16;
+vmCvar_t ui_cdkeychecked;
+vmCvar_t ui_redteam;
+vmCvar_t ui_redteam1;
+vmCvar_t ui_redteam2;
+vmCvar_t ui_redteam3;
+vmCvar_t ui_redteam4;
+vmCvar_t ui_redteam5;
+vmCvar_t ui_blueteam;
+vmCvar_t ui_blueteam1;
+vmCvar_t ui_blueteam2;
+vmCvar_t ui_blueteam3;
+vmCvar_t ui_blueteam4;
+vmCvar_t ui_blueteam5;
+vmCvar_t ui_teamName;
+vmCvar_t ui_dedicated;
+vmCvar_t ui_gameType;
+vmCvar_t ui_netGameType;
+vmCvar_t ui_actualNetGameType;
+vmCvar_t ui_joinGameType;
+vmCvar_t ui_netSource;
+vmCvar_t ui_serverFilterType;
+vmCvar_t ui_opponentName;
+vmCvar_t ui_menuFiles;
+vmCvar_t ui_currentTier;
+vmCvar_t ui_currentMap;
+vmCvar_t ui_currentNetMap;
+vmCvar_t ui_mapIndex;
+vmCvar_t ui_currentOpponent;
+vmCvar_t ui_selectedPlayer;
+vmCvar_t ui_selectedPlayerName;
+vmCvar_t ui_lastServerRefresh_0;
+vmCvar_t ui_lastServerRefresh_1;
+vmCvar_t ui_lastServerRefresh_2;
+vmCvar_t ui_lastServerRefresh_3;
+vmCvar_t ui_singlePlayerActive;
+vmCvar_t ui_scoreAccuracy;
+vmCvar_t ui_scoreImpressives;
+vmCvar_t ui_scoreExcellents;
+vmCvar_t ui_scoreCaptures;
+vmCvar_t ui_scoreDefends;
+vmCvar_t ui_scoreAssists;
+vmCvar_t ui_scoreGauntlets;
+vmCvar_t ui_scoreScore;
+vmCvar_t ui_scorePerfect;
+vmCvar_t ui_scoreTeam;
+vmCvar_t ui_scoreBase;
+vmCvar_t ui_scoreTimeBonus;
+vmCvar_t ui_scoreSkillBonus;
+vmCvar_t ui_scoreShutoutBonus;
+vmCvar_t ui_scoreTime;
+vmCvar_t ui_captureLimit;
+vmCvar_t ui_fragLimit;
+vmCvar_t ui_smallFont;
+vmCvar_t ui_bigFont;
+vmCvar_t ui_findPlayer;
+vmCvar_t ui_Q3Model;
+vmCvar_t ui_hudFiles;
+vmCvar_t ui_recordSPDemo;
+vmCvar_t ui_realCaptureLimit;
+vmCvar_t ui_realWarmUp;
+vmCvar_t ui_serverStatusTimeOut;
 // Changed RD
-vmCvar_t	ui_LowerAnim;
-vmCvar_t	ui_UpperAnim;
-vmCvar_t	ui_Weapon;
-vmCvar_t	ui_PlayerViewAngleYaw;
-vmCvar_t	ui_PlayerViewAnglePitch;
-vmCvar_t	ui_PlayerMoveAngleYaw;
-vmCvar_t	ui_PlayerMoveAnglePitch;
-vmCvar_t	ui_SaveGame;
-vmCvar_t	ui_LoadGame;
-vmCvar_t	ui_CustomServer;
-vmCvar_t	ui_HostName;
-vmCvar_t	ui_SpecialGame;
-vmCvar_t	ui_TeamMembers;
-vmCvar_t	ui_loading;
-vmCvar_t	ui_transitionkey;
-vmCvar_t	ui_applychanges;
-vmCvar_t	Save_Loading;
-vmCvar_t	persid;
-vmCvar_t	gameover; // ai script
+vmCvar_t ui_LowerAnim;
+vmCvar_t ui_UpperAnim;
+vmCvar_t ui_Weapon;
+vmCvar_t ui_PlayerViewAngleYaw;
+vmCvar_t ui_PlayerViewAnglePitch;
+vmCvar_t ui_PlayerMoveAngleYaw;
+vmCvar_t ui_PlayerMoveAnglePitch;
+vmCvar_t ui_SaveGame;
+vmCvar_t ui_LoadGame;
+vmCvar_t ui_CustomServer;
+vmCvar_t ui_HostName;
+vmCvar_t ui_SpecialGame;
+vmCvar_t ui_TeamMembers;
+vmCvar_t ui_loading;
+vmCvar_t ui_transitionkey;
+vmCvar_t ui_applychanges;
+vmCvar_t Save_Loading;
+vmCvar_t persid;
+vmCvar_t gameover; // ai script
 // end changed RD
-
 // leilei
-vmCvar_t	ui_introPlayed;
-
-vmCvar_t	ui_colors;
-
+vmCvar_t ui_introPlayed;
+vmCvar_t ui_colors;
 vmCvar_t ui_humansonly;
-
 vmCvar_t ui_missionpackChecks;
+vmCvar_t ui_new;
+vmCvar_t ui_leidebug;
+vmCvar_t ui_debug;
+vmCvar_t ui_initialized;
+vmCvar_t ui_teamArenaFirstRun;
 
 // bk001129 - made static to avoid aliasing
 static cvarTable_t		cvarTable[] = {


### PR DESCRIPTION
Tabs and extra spaces are replaced by a single space between words. Some cvars were moved to main. Some missing cvars were added to ui_local.h.