### PR TITLE
AI fixes and improvements for Possession, Domination, Rocket jumping and Grappling

### DIFF
--- a/code/game/ai_chat.c
+++ b/code/game/ai_chat.c
@@ -380,20 +380,19 @@ BotChat_EnterGame
 */
 int BotChat_EnterGame(bot_state_t *bs) {
 	char name[32];
-	float rnd;
 
-	if (bot_nochat.integer) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENTEREXITGAME, 0, 1);
-	if (!bot_fastchat.integer) {
-		if (random() > rnd) return qfalse;
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_ENTEREXITGAME)) {
+		return qfalse;
 	}
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	if (!BotValidChatPosition(bs)) return qfalse;
+	if (G_IsATeamGametype(gametype)) {
+		return qfalse;
+	}
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
+	if (!BotValidChatPosition(bs)) {
+		return qfalse;
+	}
 	BotAI_BotInitialChat(bs, "game_enter",
 				EasyClientName(bs->client, name, 32),	// 0
 				BotRandomOpponentName(bs),				// 1
@@ -413,20 +412,16 @@ BotChat_ExitGame
 */
 int BotChat_ExitGame(bot_state_t *bs) {
 	char name[32];
-	float rnd;
 
-	if (bot_nochat.integer) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENTEREXITGAME, 0, 1);
-	if (!bot_fastchat.integer) {
-		if (random() > rnd) return qfalse;
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_ENTEREXITGAME)) {
+		return qfalse;
 	}
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	//
+	if (G_IsATeamGametype(gametype)) {
+		return qfalse;
+	}
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
 	BotAI_BotInitialChat(bs, "game_exit",
 				EasyClientName(bs->client, name, 32),	// 0
 				BotRandomOpponentName(bs),				// 1
@@ -446,23 +441,20 @@ BotChat_StartLevel
 */
 int BotChat_StartLevel(bot_state_t *bs) {
 	char name[32];
-	float rnd;
 
-	if (bot_nochat.integer) return qfalse;
-	if (BotIsObserver(bs)) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) {
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_STARTENDLEVEL)) {
+		return qfalse;
+	}
+	if (G_IsATeamGametype(gametype)) {
 	    trap_EA_Command(bs->client, "vtaunt");
 	    return qfalse;
 	}
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_STARTENDLEVEL, 0, 1);
-	if (!bot_fastchat.integer) {
-		if (random() > rnd) return qfalse;
+	if (BotCanChatInTournament()) {
+		return qfalse;
 	}
-	if (BotNumActivePlayers() <= 1) return qfalse;
+	if (BotIsObserver(bs)) {
+		return qfalse;
+	}
 	BotAI_BotInitialChat(bs, "level_start",
 				EasyClientName(bs->client, name, 32),	// 0
 				NULL);
@@ -478,27 +470,23 @@ BotChat_EndLevel
 */
 int BotChat_EndLevel(bot_state_t *bs) {
 	char name[32];
-	float rnd;
 
-	if (bot_nochat.integer) return qfalse;
-	if (BotIsObserver(bs)) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	// teamplay
-	if (TeamPlayIsOn()) 
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_STARTENDLEVEL)) {
+		return qfalse;
+	}
+	if (G_IsATeamGametype(gametype)) 
 	{
 		if (BotIsFirstInRankings(bs)) {
 			trap_EA_Command(bs->client, "vtaunt");
 		}
 		return qtrue;
 	}
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_STARTENDLEVEL, 0, 1);
-	if (!bot_fastchat.integer) {
-		if (random() > rnd) return qfalse;
+	if (BotCanChatInTournament()) {
+		return qfalse;
 	}
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	//
+	if (BotIsObserver(bs)) {
+		return qfalse;
+	}
 	if (BotIsFirstInRankings(bs)) {
 		BotAI_BotInitialChat(bs, "level_end_victory",
 				EasyClientName(bs->client, name, 32),	// 0
@@ -538,25 +526,19 @@ BotChat_Death
 */
 int BotChat_Death(bot_state_t *bs) {
 	char name[32];
-	float rnd;
 
-	if (bot_nochat.integer) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_DEATH, 0, 1);
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	//if fast chatting is off
-	if (!bot_fastchat.integer) {
-		if (random() > rnd) return qfalse;
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_DEATH)) {
+		return qfalse;
 	}
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	//
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
 	if (bs->lastkilledby >= 0 && bs->lastkilledby < MAX_CLIENTS)
 		EasyClientName(bs->lastkilledby, name, 32);
 	else
 		strcpy(name, "[world]");
 	//
-	if (TeamPlayIsOn() && BotSameTeam(bs, bs->lastkilledby)) {
+	if (G_IsATeamGametype(gametype) && BotSameTeam(bs, bs->lastkilledby)) {
 		if (bs->lastkilledby == bs->client) return qfalse;
 		BotAI_BotInitialChat(bs, "death_teammate", name, NULL);
 		bs->chatto = CHAT_TEAM;
@@ -564,7 +546,7 @@ int BotChat_Death(bot_state_t *bs) {
 	else
 	{
 		//teamplay
-		if (TeamPlayIsOn()) {
+		if (G_IsATeamGametype(gametype)) {
 			trap_EA_Command(bs->client, "vtaunt");
 			return qtrue;
 		}
@@ -637,34 +619,30 @@ BotChat_Kill
 */
 int BotChat_Kill(bot_state_t *bs) {
 	char name[32];
-	float rnd;
 
-	if (bot_nochat.integer) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_KILL, 0, 1);
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	//if fast chat is off
-	if (!bot_fastchat.integer) {
-		if (random() > rnd) return qfalse;
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_KILL)) {
+		return qfalse;
+	}
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
+	if (!BotValidChatPosition(bs)) {
+		return qfalse;
 	}
 	if (bs->lastkilledplayer == bs->client) return qfalse;
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	if (!BotValidChatPosition(bs)) return qfalse;
-	//
 	if (BotVisibleEnemies(bs)) return qfalse;
 	//
 	EasyClientName(bs->lastkilledplayer, name, 32);
 	//
 	bs->chatto = CHAT_ALL;
-	if (TeamPlayIsOn() && BotSameTeam(bs, bs->lastkilledplayer)) {
+	if (G_IsATeamGametype(gametype) && BotSameTeam(bs, bs->lastkilledplayer)) {
 		BotAI_BotInitialChat(bs, "kill_teammate", name, NULL);
 		bs->chatto = CHAT_TEAM;
 	}
 	else
 	{
 		//don't chat in teamplay
-		if (TeamPlayIsOn()) {
+		if (G_IsATeamGametype(gametype)) {
 			trap_EA_Command(bs->client, "vtaunt");
 			return qfalse;			// don't wait
 		}
@@ -699,23 +677,19 @@ BotChat_EnemySuicide
 */
 int BotChat_EnemySuicide(bot_state_t *bs) {
 	char name[32];
-	float rnd;
 
-	if (bot_nochat.integer) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	//
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENEMYSUICIDE, 0, 1);
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	//if fast chat is off
-	if (!bot_fastchat.integer) {
-		if (random() > rnd) return qfalse;
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_ENEMYSUICIDE)) {
+		return qfalse;
 	}
-	if (!BotValidChatPosition(bs)) return qfalse;
-	//
+	if (G_IsATeamGametype(gametype)) {
+		return qfalse;
+	}
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
+	if (!BotValidChatPosition(bs)) {
+		return qfalse;
+	}
 	if (BotVisibleEnemies(bs)) return qfalse;
 	//
 	if (bs->enemy >= 0) EasyClientName(bs->enemy, name, 32);
@@ -734,28 +708,23 @@ BotChat_HitTalking
 int BotChat_HitTalking(bot_state_t *bs) {
 	char name[32], *weap;
 	int lasthurt_client;
-	float rnd;
 
-	if (bot_nochat.integer) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	if (BotNumActivePlayers() <= 1) return qfalse;
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_HITTALKING)) {
+		return qfalse;
+	}
+	if (G_IsATeamGametype(gametype)) {
+		return qfalse;
+	}
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
+	if (!BotValidChatPosition(bs)) {
+		return qfalse;
+	}
 	lasthurt_client = g_entities[bs->client].client->lasthurt_client;
 	if (!lasthurt_client) return qfalse;
 	if (lasthurt_client == bs->client) return qfalse;
-	//
 	if (lasthurt_client < 0 || lasthurt_client >= MAX_CLIENTS) return qfalse;
-	//
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITTALKING, 0, 1);
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	//if fast chat is off
-	if (!bot_fastchat.integer) {
-		if (random() > rnd * 0.5) return qfalse;
-	}
-	if (!BotValidChatPosition(bs)) return qfalse;
-	//
 	ClientName(g_entities[bs->client].client->lasthurt_client, name, sizeof(name));
 	weap = BotWeaponNameForMeansOfDeath(g_entities[bs->client].client->lasthurt_mod);
 	//
@@ -772,30 +741,25 @@ BotChat_HitNoDeath
 */
 int BotChat_HitNoDeath(bot_state_t *bs) {
 	char name[32], *weap;
-	float rnd;
 	int lasthurt_client;
 	aas_entityinfo_t entinfo;
 
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_HITNODEATH)) {
+		return qfalse;
+	}
+	if (G_IsATeamGametype(gametype)) {
+		return qfalse;
+	}
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
+	if (!BotValidChatPosition(bs)) {
+		return qfalse;
+	}
 	lasthurt_client = g_entities[bs->client].client->lasthurt_client;
 	if (!lasthurt_client) return qfalse;
 	if (lasthurt_client == bs->client) return qfalse;
-	//
 	if (lasthurt_client < 0 || lasthurt_client >= MAX_CLIENTS) return qfalse;
-	//
-	if (bot_nochat.integer) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITNODEATH, 0, 1);
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	//if fast chat is off
-	if (!bot_fastchat.integer) {
-		if (random() > rnd * 0.5) return qfalse;
-	}
-	if (!BotValidChatPosition(bs)) return qfalse;
-	//
 	if (BotVisibleEnemies(bs)) return qfalse;
 	//
 	BotEntityInfo(bs->enemy, &entinfo);
@@ -817,23 +781,20 @@ BotChat_HitNoKill
 */
 int BotChat_HitNoKill(bot_state_t *bs) {
 	char name[32], *weap;
-	float rnd;
 	aas_entityinfo_t entinfo;
 
-	if (bot_nochat.integer) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITNOKILL, 0, 1);
-	//don't chat in teamplay
-	if (TeamPlayIsOn()) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
-	//if fast chat is off
-	if (!bot_fastchat.integer) {
-		if (random() > rnd * 0.5) return qfalse;
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_HITNOKILL)) {
+		return qfalse;
 	}
-	if (!BotValidChatPosition(bs)) return qfalse;
-	//
+	if (G_IsATeamGametype(gametype)) {
+		return qfalse;
+	}
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
+	if (!BotValidChatPosition(bs)) {
+		return qfalse;
+	}
 	if (BotVisibleEnemies(bs)) return qfalse;
 	//
 	BotEntityInfo(bs->enemy, &entinfo);
@@ -854,29 +815,30 @@ BotChat_Random
 ==================
 */
 int BotChat_Random(bot_state_t *bs) {
-	float rnd;
 	char name[32];
 
-	if (bot_nochat.integer) return qfalse;
-	if (BotIsObserver(bs)) return qfalse;
-	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
-	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (BotCanChat(bs,CHARACTERISTIC_CHAT_RANDOM)) {
+		return qfalse;
+	}
+	if (G_IsATeamGametype(gametype)) {
+		trap_EA_Command(bs->client, "vtaunt");
+		return qfalse;			// don't wait
+	}
+	if (BotCanChatInTournament()) {
+		return qfalse;
+	}
+	if (!BotValidChatPosition(bs)) {
+		return qfalse;
+	}
+	if (BotIsObserver(bs)) {
+		return qfalse;
+	}
 	//don't chat when doing something important :)
 	if (bs->ltgtype == LTG_TEAMHELP ||
 		bs->ltgtype == LTG_TEAMACCOMPANY ||
 		bs->ltgtype == LTG_RUSHBASE) return qfalse;
 	//
-	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_RANDOM, 0, 1);
 	if (random() > bs->thinktime * 0.1) return qfalse;
-	if (!bot_fastchat.integer) {
-		if (random() > rnd) return qfalse;
-		if (random() > 0.25) return qfalse;
-	}
-	if (BotNumActivePlayers() <= 1) return qfalse;
-	//
-	if (!BotValidChatPosition(bs)) return qfalse;
-	//
 	if (BotVisibleEnemies(bs)) return qfalse;
 	//
 	if (bs->lastkilledplayer == bs->client) {
@@ -885,11 +847,6 @@ int BotChat_Random(bot_state_t *bs) {
 	else {
 		EasyClientName(bs->lastkilledplayer, name, sizeof(name));
 	}
-	if (TeamPlayIsOn()) {
-		trap_EA_Command(bs->client, "vtaunt");
-		return qfalse;			// don't wait
-	}
-	//
 	if (random() < trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_MISC, 0, 1)) {
 		BotAI_BotInitialChat(bs, "random_misc",
 					BotRandomOpponentName(bs),	// 0
@@ -1182,5 +1139,47 @@ void BotChatTest(bot_state_t *bs) {
 					BotRandomWeaponName(),		// 5
 					NULL);
 		trap_BotEnterChat(bs->cs, 0, CHAT_ALL);
+	}
+}
+/*
+==================
+BotCanChat
+Returns true if certain conditions are met.
+==================
+*/
+int BotCanChat(bot_state_t *bs, float characteristic) {
+	float rnd;
+
+	rnd = trap_Characteristic_BFloat(bs->character, characteristic, 0, 1);
+	// Are bots allowed to chat?
+	if (bot_nochat.integer) {
+		return qfalse;
+	}
+	// Has the bot said a line previously?
+	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) {
+		return qfalse;
+	}
+	// If the fast chat is enabled, can the bot talk?
+	if (!bot_fastchat.integer && (random() > rnd * 0.5)) {
+		return qfalse;
+	} 
+	// Are there more than two players?
+	if (BotNumActivePlayers() <= 1) {
+		return qfalse;
+	}
+	// All checks passed
+	return qtrue;
+}
+/*
+==================
+BotCanChatInTournament
+Returns true if the bot can chat in Tournament mode.
+==================
+*/
+int BotCanChatInTournament(void) {
+	if (gametype == GT_TOURNAMENT) {
+		return qfalse;
+	} else {
+		return qtrue;
 	}
 }

--- a/code/game/ai_chat.h
+++ b/code/game/ai_chat.h
@@ -58,4 +58,5 @@ float BotChatTime(bot_state_t *bs);
 int BotValidChatPosition(bot_state_t *bs);
 // test the initial bot chats
 void BotChatTest(bot_state_t *bs);
-
+// validator for bot chats
+int BotCanChat(bot_state_t *bs, float characteristic);

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -142,6 +142,16 @@ void BotPrintTeamGoal(bot_state_t *bs) {
 			BotAI_Print(PRT_MESSAGE, "%s: I'm gonna take care of point B for %1.0f secs\n", netname, t);
 			break;
 		}
+		case LTG_DOMCAPTURE:
+		{
+			BotAI_Print(PRT_MESSAGE, "%s: I'm gonna capture a DOM point for %1.0f secs\n", netname, t);
+			break;
+		}
+		case LTG_DOMROAM:
+		{
+			BotAI_Print(PRT_MESSAGE, "%s: I'm gonna roam the level for %1.0f secs\n", netname, t);
+			break;
+		}
 		default:
 		{
 			if (bs->ctfroam_time > FloatTime()) {

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -968,7 +968,7 @@ void BotMatch_GetFlag(bot_state_t *bs, bot_match_t *match) {
 	//set the team goal time
 	bs->teamgoal_time = FloatTime() + CTF_GETFLAG_TIME;
 	// get an alternate route in ctf
-	if (G_UsesTeamFlags(gametype)) {
+	if (G_UsesTeamFlags(gametype) || gametype == GT_POSSESSION) {
 		//get an alternative route goal towards the enemy base
 		BotGetAlternateRouteGoal(bs, BotOppositeTeam(bs));
 	}
@@ -990,14 +990,17 @@ void BotMatch_AttackEnemyBase(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
+	// In gametypes where the enemy flag must be taken, they are sent to retrieve it.
 	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
 		BotMatch_GetFlag(bs, match);
-	}
-	else if (gametype == GT_1FCTF || G_UsesTeamObelisks(gametype)) {
+	// In gametypes where a neutral flag must be taken, they are sent to retrieve it.
+	} else if (G_UsesTheWhiteFlag(gametype)) {
+		BotMatch_GetFlag(bs, match);
+	// Check for gametypes where a neutral objective appears.
+	} else if ((G_UsesTeamFlags(gametype) && G_UsesTheWhiteFlag(gametype)) || G_UsesTeamObelisks(gametype)) {
 		if (!redobelisk.areanum || !blueobelisk.areanum)
 			return;
-	}
-	else {
+	} else {
 		return;
 	}
 	//if not addressed to this bot
@@ -1934,7 +1937,7 @@ int BotMatchMessage(bot_state_t *bs, char *message) {
 			BotMatch_Patrol(bs, &match);
 			break;
 		}
-		//CTF & 1FCTF
+		//CTF & 1FCTF & Possession
 		case MSG_GETFLAG:				//ctf get the enemy flag
 		{
 			BotMatch_GetFlag(bs, &match);

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -584,37 +584,6 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 		}
 		return qtrue;
 	}
-        //if (bs->ltgtype == LTG_DOMHOLD &&
-	//			bs->defendaway_time < FloatTime()) {
-            //check for bot typing status message
-		/*if (bs->teammessage_time && bs->teammessage_time < FloatTime()) {
-			trap_BotGoalName(bs->teamgoal.number, buf, sizeof(buf));
-			BotAI_BotInitialChat(bs, "dd_start_pointb", buf, NULL);
-			trap_BotEnterChat(bs->cs, 0, CHAT_TEAM);
-			//BotVoiceChatOnly(bs, -1, VOICECHAT_ONDEFENSE);
-			bs->teammessage_time = 0;
-		}*/
-		//set the bot goal
-	//	memcpy(goal, &bs->teamgoal, sizeof(bot_goal_t));
-		//if very close... go away for some time
-	//	VectorSubtract(goal->origin, bs->origin, dir);
-	//	if (VectorLengthSquared(dir) < Square(30)) {
-			/*trap_BotResetAvoidReach(bs->ms);
-			bs->defendaway_time = FloatTime() + 3 + 3 * random();
-			if (BotHasPersistantPowerupAndWeapon(bs)) {
-				bs->defendaway_range = 100;
-			}
-			else {
-				bs->defendaway_range = 350;
-			}*/
-          //              memcpy(&bs->teamgoal, &dom_points_bot[((rand()) % (level.domination_points_count))], sizeof(bot_goal_t));
-            //            BotAlternateRoute(bs, &bs->teamgoal);
-              //          BotSetTeamStatus(bs);
-
-		//}
-		//return qtrue;
-
-       // }
 	//if defending a key area
 	if (bs->ltgtype == LTG_DEFENDKEYAREA && !retreat &&
 				bs->defendaway_time < FloatTime()) {
@@ -1115,6 +1084,39 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 				bs->harvestaway_time = FloatTime() + 4 + 3 * random();
 			}
 			return qtrue;
+		}
+	} else if (gametype == GT_DOMINATION) {
+		switch (bs->ltgtype) {
+			case LTG_DOMCAPTURE:
+				if(bs->defendaway_time < FloatTime()) {
+					//check for bot typing status message
+					if (bs->teammessage_time && bs->teammessage_time < FloatTime()) {
+						trap_BotGoalName(bs->teamgoal.number, buf, sizeof(buf));
+						BotAI_BotInitialChat(bs, "dom_start_point", buf, NULL);
+						trap_BotEnterChat(bs->cs, 0, CHAT_TEAM);
+						bs->teammessage_time = 0;
+					}
+					//set the bot goal
+					memcpy(goal, &bs->teamgoal, sizeof(bot_goal_t));
+					//if very close... go away for some time
+					VectorSubtract(goal->origin, bs->origin, dir);
+					if (VectorLengthSquared(dir) < Square(30)) {
+						trap_BotResetAvoidReach(bs->ms);
+						bs->defendaway_time = FloatTime() + 3 + 3 * random();
+						if (BotHasPersistantPowerupAndWeapon(bs)) {
+							bs->defendaway_range = 100;
+						}
+						else {
+							bs->defendaway_range = 350;
+						}
+						memcpy(&bs->teamgoal, &dom_points_bot[((rand()) % (level.domination_points_count))], sizeof(bot_goal_t));
+						BotAlternateRoute(bs, &bs->teamgoal);
+						BotSetTeamStatus(bs);
+					}
+				}
+				break;
+			case LTG_DOMROAM:
+				break;
 		}
 	}
 //#endif

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -196,11 +196,7 @@ int BotNearbyGoal(bot_state_t *bs, int tfl, bot_goal_t *ltg, float range) {
 	//check if the bot should go for air
 	if (BotGoForAir(bs, tfl, ltg, range)) return qtrue;
 	// if the bot is carrying a flag or cubes
-	if (BotCTFCarryingFlag(bs)
-#ifdef MISSIONPACK
-		|| Bot1FCTFCarryingFlag(bs) || BotHarvesterCarryingCubes(bs)
-#endif
-		) {
+	if (BotCTFCarryingFlag(bs) || Bot1FCTFCarryingFlag(bs) || BotHarvesterCarryingCubes(bs)) {
 		//if the bot is just a few secs away from the base 
 		if (trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin,
 				bs->teamgoal.areanum, TFL_DEFAULT) < 300) {
@@ -1968,13 +1964,11 @@ int AINode_Seek_LTG(bot_state_t *bs)
 		if (bs->ltgtype == LTG_DEFENDKEYAREA) range = 400;
 		else range = 150;
 		//
-#ifdef CTF
 		if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
 			//if carrying a flag the bot shouldn't be distracted too much
 			if (BotCTFCarryingFlag(bs))
 				range = 50;
 		}
-#endif //CTF
 		else if (G_UsesTheWhiteFlag(gametype)) {
 			if (Bot1FCTFCarryingFlag(bs))
 				range = 50;
@@ -2179,12 +2173,10 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 	}
 	//if the enemy is not visible
 	if (!BotEntityVisible(bs->entitynum, bs->eye, bs->viewangles, 360, bs->enemy)) {
-#ifdef MISSIONPACK
 		if (bs->enemy == redobelisk.entitynum || bs->enemy == blueobelisk.entitynum) {
 			AIEnter_Battle_Chase(bs, "battle fight: obelisk out of sight");
 			return qfalse;
 		}
-#endif
 		if (BotWantsToChase(bs)) {
 			AIEnter_Battle_Chase(bs, "battle fight: enemy out of sight");
 			return qfalse;
@@ -2488,13 +2480,11 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 	if (bs->check_time < FloatTime()) {
 		bs->check_time = FloatTime() + 1;
 		range = 150;
-#ifdef CTF
 		if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
 			//if carrying a flag the bot shouldn't be distracted too much
 			if (BotCTFCarryingFlag(bs))
 				range = 50;
 		}
-#endif //CTF
 		else if (G_UsesTheWhiteFlag(gametype)) {
 			if (Bot1FCTFCarryingFlag(bs))
 				range = 50;

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -1405,6 +1405,8 @@ int BotSelectActivateWeapon(bot_state_t *bs) {
 		return WEAPONINDEX_ROCKET_LAUNCHER;
 	else if (bs->inventory[INVENTORY_BFG10K] > 0 && bs->inventory[INVENTORY_BFGAMMO] > 0)
 		return WEAPONINDEX_BFG;
+	else if (bs->inventory[INVENTORY_GRAPPLINGHOOK] > 0)
+		return WEAPONINDEX_GRAPPLING_HOOK;
 	else {
 		return -1;
 	}

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -1560,7 +1560,9 @@ int AINode_Seek_ActivateEntity(bot_state_t *bs) {
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	if (BotCanAndWantsToUseTheGrapple(bs)) {
+		bs->tfl |= TFL_GRAPPLEHOOK;
+	}
 	// if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	// map specific code
@@ -1773,7 +1775,9 @@ int AINode_Seek_NBG(bot_state_t *bs) {
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	if (BotCanAndWantsToUseTheGrapple(bs)) {
+		bs->tfl |= TFL_GRAPPLEHOOK;
+	}
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -1916,7 +1920,9 @@ int AINode_Seek_LTG(bot_state_t *bs)
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	if (BotCanAndWantsToUseTheGrapple(bs)) {
+		bs->tfl |= TFL_GRAPPLEHOOK;
+	}
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -2190,7 +2196,9 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 	BotBattleUseItems(bs);
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	if (BotCanAndWantsToUseTheGrapple(bs)) {
+		bs->tfl |= TFL_GRAPPLEHOOK;
+	}
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -2283,7 +2291,9 @@ int AINode_Battle_Chase(bot_state_t *bs)
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	if (BotCanAndWantsToUseTheGrapple(bs)) {
+		bs->tfl |= TFL_GRAPPLEHOOK;
+	}
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -2420,7 +2430,9 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	if (BotCanAndWantsToUseTheGrapple(bs)) {
+		bs->tfl |= TFL_GRAPPLEHOOK;
+	}
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//map specific code
@@ -2597,7 +2609,9 @@ int AINode_Battle_NBG(bot_state_t *bs) {
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	if (BotCanAndWantsToUseTheGrapple(bs)) {
+		bs->tfl |= TFL_GRAPPLEHOOK;
+	}
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -2692,3 +2706,22 @@ int AINode_Battle_NBG(bot_state_t *bs) {
 	return qtrue;
 }
 
+/*
+==================
+BotCanAndWantsToUseTheGrapple
+Before switching to the grapple, checks if the bot has it in its inventory.
+==================
+*/
+int BotCanAndWantsToUseTheGrapple(bot_state_t *bs) {
+	float grappler;
+	// Bots won't use the grapple if:
+	// * grappling for them is disabled
+	if (!bot_grapple.integer) return qfalse;
+	// * they don't have the Grappling Hook
+	if (!bs->inventory[INVENTORY_GRAPPLINGHOOK]) return qfalse;
+	// * if their own bot file settings allow for it
+	grappler = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_GRAPPLE_USER, 0, 1);
+	if (grappler < 0.5) return qfalse;
+	// Else they'll be happy to use it
+	return qtrue;
+}

--- a/code/game/ai_dmnet.h
+++ b/code/game/ai_dmnet.h
@@ -58,4 +58,5 @@ int AINode_Battle_NBG(bot_state_t *bs);
 
 void BotResetNodeSwitches(void);
 void BotDumpNodeSwitches(bot_state_t *bs);
+int BotCanAndWantsToUseTheGrapple(bot_state_t *bs);
 

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -2447,28 +2447,33 @@ BotCanAndWantsToRocketJump
  */
 int BotCanAndWantsToRocketJump(bot_state_t *bs) {
 	float rocketjumper;
-
-	//if rocket jumping is disabled
+	// Bots won't rocketjump if:
+	// * rocket jumping for them is disabled
 	if (!bot_rocketjump.integer) return qfalse;
-	//if no rocket launcher
-	if (bs->inventory[INVENTORY_ROCKETLAUNCHER] <= 0) return qfalse;
-	//if low on rockets
+	// * they can use and have the Grappling Hook (it's the safer alternative)
+	if (bot_grapple.integer && bs->inventory[INVENTORY_GRAPPLINGHOOK]) return qfalse;
+	// * they don't have the Rocket Launcher
+	if (!bs->inventory[INVENTORY_ROCKETLAUNCHER]) return qfalse;
+	// * they have less than three rockets
 	if (bs->inventory[INVENTORY_ROCKETS] < 3) return qfalse;
-	//Sago: Special rule - always happy to rocket jump in elimination, eCTF end LMS if
+	// * [Sago: Special rule - always happy to rocket jump in round-based modes if selfdamage is disabled]
 	if (G_IsARoundBasedGametype(g_gametype.integer) && g_elimination_selfdamage.integer == 0) {
 		return qtrue;
 	}
-	//never rocket jump with the Quad
-	if (bs->inventory[INVENTORY_QUAD]) return qfalse;
-	//if low on health
+	// * they have the Quad
+	if (bs->inventory[INVENTORY_QUAD]) {
+		return qfalse;
+	}
+	// * if -60 HP
 	if (bs->inventory[INVENTORY_HEALTH] < 60) return qfalse;
-	//if not full health
+	// * if, while +90HP, they have -40AP
 	if (bs->inventory[INVENTORY_HEALTH] < 90) {
-		//if the bot has insufficient armor
 		if (bs->inventory[INVENTORY_ARMOR] < 40) return qfalse;
 	}
+	// * if their own bot file settings allow for it
 	rocketjumper = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_WEAPONJUMPING, 0, 1);
 	if (rocketjumper < 0.5) return qfalse;
+	// Else they'll be happy to jump
 	return qtrue;
 }
 

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -1777,7 +1777,7 @@ void BotCheckItemPickup(bot_state_t *bs, int *oldinventory) {
 							((!(G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype))) ||
 							((bs->redflagstatus == 0) &&
 							(bs->blueflagstatus == 0))) &&
-							((gametype != GT_1FCTF) ||
+							(G_UsesTheWhiteFlag(gametype) ||
 							(bs->neutralflagstatus == 0))) {
 						// tell the leader we want to be on offence
 						BotVoiceChat(bs, leader, VOICECHAT_WANTONOFFENSE);
@@ -1801,7 +1801,7 @@ void BotCheckItemPickup(bot_state_t *bs, int *oldinventory) {
 						((!(G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype))) ||
 						((bs->redflagstatus == 0) &&
 						(bs->blueflagstatus == 0))) &&
-						((gametype != GT_1FCTF) ||
+						(G_UsesTheWhiteFlag(gametype) ||
 						(bs->neutralflagstatus == 0))) {
 
 					// tell the leader we want to be on defense
@@ -1941,9 +1941,9 @@ void BotUseKamikaze(bot_state_t *bs) {
 				return;
 			}
 		}
-	} else if (gametype == GT_1FCTF) {
-		//never use kamikaze if the team flag carrier is visible
-		if (Bot1FCTFCarryingFlag(bs))
+	} else if (G_UsesTheWhiteFlag(gametype)) {
+		//never use kamikaze if the team flag carrier is visible in 1FCTF
+		if (Bot1FCTFCarryingFlag(bs) && gametype == GT_1FCTF)
 			return;
 		c = BotTeamFlagCarrierVisible(bs);
 		if (c >= 0) {
@@ -2052,9 +2052,9 @@ void BotUseInvulnerability(bot_state_t *bs) {
 				return;
 			}
 		}
-	} else if (gametype == GT_1FCTF) {
+	} else if (G_UsesTheWhiteFlag(gametype)) {
 		//never use kamikaze if the team flag carrier is visible
-		if (Bot1FCTFCarryingFlag(bs))
+		if (Bot1FCTFCarryingFlag(bs) && gametype == GT_1FCTF)
 			return;
 		c = BotEnemyFlagCarrierVisible(bs);
 		if (c >= 0)

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -2395,10 +2395,8 @@ int BotWantsToRetreat(bot_state_t *bs) {
 		BotEntityInfo(bs->enemy, &entinfo);
 		// if the enemy is carrying a flag
 		if (EntityCarriesFlag(&entinfo)) return qfalse;
-#ifdef MISSIONPACK
 		// if the enemy is carrying cubes
 		if (EntityCarriesCubes(&entinfo)) return qfalse;
-#endif
 	}
 	//if the bot is getting the flag
 	if (bs->ltgtype == LTG_GETFLAG)

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -2288,6 +2288,7 @@ int TeamPlayIsOn(void) {
 /*
 ==================
 BotAggression
+Checks in order to decide if the bot is going to act more aggressively.
 ==================
  */
 float BotAggression(bot_state_t *bs) {
@@ -2336,19 +2337,23 @@ float BotAggression(bot_state_t *bs) {
 /*
 ==================
 BotFeelingBad
+Check for certain conditions to decide strategic planning (a.k.a. retreating)
 ==================
  */
 float BotFeelingBad(bot_state_t *bs) {
+	if (bs->inventory[INVENTORY_HEALTH] < 20 && bs->inventory[INVENTORY_ARMOR] < 10) {
+		return 100;
+	}
 	if (bs->weaponnum == WP_GAUNTLET) {
 		return 100;
 	}
-	if (bs->inventory[INVENTORY_HEALTH] < 40) {
+	if (bs->inventory[INVENTORY_HEALTH] < 40 && bs->inventory[INVENTORY_ARMOR] < 20) {
 		return 100;
 	}
 	if (bs->weaponnum == WP_MACHINEGUN) {
 		return 90;
 	}
-	if (bs->inventory[INVENTORY_HEALTH] < 60) {
+	if (bs->inventory[INVENTORY_HEALTH] < 60 && bs->inventory[INVENTORY_ARMOR] < 30) {
 		return 80;
 	}
 	return 0;
@@ -2443,11 +2448,6 @@ int BotWantsToChase(bot_state_t *bs) {
 		BotEntityInfo(bs->enemy, &entinfo);
 		// always chase if the enemy is carrying cubes
 		if (EntityCarriesCubes(&entinfo)) return qtrue;
-	} else if (gametype == GT_POSSESSION) {
-		//always chase if the enemy is carrying a flag
-		BotEntityInfo(bs->enemy, &entinfo);
-		if (EntityCarriesFlag(&entinfo))
-			return qtrue;
 	}
 	//if the bot is getting the flag
 	if (bs->ltgtype == LTG_GETFLAG)

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -1840,11 +1840,8 @@ void BotUpdateInventory(bot_state_t *bs) {
 	bs->inventory[INVENTORY_BFG10K] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_BFG)) != 0;
 	bs->inventory[INVENTORY_GRAPPLINGHOOK] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_GRAPPLING_HOOK)) != 0;
 	bs->inventory[INVENTORY_NAILGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_NAILGUN)) != 0;
-	;
 	bs->inventory[INVENTORY_PROXLAUNCHER] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_PROX_LAUNCHER)) != 0;
-	;
 	bs->inventory[INVENTORY_CHAINGUN] = (bs->cur_ps.stats[STAT_WEAPONS] & (1 << WP_CHAINGUN)) != 0;
-	;
 	//ammo
 	bs->inventory[INVENTORY_SHELLS] = bs->cur_ps.ammo[WP_SHOTGUN];
 	bs->inventory[INVENTORY_BULLETS] = bs->cur_ps.ammo[WP_MACHINEGUN];
@@ -2423,7 +2420,7 @@ int BotWantsToChase(bot_state_t *bs) {
 		BotEntityInfo(bs->enemy, &entinfo);
 		if (EntityCarriesFlag(&entinfo))
 			return qtrue;
-	} else if (gametype == GT_1FCTF) {
+	} else if (G_UsesTheWhiteFlag(gametype)) {
 		//never chase if carrying the flag
 		if (Bot1FCTFCarryingFlag(bs))
 			return qfalse;

--- a/code/game/ai_dmq3.h
+++ b/code/game/ai_dmq3.h
@@ -173,6 +173,10 @@ int ClientOnSameTeamFromName(bot_state_t *bs, char *name);
 int BotPointAreaNum(vec3_t origin);
 //
 void BotMapScripts(bot_state_t *bs);
+// DD and DOM goal seek functions
+void BotDDSeekGoals(bot_state_t *bs);
+void BotDomSeekGoals(bot_state_t *bs);
+void BotDomCurrentPoint(void);
 
 //ctf flags
 #define CTF_FLAG_NONE		0
@@ -198,3 +202,4 @@ extern bot_goal_t ctf_neutralflag;
 extern bot_goal_t redobelisk;
 extern bot_goal_t blueobelisk;
 extern bot_goal_t neutralobelisk;
+extern bot_goal_t dom_points_bot[MAX_DOMINATION_POINTS];

--- a/code/game/ai_main.h
+++ b/code/game/ai_main.h
@@ -61,9 +61,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 //Long term DD goals
 #define LTG_POINTA				16	//Take/Defend point A
 #define LTG_POINTB				17	//Take/Defend point B
-//Long term DD goals
-#define LTG_DOMROAM                             18      //Go for a non taken point.
-#define LTG_DOMHOLD                             19      //Pick a point and hold it.
+//Long term DOM goals
+#define LTG_DOMROAM					18	//Go for a non taken point.
+#define LTG_DOMCAPTURE				19	//Pick a point and hold it.
 //some goal dedication times
 #define TEAM_HELP_TIME				60	//1 minute teamplay help time
 #define TEAM_ACCOMPANY_TIME			600	//10 minutes teamplay accompany time


### PR DESCRIPTION
Redoing the pull-request again. Six months without coding practice leave quite a bit of rust. :/

Anyway. The commits are self-explanatory. These changes aim to improve offline botplay for the Domination and Possession gamemodes.

In Domination, bots are now willing to take the control points, and as a result, matches are more difficult than ever.

As for Possession, they prioritize taking the flag and chasing the flag carrier. Hopefully they also go to get the flag as well.

In addition, there's a new restriction for rocketjumping that checks if the bots can use the grapple and have it in their inventory. If they have the grapple and can use it (the safer alternative to rocket jumping) they won't use rocket jumps.