### PR TITLE
[Testing required] Developer mode with two modes for coders and mappers.

### DIFF
--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -509,7 +509,7 @@ CG_StartOrbit_f
 
 static void CG_StartOrbit_f(void) {
 	// If not in code development mode, exit.
-	if (!cg_developer.integer == 1) {
+	if (!cg_developer.integer & DEVMODE_FOR_CODERS) {
 		return;
 	}
 	if (cg_cameraOrbit.value != 0) {

--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -509,7 +509,7 @@ CG_StartOrbit_f
 
 static void CG_StartOrbit_f(void) {
 	// If not in code development mode, exit.
-	if (!cg_developer.integer & DEVMODE_FOR_CODERS) {
+	if (!(cg_developer.integer & DEVMODE_FOR_CODERS)) {
 		return;
 	}
 	if (cg_cameraOrbit.value != 0) {

--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -508,7 +508,8 @@ CG_StartOrbit_f
  */
 
 static void CG_StartOrbit_f(void) {
-	if (!cg_developer.integer) {
+	// If not in code development mode, exit.
+	if (!cg_developer.integer == 1) {
 		return;
 	}
 	if (cg_cameraOrbit.value != 0) {

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1002,7 +1002,7 @@ static float CG_DrawDoubleDominationThings( float y ) {
 	statusB = cgs.blueflag;
 
 	// This is only useful in code development mode.
-	if(!cg_developer.integer == 1) {
+	if(!cg_developer.integer & DEVMODE_FOR_CODERS) {
 		return;
 	}
 	

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1001,8 +1001,8 @@ static float CG_DrawDoubleDominationThings( float y ) {
 	statusA = cgs.redflag;
 	statusB = cgs.blueflag;
 
-	// This is only useful in Developer mode.
-	if(!cg_developer.integer) {
+	// This is only useful in code development mode.
+	if(!cg_developer.integer == 1) {
 		return;
 	}
 	

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1002,7 +1002,7 @@ static float CG_DrawDoubleDominationThings( float y ) {
 	statusB = cgs.blueflag;
 
 	// This is only useful in code development mode.
-	if(!cg_developer.integer & DEVMODE_FOR_CODERS) {
+	if (!cg_developer.integer & DEVMODE_FOR_CODERS) {
 		return;
 	}
 	

--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -699,7 +699,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 	es = &cent->currentState;
 	event = es->event & ~EV_EVENT_BITS;
 
-	if (cg_debugEvents.integer) {
+	if (cg_debugEvents.integer && (cg_developer & DEVMODE_FOR_MAPPERS)) {
 		CG_Printf("ent:%3i  event:%3i ", es->number, event);
 	}
 

--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -699,7 +699,7 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 	es = &cent->currentState;
 	event = es->event & ~EV_EVENT_BITS;
 
-	if (cg_debugEvents.integer && (cg_developer & DEVMODE_FOR_MAPPERS)) {
+	if (cg_debugEvents.integer && (cg_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		CG_Printf("ent:%3i  event:%3i ", es->number, event);
 	}
 

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1416,7 +1416,7 @@ extern vmCvar_t cg_enableQ;		// leilei
 extern vmCvar_t cg_enableFS;		// leilei
 //unlagged - client options
 extern vmCvar_t cg_delag;
-//extern vmCvar_t cg_debugDelag;
+extern vmCvar_t cg_debugDelag;
 //extern vmCvar_t cg_drawBBox;
 extern vmCvar_t cg_cmdTimeNudge;
 extern vmCvar_t sv_fps;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -237,7 +237,7 @@ vmCvar_t cg_enableQ;
 
 //unlagged - client options
 vmCvar_t cg_delag;
-//vmCvar_t cg_debugDelag;
+vmCvar_t cg_debugDelag;
 //vmCvar_t cg_drawBBox;
 vmCvar_t cg_cmdTimeNudge;
 vmCvar_t sv_fps;
@@ -461,7 +461,7 @@ static cvarTable_t cvarTable[] = {// bk001129
 	{ &cg_oldPlasma, "cg_oldPlasma", "1", CVAR_ARCHIVE},
 	//unlagged - client options
 	{ &cg_delag, "cg_delag", "1", CVAR_ARCHIVE | CVAR_USERINFO},
-	//	{ &cg_debugDelag, "cg_debugDelag", "0", CVAR_USERINFO | CVAR_CHEAT },
+	{ &cg_debugDelag, "cg_debugDelag", "0", CVAR_USERINFO | CVAR_CHEAT },
 	//	{ &cg_drawBBox, "cg_drawBBox", "0", CVAR_CHEAT },
 	{ &cg_cmdTimeNudge, "cg_cmdTimeNudge", "0", CVAR_ARCHIVE | CVAR_USERINFO},
 	// this will be automagically copied from the server

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -3099,7 +3099,7 @@ void CG_ResetPlayerEntity(centity_t *cent) {
 
 
 
-	if (cg_debugPosition.integer & DEVMODE_FOR_CODERS) {
+	if (cg_debugPosition.integer && (cg_developer & DEVMODE_FOR_CODERS) {
 		CG_Printf("%i ResetPlayerEntity yaw=%f\n", cent->currentState.number, cent->pe.torso.yawAngle);
 	}
 }

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -1322,7 +1322,7 @@ static void CG_SetLerpFrameAnimation(clientInfo_t *ci, lerpFrame_t *lf, int newA
 	lf->animation = anim;
 	lf->animationTime = lf->frameTime + anim->initialLerp;
 
-	if (cg_debugAnim.integer) {
+	if (cg_debugAnim.integer && (cg_developer.integer & DEVMODE_FOR_CODERS)) {
 		CG_Printf("Anim: %i\n", newAnimation);
 	}
 }
@@ -1394,7 +1394,7 @@ static void CG_RunLerpFrame(clientInfo_t *ci, lerpFrame_t *lf, int newAnimation,
 		}
 		if (cg.time > lf->frameTime) {
 			lf->frameTime = cg.time;
-			if (cg_debugAnim.integer) {
+			if (cg_debugAnim.integer & DEVMODE_FOR_CODERS) {
 				CG_Printf("Clamp lf->frameTime\n");
 			}
 		}
@@ -3099,7 +3099,7 @@ void CG_ResetPlayerEntity(centity_t *cent) {
 
 
 
-	if (cg_debugPosition.integer) {
+	if (cg_debugPosition.integer & DEVMODE_FOR_CODERS) {
 		CG_Printf("%i ResetPlayerEntity yaw=%f\n", cent->currentState.number, cent->pe.torso.yawAngle);
 	}
 }

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -3099,7 +3099,7 @@ void CG_ResetPlayerEntity(centity_t *cent) {
 
 
 
-	if (cg_debugPosition.integer && (cg_developer & DEVMODE_FOR_CODERS) {
+	if (cg_debugPosition.integer && (cg_developer.integer & DEVMODE_FOR_CODERS)) {
 		CG_Printf("%i ResetPlayerEntity yaw=%f\n", cent->currentState.number, cent->pe.torso.yawAngle);
 	}
 }

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -130,9 +130,9 @@ static void CG_ParseAccuracy( void ) {
 	for ( i = WP_MACHINEGUN ; i < WP_NUM_WEAPONS ; i++ ) {
 		cg.accuracys[i-WP_MACHINEGUN][0] = atoi( CG_Argv( (i-WP_MACHINEGUN)*2 + 1 ) );
 		cg.accuracys[i-WP_MACHINEGUN][1] = atoi( CG_Argv( (i-WP_MACHINEGUN)*2 + 2 ) );
-#if DEBUG
-		CG_Printf("W: %i   shots: %i   Hits: %i\n", i,cg.accuracys[i][0], cg.accuracys[i][1]);
-#endif
+		if(cg_developer.integer & DEVMODE_FOR_CODERS) {
+			CG_Printf("W: %i   shots: %i   Hits: %i\n", i,cg.accuracys[i][0], cg.accuracys[i][1]);
+		}
 	}
 
 }

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -130,7 +130,7 @@ static void CG_ParseAccuracy( void ) {
 	for ( i = WP_MACHINEGUN ; i < WP_NUM_WEAPONS ; i++ ) {
 		cg.accuracys[i-WP_MACHINEGUN][0] = atoi( CG_Argv( (i-WP_MACHINEGUN)*2 + 1 ) );
 		cg.accuracys[i-WP_MACHINEGUN][1] = atoi( CG_Argv( (i-WP_MACHINEGUN)*2 + 2 ) );
-		if(cg_developer.integer & DEVMODE_FOR_CODERS) {
+		if (cg_developer.integer & DEVMODE_FOR_CODERS) {
 			CG_Printf("W: %i   shots: %i   Hits: %i\n", i,cg.accuracys[i][0], cg.accuracys[i][1]);
 		}
 	}

--- a/code/cgame/cg_unlagged.c
+++ b/code/cgame/cg_unlagged.c
@@ -77,7 +77,7 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			/* THIS IS FOR DEBUGGING!
 			 you definitely *will* want something like this to test the backward reconciliation
 			// to make sure it's working *exactly* right */
-			if ( cg_debugDelag.integer && (cg_developer.integer & DEVMODE_FOR_CODERS)) {
+			if (cg_debugDelag.integer && (cg_developer.integer & DEVMODE_FOR_CODERS)) {
 				/* Sago: There are some problems with some unlagged code. People will just have to trust it*/
 				// trace forward
 				CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint, cent->currentState.number, CONTENTS_BODY|CONTENTS_SOLID );

--- a/code/cgame/cg_unlagged.c
+++ b/code/cgame/cg_unlagged.c
@@ -74,11 +74,11 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 			// trace forward
 			VectorMA( muzzlePoint, 8192, forward, endPoint );
 
-			// THIS IS FOR DEBUGGING!
-			// you definitely *will* want something like this to test the backward reconciliation
-			// to make sure it's working *exactly* right
-			/*if ( cg_debugDelag.integer ) {
-				* Sago: There are some problems with some unlagged code. People will just have to trust it
+			/* THIS IS FOR DEBUGGING!
+			 you definitely *will* want something like this to test the backward reconciliation
+			// to make sure it's working *exactly* right */
+			if ( cg_debugDelag.integer && (cg_developer.integer & DEVMODE_FOR_CODERS)) {
+				/* Sago: There are some problems with some unlagged code. People will just have to trust it*/
 				// trace forward
 				CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint, cent->currentState.number, CONTENTS_BODY|CONTENTS_SOLID );
 
@@ -127,7 +127,7 @@ void CG_PredictWeaponEffects( centity_t *cent ) {
 							cg.frameInterpolation, origin1[0], origin1[1], origin1[2], origin2[0], origin2[1], origin2[2]);
 					}
 				}
-			}*/
+			}
 
 			// find the rail's end point
 			CG_Trace( &trace, muzzlePoint, vec3_origin, vec3_origin, endPoint, cg.predictedPlayerState.clientNum, CONTENTS_SOLID );

--- a/code/game/ai_chat.c
+++ b/code/game/ai_chat.c
@@ -381,7 +381,10 @@ BotChat_EnterGame
 int BotChat_EnterGame(bot_state_t *bs) {
 	char name[32];
 	float rnd;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	//don't chat in teamplay
@@ -414,7 +417,10 @@ BotChat_ExitGame
 int BotChat_ExitGame(bot_state_t *bs) {
 	char name[32];
 	float rnd;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	//don't chat in teamplay
@@ -447,7 +453,10 @@ BotChat_StartLevel
 int BotChat_StartLevel(bot_state_t *bs) {
 	char name[32];
 	float rnd;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
@@ -479,7 +488,10 @@ BotChat_EndLevel
 int BotChat_EndLevel(bot_state_t *bs) {
 	char name[32];
 	float rnd;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
@@ -539,7 +551,10 @@ BotChat_Death
 int BotChat_Death(bot_state_t *bs) {
 	char name[32];
 	float rnd;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_DEATH, 0, 1);
@@ -638,7 +653,10 @@ BotChat_Kill
 int BotChat_Kill(bot_state_t *bs) {
 	char name[32];
 	float rnd;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_KILL, 0, 1);
@@ -700,7 +718,10 @@ BotChat_EnemySuicide
 int BotChat_EnemySuicide(bot_state_t *bs) {
 	char name[32];
 	float rnd;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	if (BotNumActivePlayers() <= 1) return qfalse;
@@ -735,7 +756,10 @@ int BotChat_HitTalking(bot_state_t *bs) {
 	char name[32], *weap;
 	int lasthurt_client;
 	float rnd;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	if (BotNumActivePlayers() <= 1) return qfalse;
@@ -775,7 +799,10 @@ int BotChat_HitNoDeath(bot_state_t *bs) {
 	float rnd;
 	int lasthurt_client;
 	aas_entityinfo_t entinfo;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	lasthurt_client = g_entities[bs->client].client->lasthurt_client;
 	if (!lasthurt_client) return qfalse;
 	if (lasthurt_client == bs->client) return qfalse;
@@ -819,7 +846,10 @@ int BotChat_HitNoKill(bot_state_t *bs) {
 	char name[32], *weap;
 	float rnd;
 	aas_entityinfo_t entinfo;
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	if (BotNumActivePlayers() <= 1) return qfalse;
@@ -856,7 +886,10 @@ BotChat_Random
 int BotChat_Random(bot_state_t *bs) {
 	float rnd;
 	char name[32];
-
+	//don't chat in developer mode
+	if (bot_developer.integer >= 1) {
+		return qfalse;
+	}
 	if (bot_nochat.integer) return qfalse;
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;

--- a/code/game/ai_chat.c
+++ b/code/game/ai_chat.c
@@ -382,7 +382,8 @@ int BotChat_EnterGame(bot_state_t *bs) {
 	char name[32];
 	float rnd;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -418,7 +419,8 @@ int BotChat_ExitGame(bot_state_t *bs) {
 	char name[32];
 	float rnd;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -454,7 +456,8 @@ int BotChat_StartLevel(bot_state_t *bs) {
 	char name[32];
 	float rnd;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -489,7 +492,8 @@ int BotChat_EndLevel(bot_state_t *bs) {
 	char name[32];
 	float rnd;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -552,7 +556,8 @@ int BotChat_Death(bot_state_t *bs) {
 	char name[32];
 	float rnd;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -654,7 +659,8 @@ int BotChat_Kill(bot_state_t *bs) {
 	char name[32];
 	float rnd;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -719,7 +725,8 @@ int BotChat_EnemySuicide(bot_state_t *bs) {
 	char name[32];
 	float rnd;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -757,7 +764,8 @@ int BotChat_HitTalking(bot_state_t *bs) {
 	int lasthurt_client;
 	float rnd;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -800,7 +808,8 @@ int BotChat_HitNoDeath(bot_state_t *bs) {
 	int lasthurt_client;
 	aas_entityinfo_t entinfo;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	lasthurt_client = g_entities[bs->client].client->lasthurt_client;
@@ -847,7 +856,8 @@ int BotChat_HitNoKill(bot_state_t *bs) {
 	float rnd;
 	aas_entityinfo_t entinfo;
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;
@@ -887,7 +897,8 @@ int BotChat_Random(bot_state_t *bs) {
 	float rnd;
 	char name[32];
 	//don't chat in developer mode
-	if (bot_developer.integer >= 1) {
+	if ((bot_developer.integer & DEVMODE_FOR_CODERS) ||
+			(bot_developer.integer & DEVMODE_FOR_MAPPERS)) {
 		return qfalse;
 	}
 	if (bot_nochat.integer) return qfalse;

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -67,8 +67,8 @@ void BotPrintTeamGoal(bot_state_t *bs) {
 	char netname[MAX_NETNAME];
 	float t;
 
-	//If not in the proper developer mode, exit.
-	if (bot_developer.integer != 1) {
+	//If not in the coder developer mode, exit.
+	if (!(bot_developer.integer & DEVMODE_FOR_CODERS)) {
 		return;
 	}
 
@@ -599,7 +599,7 @@ void BotMatch_HelpAccompany(bot_state_t *bs, bot_match_t *match) {
 		BotRememberLastOrderedTask(bs);
 	}
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -648,7 +648,7 @@ void BotMatch_DefendKeyArea(bot_state_t *bs, bot_match_t *match) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -698,7 +698,7 @@ void BotMatch_TakeA(bot_state_t *bs, bot_match_t *match) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -748,7 +748,7 @@ void BotMatch_TakeB(bot_state_t *bs, bot_match_t *match) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -789,7 +789,7 @@ void BotMatch_GetItem(bot_state_t *bs, bot_match_t *match) {
 	//
 	BotSetTeamStatus(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -882,7 +882,7 @@ void BotMatch_Camp(bot_state_t *bs, bot_match_t *match) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -922,7 +922,7 @@ void BotMatch_Patrol(bot_state_t *bs, bot_match_t *match) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -977,7 +977,7 @@ void BotMatch_GetFlag(bot_state_t *bs, bot_match_t *match) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -1024,7 +1024,7 @@ void BotMatch_AttackEnemyBase(bot_state_t *bs, bot_match_t *match) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -1067,7 +1067,7 @@ void BotMatch_Harvest(bot_state_t *bs, bot_match_t *match) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -1112,7 +1112,7 @@ void BotMatch_RushBase(bot_state_t *bs, bot_match_t *match) {
 	//
 	BotSetTeamStatus(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -1199,7 +1199,7 @@ void BotMatch_ReturnFlag(bot_state_t *bs, bot_match_t *match) {
 	//
 	BotSetTeamStatus(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -1822,7 +1822,7 @@ void BotMatch_Kill(bot_state_t *bs, bot_match_t *match) {
 	//
 	BotSetTeamStatus(bs);
 	// Actual outputting of the message requires developer mode.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -58,7 +58,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 int notleader[MAX_CLIENTS];
 
-#ifdef DEBUG
 /*
 ==================
 BotPrintTeamGoal
@@ -67,6 +66,11 @@ BotPrintTeamGoal
 void BotPrintTeamGoal(bot_state_t *bs) {
 	char netname[MAX_NETNAME];
 	float t;
+
+	//If not in the proper developer mode, exit.
+	if (bot_developer.integer != 1) {
+		return;
+	}
 
 	ClientName(bs->client, netname, sizeof(netname));
 	t = bs->teamgoal_time - FloatTime();
@@ -154,7 +158,6 @@ void BotPrintTeamGoal(bot_state_t *bs) {
 		}
 	}
 }
-#endif //DEBUG
 
 /*
 ==================
@@ -595,9 +598,10 @@ void BotMatch_HelpAccompany(bot_state_t *bs, bot_match_t *match) {
 		// remember last ordered task
 		BotRememberLastOrderedTask(bs);
 	}
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -643,9 +647,10 @@ void BotMatch_DefendKeyArea(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -692,9 +697,10 @@ void BotMatch_TakeA(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -741,9 +747,10 @@ void BotMatch_TakeB(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -781,9 +788,10 @@ void BotMatch_GetItem(bot_state_t *bs, bot_match_t *match) {
 	bs->teamgoal_time = FloatTime() + TEAM_GETITEM_TIME;
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -873,9 +881,10 @@ void BotMatch_Camp(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -912,9 +921,10 @@ void BotMatch_Patrol(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -966,9 +976,10 @@ void BotMatch_GetFlag(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1012,9 +1023,10 @@ void BotMatch_AttackEnemyBase(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1054,9 +1066,10 @@ void BotMatch_Harvest(bot_state_t *bs, bot_match_t *match) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1098,9 +1111,10 @@ void BotMatch_RushBase(bot_state_t *bs, bot_match_t *match) {
 	bs->rushbaseaway_time = 0;
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1184,9 +1198,10 @@ void BotMatch_ReturnFlag(bot_state_t *bs, bot_match_t *match) {
 	bs->rushbaseaway_time = 0;
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1239,7 +1254,7 @@ void BotMatch_LeaveSubteam(bot_state_t *bs, bot_match_t *match) {
 
 /*
 ==================
-BotMatch_LeaveSubteam
+BotMatch_WhichTeam
 ==================
 */
 void BotMatch_WhichTeam(bot_state_t *bs, bot_match_t *match) {
@@ -1806,9 +1821,10 @@ void BotMatch_Kill(bot_state_t *bs, bot_match_t *match) {
 	bs->teamgoal_time = FloatTime() + TEAM_KILL_SOMEONE;
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Actual outputting of the message requires developer mode.
+	if (bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -103,7 +103,7 @@ void BotRecordNodeSwitch(bot_state_t *bs, char *node, char *str, char *s) {
 	ClientName(bs->client, netname, sizeof(netname));
 	Com_sprintf(nodeswitch[numnodeswitches], 144, "%s at %2.1f entered %s: %s from %s\n", netname, FloatTime(), node, str, s);
 	// Developer mode outputs a message.
-	if (bot_developer.integer == 1) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotAI_Print(PRT_MESSAGE, "%s", nodeswitch[numnodeswitches]);
 	}
 	numnodeswitches++;
@@ -160,7 +160,7 @@ int BotGoForAir(bot_state_t *bs, int tfl, bot_goal_t *ltg, float range) {
 	//if the bot needs air
 	if (bs->lastair_time < FloatTime() - 6) {
 		// Developer mode outputs a message.
-		if(bot_developer.integer == 1) {
+		if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 			BotAI_Print(PRT_MESSAGE, "going for air\n");
 		}
 		//if we can find an air goal
@@ -310,7 +310,7 @@ int BotGetItemLongTermGoal(bot_state_t *bs, int tfl, bot_goal_t *goal) {
 		}
 		else {//the bot gets sorta stuck with all the avoid timings, shouldn't happen though
 			// Developer mode outputs a message.
-			if(bot_developer.integer == 1){
+			if(bot_developer.integer & DEVMODE_FOR_CODERS){
 				char netname[128];
 				BotAI_Print(PRT_MESSAGE, "%s: no valid ltg (probably stuck)\n", ClientName(bs->client, netname, sizeof(netname)));
 			}
@@ -1597,7 +1597,7 @@ int AINode_Seek_ActivateEntity(bot_state_t *bs) {
 		// if the entity the bot shoots at moved
 		if (!VectorCompare(bs->activatestack->origin, entinfo.origin)) {
 			// Developer mode outputs a message.
-			if(bot_developer.integer == 1) {
+			if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 				BotAI_Print(PRT_MESSAGE, "hit shootable button or trigger\n");
 			}
 			bs->activatestack->time = 0;
@@ -1625,7 +1625,7 @@ int AINode_Seek_ActivateEntity(bot_state_t *bs) {
 			//if the bot touches the current goal
 			if (trap_BotTouchingGoal(bs->origin, goal)) {
 				// Developer mode outputs a message.
-				if(bot_developer.integer == 1) {
+				if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 					BotAI_Print(PRT_MESSAGE, "touched button or trigger\n");
 				}
 				bs->activatestack->time = 0;
@@ -2094,7 +2094,7 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 		return qfalse;
 	}
 	//if there is another better enemy (only available in Developer mode)
-	if (BotFindEnemy(bs, bs->enemy) && (bot_developer.integer == 1)) {
+	if (BotFindEnemy(bs, bs->enemy) && (bot_developer.integer & DEVMODE_FOR_CODERS)) {
 		BotAI_Print(PRT_MESSAGE, "found new better enemy\n");
 	}
 	//if no enemy
@@ -2412,7 +2412,7 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 		return qfalse;
 	}
 	//if there is another better enemy (only available in Developer mode)
-	if (BotFindEnemy(bs, bs->enemy) && (bot_developer.integer == 1)) {
+	if (BotFindEnemy(bs, bs->enemy) && (bot_developer.integer & DEVMODE_FOR_CODERS)) {
 		BotAI_Print(PRT_MESSAGE, "found new better enemy\n");
 	}
 	//

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -160,7 +160,7 @@ int BotGoForAir(bot_state_t *bs, int tfl, bot_goal_t *ltg, float range) {
 	//if the bot needs air
 	if (bs->lastair_time < FloatTime() - 6) {
 		// Developer mode outputs a message.
-		if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+		if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 			BotAI_Print(PRT_MESSAGE, "going for air\n");
 		}
 		//if we can find an air goal
@@ -310,7 +310,7 @@ int BotGetItemLongTermGoal(bot_state_t *bs, int tfl, bot_goal_t *goal) {
 		}
 		else {//the bot gets sorta stuck with all the avoid timings, shouldn't happen though
 			// Developer mode outputs a message.
-			if(bot_developer.integer & DEVMODE_FOR_CODERS){
+			if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 				char netname[128];
 				BotAI_Print(PRT_MESSAGE, "%s: no valid ltg (probably stuck)\n", ClientName(bs->client, netname, sizeof(netname)));
 			}
@@ -1597,7 +1597,7 @@ int AINode_Seek_ActivateEntity(bot_state_t *bs) {
 		// if the entity the bot shoots at moved
 		if (!VectorCompare(bs->activatestack->origin, entinfo.origin)) {
 			// Developer mode outputs a message.
-			if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+			if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 				BotAI_Print(PRT_MESSAGE, "hit shootable button or trigger\n");
 			}
 			bs->activatestack->time = 0;
@@ -1625,7 +1625,7 @@ int AINode_Seek_ActivateEntity(bot_state_t *bs) {
 			//if the bot touches the current goal
 			if (trap_BotTouchingGoal(bs->origin, goal)) {
 				// Developer mode outputs a message.
-				if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+				if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 					BotAI_Print(PRT_MESSAGE, "touched button or trigger\n");
 				}
 				bs->activatestack->time = 0;
@@ -2094,8 +2094,10 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 		return qfalse;
 	}
 	//if there is another better enemy (only available in Developer mode)
-	if (BotFindEnemy(bs, bs->enemy) && (bot_developer.integer & DEVMODE_FOR_CODERS)) {
-		BotAI_Print(PRT_MESSAGE, "found new better enemy\n");
+	if (BotFindEnemy(bs, bs->enemy)) {
+		if (bot_developer.integer & DEVMODE_FOR_CODERS) {
+			BotAI_Print(PRT_MESSAGE, "found new better enemy\n");
+		}
 	}
 	//if no enemy
 	if (bs->enemy < 0) {
@@ -2411,9 +2413,11 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 		AIEnter_Seek_LTG(bs, "battle retreat: enemy dead");
 		return qfalse;
 	}
-	//if there is another better enemy (only available in Developer mode)
-	if (BotFindEnemy(bs, bs->enemy) && (bot_developer.integer & DEVMODE_FOR_CODERS)) {
-		BotAI_Print(PRT_MESSAGE, "found new better enemy\n");
+	//if there is another better enemy
+	if (BotFindEnemy(bs, bs->enemy)) {
+		if (bot_developer.integer & DEVMODE_FOR_CODERS) {
+			BotAI_Print(PRT_MESSAGE, "found new better enemy\n");
+		}
 	}
 	//
 	bs->tfl = TFL_DEFAULT;

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -102,11 +102,10 @@ void BotRecordNodeSwitch(bot_state_t *bs, char *node, char *str, char *s) {
 
 	ClientName(bs->client, netname, sizeof(netname));
 	Com_sprintf(nodeswitch[numnodeswitches], 144, "%s at %2.1f entered %s: %s from %s\n", netname, FloatTime(), node, str, s);
-#ifdef DEBUG
-	if (0) {
+	// Developer mode outputs a message.
+	if (bot_developer.integer == 1) {
 		BotAI_Print(PRT_MESSAGE, "%s", nodeswitch[numnodeswitches]);
 	}
-#endif //DEBUG
 	numnodeswitches++;
 }
 
@@ -160,10 +159,10 @@ int BotGoForAir(bot_state_t *bs, int tfl, bot_goal_t *ltg, float range) {
 
 	//if the bot needs air
 	if (bs->lastair_time < FloatTime() - 6) {
-		//
-#ifdef DEBUG
-		//BotAI_Print(PRT_MESSAGE, "going for air\n");
-#endif //DEBUG
+		// Developer mode outputs a message.
+		if(bot_developer.integer == 1) {
+			BotAI_Print(PRT_MESSAGE, "going for air\n");
+		}
 		//if we can find an air goal
 		if (BotGetAirGoal(bs, &goal)) {
 			trap_BotPushGoal(bs->gs, &goal);
@@ -310,12 +309,11 @@ int BotGetItemLongTermGoal(bot_state_t *bs, int tfl, bot_goal_t *goal) {
 			bs->ltg_time = FloatTime() + 20;
 		}
 		else {//the bot gets sorta stuck with all the avoid timings, shouldn't happen though
-			//
-#ifdef DEBUG
-			char netname[128];
-
-			BotAI_Print(PRT_MESSAGE, "%s: no valid ltg (probably stuck)\n", ClientName(bs->client, netname, sizeof(netname)));
-#endif
+			// Developer mode outputs a message.
+			if(bot_developer.integer == 1){
+				char netname[128];
+				BotAI_Print(PRT_MESSAGE, "%s: no valid ltg (probably stuck)\n", ClientName(bs->client, netname, sizeof(netname)));
+			}
 			//trap_BotDumpAvoidGoals(bs->gs);
 			//reset the avoid goals and the avoid reach
 			trap_BotResetAvoidGoals(bs->gs);
@@ -1598,9 +1596,10 @@ int AINode_Seek_ActivateEntity(bot_state_t *bs) {
 		BotEntityInfo(goal->entitynum, &entinfo);
 		// if the entity the bot shoots at moved
 		if (!VectorCompare(bs->activatestack->origin, entinfo.origin)) {
-#ifdef DEBUG
-			BotAI_Print(PRT_MESSAGE, "hit shootable button or trigger\n");
-#endif //DEBUG
+			// Developer mode outputs a message.
+			if(bot_developer.integer == 1) {
+				BotAI_Print(PRT_MESSAGE, "hit shootable button or trigger\n");
+			}
 			bs->activatestack->time = 0;
 		}
 		// if the activate goal has been activated or the bot takes too long
@@ -1625,9 +1624,10 @@ int AINode_Seek_ActivateEntity(bot_state_t *bs) {
 		else if (!bs->activatestack->shoot) {
 			//if the bot touches the current goal
 			if (trap_BotTouchingGoal(bs->origin, goal)) {
-#ifdef DEBUG
-				BotAI_Print(PRT_MESSAGE, "touched button or trigger\n");
-#endif //DEBUG
+				// Developer mode outputs a message.
+				if(bot_developer.integer == 1) {
+					BotAI_Print(PRT_MESSAGE, "touched button or trigger\n");
+				}
 				bs->activatestack->time = 0;
 			}
 		}
@@ -2093,11 +2093,9 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 		AIEnter_Respawn(bs, "battle fight: bot dead");
 		return qfalse;
 	}
-	//if there is another better enemy
-	if (BotFindEnemy(bs, bs->enemy)) {
-#ifdef DEBUG
+	//if there is another better enemy (only available in Developer mode)
+	if (BotFindEnemy(bs, bs->enemy) && (bot_developer.integer == 1)) {
 		BotAI_Print(PRT_MESSAGE, "found new better enemy\n");
-#endif
 	}
 	//if no enemy
 	if (bs->enemy < 0) {
@@ -2413,11 +2411,9 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 		AIEnter_Seek_LTG(bs, "battle retreat: enemy dead");
 		return qfalse;
 	}
-	//if there is another better enemy
-	if (BotFindEnemy(bs, bs->enemy)) {
-#ifdef DEBUG
+	//if there is another better enemy (only available in Developer mode)
+	if (BotFindEnemy(bs, bs->enemy) && (bot_developer.integer == 1)) {
 		BotAI_Print(PRT_MESSAGE, "found new better enemy\n");
-#endif
 	}
 	//
 	bs->tfl = TFL_DEFAULT;

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -791,7 +791,7 @@ void BotCTFSeekGoals(bot_state_t *bs) {
 	}
 	bs->owndecision_time = FloatTime() + 5;
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -1108,7 +1108,7 @@ void Bot1FCTFSeekGoals(bot_state_t *bs) {
 	}
 	bs->owndecision_time = FloatTime() + 5;
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -4274,7 +4274,7 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 	}
 	// get the targetname so we can find an entity with a matching target
 	if (!trap_AAS_ValueForBSPEpairKey(ent, "targetname", targetname[0], sizeof (targetname[0]))) {
-		if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+		if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 			BotAI_Print(PRT_ERROR, "BotGetActivateGoal: entity with model \"%s\" has no targetname\n", model);
 		}
 		return 0;
@@ -4290,14 +4290,14 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 			}
 		}
 		if (!ent) {
-			if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+			if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 				BotAI_Print(PRT_ERROR, "BotGetActivateGoal: no entity with target \"%s\"\n", targetname[i]);
 			}
 			i--;
 			continue;
 		}
 		if (!trap_AAS_ValueForBSPEpairKey(ent, "classname", classname, sizeof (classname))) {
-			if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+			if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 				BotAI_Print(PRT_ERROR, "BotGetActivateGoal: entity with target \"%s\" has no classname\n", targetname[i]);
 			}
 			continue;
@@ -4361,7 +4361,7 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 			}
 		}
 	}
-	if(bot_developer.integer & DEVMODE_FOR_MAPPERS) {
+	if (bot_developer.integer & DEVMODE_FOR_MAPPERS) {
 		BotAI_Print(PRT_ERROR, "BotGetActivateGoal: no valid activator for entity with target \"%s\"\n", targetname[0]);
 	}
 	return 0;
@@ -4473,7 +4473,7 @@ void BotAIBlocked(bot_state_t *bs, bot_moveresult_t *moveresult, int activate) {
 	}
 	// get info for the entity that is blocking the bot
 	BotEntityInfo(moveresult->blockentity, &entinfo);
-	if(bot_developer.integer & DEVMODE_FOR_MAPPERS) {
+	if (bot_developer.integer & DEVMODE_FOR_MAPPERS) {
 		char netname[MAX_NETNAME];
 
 		ClientName(bs->client, netname, sizeof (netname));
@@ -5279,12 +5279,14 @@ void BotDeathmatchAI(bot_state_t *bs, float thinktime) {
 	//if the bot removed itself :)
 	if (!bs->inuse) return;
 	//if the bot executed too many AI nodes
-	if ((i >= MAX_NODESWITCHES) && (bot_developer.integer & DEVMODE_FOR_CODERS)) {
-		trap_BotDumpGoalStack(bs->gs);
-		trap_BotDumpAvoidGoals(bs->gs);
-		BotDumpNodeSwitches(bs);
-		ClientName(bs->client, name, sizeof (name));
-		BotAI_Print(PRT_ERROR, "%s at %1.1f switched more than %d AI nodes\n", name, FloatTime(), MAX_NODESWITCHES);
+	if (i >= MAX_NODESWITCHES) {
+		if (bot_developer.integer & DEVMODE_FOR_CODERS) {
+			trap_BotDumpGoalStack(bs->gs);
+			trap_BotDumpAvoidGoals(bs->gs);
+			BotDumpNodeSwitches(bs);
+			ClientName(bs->client, name, sizeof (name));
+			BotAI_Print(PRT_ERROR, "%s at %1.1f switched more than %d AI nodes\n", name, FloatTime(), MAX_NODESWITCHES);
+		}
 	}
 	//
 	bs->lastframe_health = bs->inventory[INVENTORY_HEALTH];

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -791,7 +791,7 @@ void BotCTFSeekGoals(bot_state_t *bs) {
 	}
 	bs->owndecision_time = FloatTime() + 5;
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -1108,7 +1108,7 @@ void Bot1FCTFSeekGoals(bot_state_t *bs) {
 	}
 	bs->owndecision_time = FloatTime() + 5;
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -4186,8 +4186,6 @@ BotGetActivateGoal
   goal->entitynum will be set to the game entity to activate
 ==================
  */
-//#define OBSTACLEDEBUG
-
 int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activategoal) {
 	int i, ent, cur_entities[10], spawnflags, modelindex, areas[MAX_ACTIVATEAREAS * 2], numareas, t;
 	char model[MAX_INFO_STRING], tmpmodel[128];
@@ -4276,7 +4274,7 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 	}
 	// get the targetname so we can find an entity with a matching target
 	if (!trap_AAS_ValueForBSPEpairKey(ent, "targetname", targetname[0], sizeof (targetname[0]))) {
-		if(bot_developer.integer == 1) {
+		if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 			BotAI_Print(PRT_ERROR, "BotGetActivateGoal: entity with model \"%s\" has no targetname\n", model);
 		}
 		return 0;
@@ -4292,14 +4290,14 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 			}
 		}
 		if (!ent) {
-			if(bot_developer.integer == 1) {
+			if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 				BotAI_Print(PRT_ERROR, "BotGetActivateGoal: no entity with target \"%s\"\n", targetname[i]);
 			}
 			i--;
 			continue;
 		}
 		if (!trap_AAS_ValueForBSPEpairKey(ent, "classname", classname, sizeof (classname))) {
-			if(bot_developer.integer == 1) {
+			if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 				BotAI_Print(PRT_ERROR, "BotGetActivateGoal: entity with target \"%s\" has no classname\n", targetname[i]);
 			}
 			continue;
@@ -4363,7 +4361,7 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 			}
 		}
 	}
-	if(bot_developer.integer >= 2) {
+	if(bot_developer.integer & DEVMODE_FOR_MAPPERS) {
 		BotAI_Print(PRT_ERROR, "BotGetActivateGoal: no valid activator for entity with target \"%s\"\n", targetname[0]);
 	}
 	return 0;
@@ -4475,7 +4473,7 @@ void BotAIBlocked(bot_state_t *bs, bot_moveresult_t *moveresult, int activate) {
 	}
 	// get info for the entity that is blocking the bot
 	BotEntityInfo(moveresult->blockentity, &entinfo);
-	if(bot_developer.integer >= 2) {
+	if(bot_developer.integer & DEVMODE_FOR_MAPPERS) {
 		char netname[MAX_NETNAME];
 
 		ClientName(bs->client, netname, sizeof (netname));
@@ -5281,7 +5279,7 @@ void BotDeathmatchAI(bot_state_t *bs, float thinktime) {
 	//if the bot removed itself :)
 	if (!bs->inuse) return;
 	//if the bot executed too many AI nodes
-	if (i >= MAX_NODESWITCHES && (bot_developer.integer == 1)) {
+	if ((i >= MAX_NODESWITCHES) && (bot_developer.integer & DEVMODE_FOR_CODERS)) {
 		trap_BotDumpGoalStack(bs->gs);
 		trap_BotDumpAvoidGoals(bs->gs);
 		BotDumpNodeSwitches(bs);

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -84,8 +84,6 @@ vmCvar_t bot_challenge;
 vmCvar_t bot_predictobstacles;
 vmCvar_t bot_spSkill;
 
-extern vmCvar_t bot_developer;
-
 vec3_t lastteleport_origin; //last teleport event origin
 float lastteleport_time; //last teleport event time
 int max_bspmodelindex; //maximum BSP model index
@@ -792,9 +790,10 @@ void BotCTFSeekGoals(bot_state_t *bs) {
 		BotSetTeamStatus(bs);
 	}
 	bs->owndecision_time = FloatTime() + 5;
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -1108,9 +1107,10 @@ void Bot1FCTFSeekGoals(bot_state_t *bs) {
 		BotSetTeamStatus(bs);
 	}
 	bs->owndecision_time = FloatTime() + 5;
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -4276,7 +4276,7 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 	}
 	// get the targetname so we can find an entity with a matching target
 	if (!trap_AAS_ValueForBSPEpairKey(ent, "targetname", targetname[0], sizeof (targetname[0]))) {
-		if (bot_developer.integer) {
+		if(bot_developer.integer == 1) {
 			BotAI_Print(PRT_ERROR, "BotGetActivateGoal: entity with model \"%s\" has no targetname\n", model);
 		}
 		return 0;
@@ -4292,14 +4292,14 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 			}
 		}
 		if (!ent) {
-			if (bot_developer.integer) {
+			if(bot_developer.integer == 1) {
 				BotAI_Print(PRT_ERROR, "BotGetActivateGoal: no entity with target \"%s\"\n", targetname[i]);
 			}
 			i--;
 			continue;
 		}
 		if (!trap_AAS_ValueForBSPEpairKey(ent, "classname", classname, sizeof (classname))) {
-			if (bot_developer.integer) {
+			if(bot_developer.integer == 1) {
 				BotAI_Print(PRT_ERROR, "BotGetActivateGoal: entity with target \"%s\" has no classname\n", targetname[i]);
 			}
 			continue;
@@ -4363,9 +4363,9 @@ int BotGetActivateGoal(bot_state_t *bs, int entitynum, bot_activategoal_t *activ
 			}
 		}
 	}
-#ifdef OBSTACLEDEBUG
-	BotAI_Print(PRT_ERROR, "BotGetActivateGoal: no valid activator for entity with target \"%s\"\n", targetname[0]);
-#endif
+	if(bot_developer.integer >= 2) {
+		BotAI_Print(PRT_ERROR, "BotGetActivateGoal: no valid activator for entity with target \"%s\"\n", targetname[0]);
+	}
 	return 0;
 }
 
@@ -4456,9 +4456,6 @@ open, which buttons to activate etc.
 ==================
  */
 void BotAIBlocked(bot_state_t *bs, bot_moveresult_t *moveresult, int activate) {
-#ifdef OBSTACLEDEBUG
-	char netname[MAX_NETNAME];
-#endif
 	int movetype, bspent;
 	vec3_t hordir, start, sideward, angles, up = {0, 0, 1};
 	aas_entityinfo_t entinfo;
@@ -4478,10 +4475,12 @@ void BotAIBlocked(bot_state_t *bs, bot_moveresult_t *moveresult, int activate) {
 	}
 	// get info for the entity that is blocking the bot
 	BotEntityInfo(moveresult->blockentity, &entinfo);
-#ifdef OBSTACLEDEBUG
-	ClientName(bs->client, netname, sizeof (netname));
-	BotAI_Print(PRT_MESSAGE, "%s: I'm blocked by model %d\n", netname, entinfo.modelindex);
-#endif // OBSTACLEDEBUG
+	if(bot_developer.integer >= 2) {
+		char netname[MAX_NETNAME];
+
+		ClientName(bs->client, netname, sizeof (netname));
+		BotAI_Print(PRT_MESSAGE, "%s: I'm blocked by model %d\n", netname, entinfo.modelindex);
+	}
 	// if blocked by a bsp model and the bot wants to activate it
 	if (activate && entinfo.modelindex > 0 && entinfo.modelindex <= max_bspmodelindex) {
 		// find the bsp entity which should be activated in order to get the blocking entity out of the way
@@ -5282,16 +5281,13 @@ void BotDeathmatchAI(bot_state_t *bs, float thinktime) {
 	//if the bot removed itself :)
 	if (!bs->inuse) return;
 	//if the bot executed too many AI nodes
-	//Sago: FIXME - Outcommented this test... this is wrong
-#ifdef DEBUG
-	if (i >= MAX_NODESWITCHES) {
+	if (i >= MAX_NODESWITCHES && (bot_developer.integer == 1)) {
 		trap_BotDumpGoalStack(bs->gs);
 		trap_BotDumpAvoidGoals(bs->gs);
 		BotDumpNodeSwitches(bs);
 		ClientName(bs->client, name, sizeof (name));
 		BotAI_Print(PRT_ERROR, "%s at %1.1f switched more than %d AI nodes\n", name, FloatTime(), MAX_NODESWITCHES);
 	}
-#endif
 	//
 	bs->lastframe_health = bs->inventory[INVENTORY_HEALTH];
 	bs->lasthitcount = bs->cur_ps.persistant[PERS_HITS];

--- a/code/game/ai_dmq3.h
+++ b/code/game/ai_dmq3.h
@@ -189,6 +189,7 @@ extern vmCvar_t bot_fastchat;
 extern vmCvar_t bot_nochat;
 extern vmCvar_t bot_testrchat;
 extern vmCvar_t bot_challenge;
+extern vmCvar_t bot_developer;
 
 extern bot_goal_t ctf_redflag;
 extern bot_goal_t ctf_blueflag;

--- a/code/game/ai_main.h
+++ b/code/game/ai_main.h
@@ -30,7 +30,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  *****************************************************************************/
 
-//#define DEBUG
 #define CTF
 
 #define MAX_ITEMS					256

--- a/code/game/ai_vcmd.c
+++ b/code/game/ai_vcmd.c
@@ -101,9 +101,10 @@ void BotVoiceChat_GetFlag(bot_state_t *bs, int client, int mode) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -151,9 +152,10 @@ void BotVoiceChat_Offense(bot_state_t *bs, int client, int mode) {
 		// remember last ordered task
 		BotRememberLastOrderedTask(bs);
 	}
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -198,9 +200,10 @@ void BotVoiceChat_Defend(bot_state_t *bs, int client, int mode) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -230,9 +233,10 @@ void BotVoiceChat_Patrol(bot_state_t *bs, int client, int mode) {
 	BotVoiceChatOnly(bs, -1, VOICECHAT_ONPATROL);
 	//
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -286,9 +290,10 @@ void BotVoiceChat_Camp(bot_state_t *bs, int client, int mode) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -340,9 +345,10 @@ void BotVoiceChat_FollowMe(bot_state_t *bs, int client, int mode) {
 	BotSetTeamStatus(bs);
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -356,9 +362,10 @@ void BotVoiceChat_FollowFlagCarrier(bot_state_t *bs, int client, int mode) {
 	carrier = BotTeamFlagCarrier(bs);
 	if (carrier >= 0)
 		BotVoiceChat_FollowMe(bs, carrier, mode);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*
@@ -383,9 +390,10 @@ void BotVoiceChat_ReturnFlag(bot_state_t *bs, int client, int mode) {
 	bs->teamgoal_time = FloatTime() + CTF_RETURNFLAG_TIME;
 	bs->rushbaseaway_time = 0;
 	BotSetTeamStatus(bs);
-#ifdef DEBUG
-	BotPrintTeamGoal(bs);
-#endif //DEBUG
+	// Developer mode outputs a message.
+	if(bot_developer.integer == 1) {
+		BotPrintTeamGoal(bs);
+	}
 }
 
 /*

--- a/code/game/ai_vcmd.c
+++ b/code/game/ai_vcmd.c
@@ -102,7 +102,7 @@ void BotVoiceChat_GetFlag(bot_state_t *bs, int client, int mode) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -153,7 +153,7 @@ void BotVoiceChat_Offense(bot_state_t *bs, int client, int mode) {
 		BotRememberLastOrderedTask(bs);
 	}
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -201,7 +201,7 @@ void BotVoiceChat_Defend(bot_state_t *bs, int client, int mode) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -234,7 +234,7 @@ void BotVoiceChat_Patrol(bot_state_t *bs, int client, int mode) {
 	//
 	BotSetTeamStatus(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -291,7 +291,7 @@ void BotVoiceChat_Camp(bot_state_t *bs, int client, int mode) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -346,7 +346,7 @@ void BotVoiceChat_FollowMe(bot_state_t *bs, int client, int mode) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -363,7 +363,7 @@ void BotVoiceChat_FollowFlagCarrier(bot_state_t *bs, int client, int mode) {
 	if (carrier >= 0)
 		BotVoiceChat_FollowMe(bs, carrier, mode);
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -391,7 +391,7 @@ void BotVoiceChat_ReturnFlag(bot_state_t *bs, int client, int mode) {
 	bs->rushbaseaway_time = 0;
 	BotSetTeamStatus(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer == 1) {
+	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }

--- a/code/game/ai_vcmd.c
+++ b/code/game/ai_vcmd.c
@@ -102,7 +102,7 @@ void BotVoiceChat_GetFlag(bot_state_t *bs, int client, int mode) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -153,7 +153,7 @@ void BotVoiceChat_Offense(bot_state_t *bs, int client, int mode) {
 		BotRememberLastOrderedTask(bs);
 	}
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -201,7 +201,7 @@ void BotVoiceChat_Defend(bot_state_t *bs, int client, int mode) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -234,7 +234,7 @@ void BotVoiceChat_Patrol(bot_state_t *bs, int client, int mode) {
 	//
 	BotSetTeamStatus(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -291,7 +291,7 @@ void BotVoiceChat_Camp(bot_state_t *bs, int client, int mode) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -346,7 +346,7 @@ void BotVoiceChat_FollowMe(bot_state_t *bs, int client, int mode) {
 	// remember last ordered task
 	BotRememberLastOrderedTask(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -363,7 +363,7 @@ void BotVoiceChat_FollowFlagCarrier(bot_state_t *bs, int client, int mode) {
 	if (carrier >= 0)
 		BotVoiceChat_FollowMe(bs, carrier, mode);
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }
@@ -391,7 +391,7 @@ void BotVoiceChat_ReturnFlag(bot_state_t *bs, int client, int mode) {
 	bs->rushbaseaway_time = 0;
 	BotSetTeamStatus(bs);
 	// Developer mode outputs a message.
-	if(bot_developer.integer & DEVMODE_FOR_CODERS) {
+	if (bot_developer.integer & DEVMODE_FOR_CODERS) {
 		BotPrintTeamGoal(bs);
 	}
 }

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -64,6 +64,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define QUACK_SCALE		0.85
 #define	QUACK_VIEWHEIGHT	22
 
+/* Neon_Knight: Developer modes */
+#define DEVMODE_FOR_CODERS	1
+#define DEVMODE_FOR_MAPPERS	2
+
 //
 // config strings are a general means of communicating variable length strings
 // from the server to all connected clients.

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -1087,7 +1087,7 @@ void ClientUserinfoChanged( int clientNum ) {
 	client->pers.cmdTimeNudge = atoi( s );
 
 	// see if the player wants to debug the backward reconciliation
-	if(g_developer.integer & DEVMODE_FOR_CODERS ) {
+	if (g_developer.integer & DEVMODE_FOR_CODERS) {
 		s = Info_ValueForKey( userinfo, "cg_debugDelag" );
 		if ( !atoi( s ) ) {
 			client->pers.debugDelag = qfalse;

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -1087,13 +1087,15 @@ void ClientUserinfoChanged( int clientNum ) {
 	client->pers.cmdTimeNudge = atoi( s );
 
 	// see if the player wants to debug the backward reconciliation
-	/*s = Info_ValueForKey( userinfo, "cg_debugDelag" );
-	if ( !atoi( s ) ) {
-		client->pers.debugDelag = qfalse;
+	if(g_developer.integer & DEVMODE_FOR_CODERS ) {
+		s = Info_ValueForKey( userinfo, "cg_debugDelag" );
+		if ( !atoi( s ) ) {
+			client->pers.debugDelag = qfalse;
+		}
+		else {
+			client->pers.debugDelag = qtrue;
+		}
 	}
-	else {
-		client->pers.debugDelag = qtrue;
-	}*/
 
 	// see if the player is simulating incoming latency
 	//s = Info_ValueForKey( userinfo, "cg_latentSnaps" );

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -1292,7 +1292,7 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker,
 	asave = CheckArmor (targ, take, dflags);
 	take -= asave;
 
-	if ( g_debugDamage.integer ) {
+	if (g_debugDamage.integer && (g_developer.integer & DEVMODE_FOR_CODERS)) {
 		G_Printf( "%i: client:%i health:%i damage:%i armor:%i\n", level.time, targ->s.number,
 		          targ->health, take, asave );
 	}

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -272,7 +272,7 @@ typedef struct {
 //unlagged - client options
 	// these correspond with variables in the userinfo string
 	int			delag;
-//	int			debugDelag;
+	int			debugDelag;
 	int			cmdTimeNudge;
 //unlagged - client options
 //unlagged - lag simulation #2

--- a/code/game/g_utils.c
+++ b/code/game/g_utils.c
@@ -647,7 +647,7 @@ void G_GlobalSound( int soundIndex )
 	//Let's avoid the S_FindName error if soundIndex is 0.
 	//Sago: And let's check that the sound index is within the allowed range.
 	if( ( soundIndex <= 0 ) ||  soundIndex >= MAX_SOUNDS ) {
-		if (g_developer.integer & DEVMODE_FOR_CODERS){
+		if (g_developer.integer & DEVMODE_FOR_CODERS) {
 			//Display this message when in code developer mode
 			G_Printf( "GlobalSound: Error, no soundIndex specified. Check your code!\n" );
 		}

--- a/code/game/g_utils.c
+++ b/code/game/g_utils.c
@@ -647,8 +647,8 @@ void G_GlobalSound( int soundIndex )
 	//Let's avoid the S_FindName error if soundIndex is 0.
 	//Sago: And let's check that the sound index is within the allowed range.
 	if( ( soundIndex <= 0 ) ||  soundIndex >= MAX_SOUNDS ) {
-		if (g_developer.integer){
-			//Display this message when debugging
+		if (g_developer.integer == 1){
+			//Display this message when in code developer mode
 			G_Printf( "GlobalSound: Error, no soundIndex specified. Check your code!\n" );
 		}
 		return;

--- a/code/game/g_utils.c
+++ b/code/game/g_utils.c
@@ -647,7 +647,7 @@ void G_GlobalSound( int soundIndex )
 	//Let's avoid the S_FindName error if soundIndex is 0.
 	//Sago: And let's check that the sound index is within the allowed range.
 	if( ( soundIndex <= 0 ) ||  soundIndex >= MAX_SOUNDS ) {
-		if (g_developer.integer == 1){
+		if (g_developer.integer & DEVMODE_FOR_CODERS){
 			//Display this message when in code developer mode
 			G_Printf( "GlobalSound: Error, no soundIndex specified. Check your code!\n" );
 		}


### PR DESCRIPTION
There were a lot if #ifdef DEBUG in the code. So what about a mode where debug info could be displayed?

**[Here's a test pk3](https://cdn.discordapp.com/attachments/405518544382590987/675370157132087306/z_oax_v2.pk3) Updated February 7, 2020.**

We use `"developer 1"` to enter devmode for coders and `"developer 2"` for devmode for mappers. `"developer 3"` enters both devmode for coders as well as for mappers. Enabling devmode turns regular bot chat off (they would only input whatever information is needed for debugging).