### PR TITLE
ai_team.c: Code simplification by sending redundant pieces to new functions

### DIFF
--- a/code/game/ai_team.c
+++ b/code/game/ai_team.c
@@ -398,48 +398,39 @@ void BotCTFOrders_BothFlagsNotAtBase(bot_state_t *bs) {
 	BotSortTeamMatesByTaskPreference(bs, teammates, numteammates);
 	//different orders based on the number of team mates
 	switch(bs->numteammates) {
+		/* One player in a team: do nothing. */
 		case 1: break;
+		/* Two players in a team: one of them takes the Flag Carrier role. */
 		case 2:
 		{
-			//tell the one not carrying the flag to attack the enemy base
-			if (teammates[0] != bs->flagcarrier) other = teammates[0];
-			else other = teammates[1];
-			ClientName(other, name, sizeof(name));
-			if (bot_nochat.integer<3) BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-			BotSayTeamOrder(bs, other);
-			BotSayVoiceTeamOrder(bs, other, VOICECHAT_GETFLAG);
+			if (teammates[0] != bs->flagcarrier) {
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_GETTHEFLAG, NULL);
+			} else {
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
+			}
 			break;
 		}
+		/* Three players in a team: the bot who isn't carrying the flag but is close
+			to the carrier takes the Flag Defender role. The one furthest from the
+			base becomes the Flag Carrier. */
 		case 3:
 		{
-			//tell the one closest to the base not carrying the flag to accompany the flag carrier
 			if (teammates[0] != bs->flagcarrier) other = teammates[0];
 			else other = teammates[1];
-			ClientName(other, name, sizeof(name));
 			if ( bs->flagcarrier != -1 ) {
-				ClientName(bs->flagcarrier, carriername, sizeof(carriername));
 				if (bs->flagcarrier == bs->client) {
-					if (bot_nochat.integer<3)BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
-					if (bot_nochat.integer<3)BotSayVoiceTeamOrder(bs, other, VOICECHAT_FOLLOWME);
+					BotAI_GiveRoleToTheBot(bs, bs->flagcarrier, carriername, ORDER_FOLLOWME, NULL);
+				} else {
+					BotAI_GiveRoleToTheBot(bs, bs->flagcarrier, name, ORDER_FOLLOWTEAMMATE, carriername);
 				}
-				else {
-					if (bot_nochat.integer<3)BotAI_BotInitialChat(bs, "cmd_accompany", name, carriername, NULL);
-					if (bot_nochat.integer<3)BotSayVoiceTeamOrder(bs, other, VOICECHAT_FOLLOWFLAGCARRIER);
-				}
+			} else {
+				BotAI_GiveRoleToTheBot(bs, other, name, ORDER_GETTHEFLAG, NULL);
 			}
-			else {
-				//
-				if (bot_nochat.integer<3)BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				if (bot_nochat.integer<3)BotSayVoiceTeamOrder(bs, other, VOICECHAT_GETFLAG);
+			if (teammates[2] != bs->flagcarrier) {
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_RETURNOURFLAG, NULL);
+			} else {
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_RETURNOURFLAG, NULL);
 			}
-			if (bot_nochat.integer<3)BotSayTeamOrder(bs, other);
-			//tell the one furthest from the the base not carrying the flag to get the enemy flag
-			if (teammates[2] != bs->flagcarrier) other = teammates[2];
-			else other = teammates[1];
-			ClientName(other, name, sizeof(name));
-			if (bot_nochat.integer<3)BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-			if (bot_nochat.integer<3)BotSayTeamOrder(bs, other);
-			if (bot_nochat.integer<3)BotSayVoiceTeamOrder(bs, other, VOICECHAT_RETURNFLAG);
 			break;
 		}
 		default:
@@ -456,16 +447,12 @@ void BotCTFOrders_BothFlagsNotAtBase(bot_state_t *bs) {
 						continue;
 					}
 					//
-					ClientName(teammates[i], name, sizeof(name));
 					if (bs->flagcarrier == bs->client) {
-						if (bot_nochat.integer<3)BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
-						if (bot_nochat.integer<3)BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_FOLLOWME);
+						BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_FOLLOWME, NULL);
 					}
 					else {
-						if (bot_nochat.integer<3)BotAI_BotInitialChat(bs, "cmd_accompany", name, carriername, NULL);
-						if (bot_nochat.integer<3)BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_FOLLOWFLAGCARRIER);
+						BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_FOLLOWTEAMMATE, carriername);
 					}
-					if (bot_nochat.integer<3)BotSayTeamOrder(bs, teammates[i]);
 				}
 			}
 			else {
@@ -475,10 +462,7 @@ void BotCTFOrders_BothFlagsNotAtBase(bot_state_t *bs) {
 						continue;
 					}
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					if (bot_nochat.integer<3)BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					if (bot_nochat.integer<3)BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_GETFLAG);
-					if (bot_nochat.integer<3)BotSayTeamOrder(bs, teammates[i]);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_GETTHEFLAG, NULL);
 				}
 			}
 			for (i = 0; i < attackers; i++) {
@@ -487,10 +471,7 @@ void BotCTFOrders_BothFlagsNotAtBase(bot_state_t *bs) {
 					continue;
 				}
 				//
-				ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-				if (bot_nochat.integer<3)BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				if (bot_nochat.integer<3)BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-				if (bot_nochat.integer<3)BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_RETURNFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_RETURNOURFLAG, NULL);
 			}
 			//
 			break;
@@ -507,7 +488,9 @@ void BotCTFOrders_FlagNotAtBase(bot_state_t *bs) {
 	int numteammates, defenders, attackers, i;
 	int teammates[MAX_CLIENTS];
 	char name[MAX_NETNAME];
+
 	if (bot_nochat.integer>2) return;
+
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
 	BotSortTeamMatesByTaskPreference(bs, teammates, numteammates);
 	//In oneway ctf we must all move out of the base (only one strategi, maybe we can also send some to the enemy base  to meet the flag carier?)
@@ -515,10 +498,7 @@ void BotCTFOrders_FlagNotAtBase(bot_state_t *bs) {
 	if(g_elimination_ctf_oneway.integer > 0) {
 		for (i = 0; i < numteammates; i++) {
 			//
-			ClientName(teammates[i], name, sizeof(name));
-			BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-			BotSayTeamOrder(bs, teammates[i]);
-			BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_GETFLAG);
+			BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_GETTHEFLAG, NULL);
 		}
 		return;
 	}
@@ -531,34 +511,19 @@ void BotCTFOrders_FlagNotAtBase(bot_state_t *bs) {
 			case 2:
 			{
 				// keep one near the base for when the flag is returned
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			case 3:
 			{
 				//keep one near the base for when the flag is returned
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other two get the flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				//
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			default:
@@ -570,58 +535,36 @@ void BotCTFOrders_FlagNotAtBase(bot_state_t *bs) {
 				if (attackers > 6) attackers = 6;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 				//
 				break;
 			}
 		}
-	}
-	else {
+	} else {
 		//different orders based on the number of team mates
 		switch(bs->numteammates) {
 			case 1: break;
 			case 2:
 			{
 				//both will go for the enemy flag
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_GETTHEFLAG, NULL);
 				//
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			case 3:
 			{
 				//everyone go for the flag
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_GETTHEFLAG, NULL);
 				//
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				//
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			default:
@@ -633,17 +576,11 @@ void BotCTFOrders_FlagNotAtBase(bot_state_t *bs) {
 				if (attackers > 7) attackers = 7;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 				//
 				break;
@@ -658,11 +595,11 @@ BotCTFOrders
 ==================
 */
 void BotCTFOrders_EnemyFlagNotAtBase(bot_state_t *bs) {
-	int numteammates, defenders, attackers, i, other;
+	int numteammates, defenders, attackers, i;
 	int teammates[MAX_CLIENTS];
 	char name[MAX_NETNAME], carriername[MAX_NETNAME];
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
 	BotSortTeamMatesByTaskPreference(bs, teammates, numteammates);
@@ -672,30 +609,27 @@ void BotCTFOrders_EnemyFlagNotAtBase(bot_state_t *bs) {
 		case 2:
 		{
 			//tell the one not carrying the flag to defend the base
-			if (teammates[0] == bs->flagcarrier) other = teammates[1];
-			else other = teammates[0];
-			ClientName(other, name, sizeof(name));
-			BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-			BotSayTeamOrder(bs, other);
-			BotSayVoiceTeamOrder(bs, other, VOICECHAT_DEFEND);
+			if (teammates[0] == bs->flagcarrier) {
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
+			} else {
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
+			}
 			break;
 		}
 		case 3:
 		{
 			//tell the one closest to the base not carrying the flag to defend the base
-			if (teammates[0] != bs->flagcarrier) other = teammates[0];
-			else other = teammates[1];
-			ClientName(other, name, sizeof(name));
-			BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-			BotSayTeamOrder(bs, other);
-			BotSayVoiceTeamOrder(bs, other, VOICECHAT_DEFEND);
+			if (teammates[0] != bs->flagcarrier) {
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
+			} else {
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
+			}
 			//tell the other also to defend the base
-			if (teammates[2] != bs->flagcarrier) other = teammates[2];
-			else other = teammates[1];
-			ClientName(other, name, sizeof(name));
-			BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-			BotSayTeamOrder(bs, other);
-			BotSayVoiceTeamOrder(bs, other, VOICECHAT_DEFEND);
+			if (teammates[2] != bs->flagcarrier) {
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_DEFENDTHEBASE, NULL);
+			} else {
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
+			}
 			break;
 		}
 		default:
@@ -711,10 +645,7 @@ void BotCTFOrders_EnemyFlagNotAtBase(bot_state_t *bs) {
 				if (teammates[i] == bs->flagcarrier) {
 					continue;
 				}
-				ClientName(teammates[i], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[i]);
-				BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 			}
 			// if we have a flag carrier
 			if ( bs->flagcarrier != -1 ) {
@@ -725,16 +656,11 @@ void BotCTFOrders_EnemyFlagNotAtBase(bot_state_t *bs) {
 						continue;
 					}
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
 					if (bs->flagcarrier == bs->client) {
-						BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
-						BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_FOLLOWME);
+						BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_FOLLOWME, NULL);
+					} else {
+						BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_FOLLOWTEAMMATE, carriername);
 					}
-					else {
-						BotAI_BotInitialChat(bs, "cmd_accompany", name, carriername, NULL);
-						BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_FOLLOWFLAGCARRIER);
-					}
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
 				}
 			}
 			else {
@@ -743,11 +669,7 @@ void BotCTFOrders_EnemyFlagNotAtBase(bot_state_t *bs) {
 					if (teammates[numteammates - i - 1] == bs->flagcarrier) {
 						continue;
 					}
-					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 			}
 			//
@@ -758,58 +680,7 @@ void BotCTFOrders_EnemyFlagNotAtBase(bot_state_t *bs) {
 
 /*
 ==================
-BotDDorders
-==================
-*/
-
-void BotDDorders_Standard(bot_state_t *bs) {
-	int numteammates, i;
-	int teammates[MAX_CLIENTS];
-	char name[MAX_NETNAME];
-
-        if (bot_nochat.integer>2) return;
-
-	//sort team mates by travel time to base
-	numteammates = BotSortTeamMatesByRelativeTravelTime2ddA(bs, teammates, sizeof(teammates));
-
-	switch(numteammates) {
-		case 1: break;
-		/*case 2: 
-		{
-			//the one closest to point A will take that
-			ClientName(teammates[0], name, sizeof(name));
-			BotAI_BotInitialChat(bs, "cmd_takea", name, NULL);
-			BotSayTeamOrder(bs, teammates[0]);
-			//BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_TAKEA);
-			//the other goes for point B
-			ClientName(teammates[1], name, sizeof(name));
-			BotAI_BotInitialChat(bs, "cmd_takeb", name, NULL);
-			BotSayTeamOrder(bs, teammates[1]);
-			//BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_TAKEB);
-			break;
-		}*/
-		default:
-		{
-			for(i=0;i<numteammates/2;i++) { //Half take point A
-				ClientName(teammates[i], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_takea", name, NULL);
-				BotSayTeamOrder(bs, teammates[i]);
-				//BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_TAKEA);
-			}
-			for(i=numteammates/2+1;i<numteammates;i++) { //Rest takes point B
-				ClientName(teammates[i], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_takeb", name, NULL);
-				BotSayTeamOrder(bs, teammates[i]);
-				//BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_TAKEB);
-			}
-			break;
-		}
-	}
-}
-
-/*
-==================
-BotCTFOrders
+BotCTFOrders_BothFlagsAtBase
 ==================
 */
 void BotCTFOrders_BothFlagsAtBase(bot_state_t *bs) {
@@ -818,7 +689,7 @@ void BotCTFOrders_BothFlagsAtBase(bot_state_t *bs) {
 	char name[MAX_NETNAME];
 	qboolean weAreAttacking;
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	//sort team mates by travel time to base
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
@@ -834,19 +705,11 @@ void BotCTFOrders_BothFlagsAtBase(bot_state_t *bs) {
 		
 		if(weAreAttacking) {
 			for (i = 0; i < numteammates; i++) {
-				//
-				ClientName(teammates[i], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[i]);
-				BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_GETTHEFLAG, NULL);
 			}
 		} else {
 			for (i = 0; i < numteammates; i++) {
-				//
-				ClientName(teammates[i], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[i]);
-				BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 			}
 		}
 		return; //Sago: Or the leader will make a counter order.
@@ -860,34 +723,19 @@ void BotCTFOrders_BothFlagsAtBase(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the second one closest to the base will defend the base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			default:
@@ -897,18 +745,10 @@ void BotCTFOrders_BothFlagsAtBase(bot_state_t *bs) {
 				attackers = (int) (float) numteammates * 0.4 + 0.5;
 				if (attackers > 4) attackers = 4;
 				for (i = 0; i < defenders; i++) {
-					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
-					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 				//
 				break;
@@ -922,34 +762,19 @@ void BotCTFOrders_BothFlagsAtBase(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the others should go for the enemy flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				//
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			default:
@@ -960,17 +785,11 @@ void BotCTFOrders_BothFlagsAtBase(bot_state_t *bs) {
 				if (attackers > 5) attackers = 5;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 				//
 				break;
@@ -1005,7 +824,42 @@ BotDDorders
 ==================
 */
 void BotDDorders(bot_state_t *bs) {
-	BotDDorders_Standard(bs);	
+	int numteammates, i;
+	int teammates[MAX_CLIENTS];
+	char name[MAX_NETNAME];
+
+	if (bot_nochat.integer>2) return;
+
+	//sort team mates by travel time to base
+	numteammates = BotSortTeamMatesByRelativeTravelTime2ddA(bs, teammates, sizeof(teammates));
+
+	switch(numteammates) {
+		case 1: break;
+		case 2: 
+		{
+			//the one closest to point A will take that
+			//BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_TAKEPOINTA, NULL);
+			BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_TAKEPOINTA, NULL);
+			//the other goes for point B
+			//BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_TAKEPOINTB, NULL);
+			BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_TAKEPOINTB, NULL);
+			break;
+		}
+		default:
+		{
+			for(i=0;i<numteammates/2;i++) {
+				//Half take point A
+				//BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_TAKEPOINTA, NULL);
+				BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_TAKEPOINTA, NULL);
+			}
+			for(i=numteammates/2+1;i<numteammates;i++) {
+				//Rest takes point B
+				//BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_TAKEPOINTB, NULL);
+				BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_TAKEPOINTB, NULL);
+			}
+			break;
+		}
+	}
 }
 
 
@@ -1018,20 +872,16 @@ void BotCreateGroup(bot_state_t *bs, int *teammates, int groupsize) {
 	char name[MAX_NETNAME], leadername[MAX_NETNAME];
 	int i;
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	// the others in the group will follow the teammates[0]
-	ClientName(teammates[0], leadername, sizeof(leadername));
 	for (i = 1; i < groupsize; i++)
 	{
-		ClientName(teammates[i], name, sizeof(name));
 		if (teammates[0] == bs->client) {
-			BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
+			BotAI_GiveRoleToTheBot(bs, teammates[0], leadername, ORDER_FOLLOWME, NULL);
+		} else {
+			BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_FOLLOWTEAMMATE, leadername);
 		}
-		else {
-			BotAI_BotInitialChat(bs, "cmd_accompany", name, leadername, NULL);
-		}
-		BotSayTeamOrderAlways(bs, teammates[i]);
 	}
 }
 
@@ -1051,9 +901,13 @@ void BotTeamOrders(bot_state_t *bs) {
 	for (i = 0; i < level.maxclients; i++) {
 		trap_GetConfigstring(CS_PLAYERS+i, buf, sizeof(buf));
 		//if no config string or no name
-		if (!strlen(buf) || !strlen(Info_ValueForKey(buf, "n"))) continue;
+		if (!strlen(buf) || !strlen(Info_ValueForKey(buf, "n"))) {
+			continue;
+		}
 		//skip spectators
-		if (atoi(Info_ValueForKey(buf, "t")) == TEAM_SPECTATOR) continue;
+		if (atoi(Info_ValueForKey(buf, "t")) == TEAM_SPECTATOR) {
+			continue;
+		}
 		//
 		if (BotSameTeam(bs, i)) {
 			teammates[numteammates] = i;
@@ -1110,7 +964,7 @@ void Bot1FCTFOrders_FlagAtCenter(bot_state_t *bs) {
 	int teammates[MAX_CLIENTS];
 	char name[MAX_NETNAME];
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	//sort team mates by travel time to base
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
@@ -1124,34 +978,19 @@ void Bot1FCTFOrders_FlagAtCenter(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the second one closest to the base will defend the base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			default:
@@ -1164,17 +1003,11 @@ void Bot1FCTFOrders_FlagAtCenter(bot_state_t *bs) {
 				if (attackers > 4) attackers = 4;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 				//
 				break;
@@ -1188,34 +1021,19 @@ void Bot1FCTFOrders_FlagAtCenter(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the others should go for the enemy flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				//
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			default:
@@ -1228,17 +1046,11 @@ void Bot1FCTFOrders_FlagAtCenter(bot_state_t *bs) {
 				if (attackers > 6) attackers = 6;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 				//
 				break;
@@ -1259,7 +1071,7 @@ void Bot1FCTFOrders_TeamHasFlag(bot_state_t *bs) {
 	int teammates[MAX_CLIENTS];
 	char name[MAX_NETNAME], carriername[MAX_NETNAME];
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	//sort team mates by travel time to base
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
@@ -1273,44 +1085,38 @@ void Bot1FCTFOrders_TeamHasFlag(bot_state_t *bs) {
 			case 2:
 			{
 				//tell the one not carrying the flag to attack the enemy base
-				if (teammates[0] == bs->flagcarrier) other = teammates[1];
-				else other = teammates[0];
-				ClientName(other, name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
-				BotSayTeamOrder(bs, other);
-				BotSayVoiceTeamOrder(bs, other, VOICECHAT_OFFENSE);
+				if (teammates[0] == bs->flagcarrier) {
+					BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_ATTACKTHEENEMYBASE, NULL);
+				} else {
+					BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_ATTACKTHEENEMYBASE, NULL);
+				}
 				break;
 			}
 			case 3:
 			{
 				//tell the one closest to the base not carrying the flag to defend the base
-				if (teammates[0] != bs->flagcarrier) other = teammates[0];
-				else other = teammates[1];
-				ClientName(other, name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, other);
-				BotSayVoiceTeamOrder(bs, other, VOICECHAT_DEFEND);
+				if (teammates[0] != bs->flagcarrier) {
+					BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
+				} else {
+					BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
+				}
 				//tell the one furthest from the base not carrying the flag to accompany the flag carrier
-				if (teammates[2] != bs->flagcarrier) other = teammates[2];
-				else other = teammates[1];
-				ClientName(other, name, sizeof(name));
+				if (teammates[2] != bs->flagcarrier) {
+					other = teammates[2];
+				} else {
+					other = teammates[1];
+				}
 				if ( bs->flagcarrier != -1 ) {
-					ClientName(bs->flagcarrier, carriername, sizeof(carriername));
 					if (bs->flagcarrier == bs->client) {
-						BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
-						BotSayVoiceTeamOrder(bs, other, VOICECHAT_FOLLOWME);
+						BotAI_GiveRoleToTheBot(bs, bs->flagcarrier, carriername, ORDER_FOLLOWME, NULL);
 					}
 					else {
-						BotAI_BotInitialChat(bs, "cmd_accompany", name, carriername, NULL);
-						BotSayVoiceTeamOrder(bs, other, VOICECHAT_FOLLOWFLAGCARRIER);
+						BotAI_GiveRoleToTheBot(bs, bs->flagcarrier, name, ORDER_FOLLOWTEAMMATE, carriername);
 					}
-				}
-				else {
+				} else {
 					//
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayVoiceTeamOrder(bs, other, VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, other, name, ORDER_GETTHEFLAG, NULL);
 				}
-				BotSayTeamOrder(bs, other);
 				break;
 			}
 			default:
@@ -1326,10 +1132,7 @@ void Bot1FCTFOrders_TeamHasFlag(bot_state_t *bs) {
 					if (teammates[i] == bs->flagcarrier) {
 						continue;
 					}
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				if (bs->flagcarrier != -1) {
 					ClientName(bs->flagcarrier, carriername, sizeof(carriername));
@@ -1339,16 +1142,11 @@ void Bot1FCTFOrders_TeamHasFlag(bot_state_t *bs) {
 							continue;
 						}
 						//
-						ClientName(teammates[numteammates - i - 1], name, sizeof(name));
 						if (bs->flagcarrier == bs->client) {
-							BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
-							BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_FOLLOWME);
+							BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_FOLLOWME, NULL);
+						} else {
+							BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_FOLLOWTEAMMATE, carriername);
 						}
-						else {
-							BotAI_BotInitialChat(bs, "cmd_accompany", name, carriername, NULL);
-							BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_FOLLOWFLAGCARRIER);
-						}
-						BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
 					}
 				}
 				else {
@@ -1358,10 +1156,7 @@ void Bot1FCTFOrders_TeamHasFlag(bot_state_t *bs) {
 							continue;
 						}
 						//
-						ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-						BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-						BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-						BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+						BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 					}
 				}
 				//
@@ -1376,37 +1171,32 @@ void Bot1FCTFOrders_TeamHasFlag(bot_state_t *bs) {
 			case 2:
 			{
 				//tell the one not carrying the flag to defend the base
-				if (teammates[0] == bs->flagcarrier) other = teammates[1];
-				else other = teammates[0];
-				ClientName(other, name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, other);
-				BotSayVoiceTeamOrder(bs, other, VOICECHAT_DEFEND);
+				if (teammates[0] == bs->flagcarrier) {
+					BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
+				} else {
+					BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
+				}
 				break;
 			}
 			case 3:
 			{
 				//tell the one closest to the base not carrying the flag to defend the base
-				if (teammates[0] != bs->flagcarrier) other = teammates[0];
-				else other = teammates[1];
-				ClientName(other, name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, other);
-				BotSayVoiceTeamOrder(bs, other, VOICECHAT_DEFEND);
+				if (teammates[0] != bs->flagcarrier) {
+					BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
+				} else {
+					BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
+				}
 				//tell the one furthest from the base not carrying the flag to accompany the flag carrier
-				if (teammates[2] != bs->flagcarrier) other = teammates[2];
-				else other = teammates[1];
-				ClientName(other, name, sizeof(name));
-				ClientName(bs->flagcarrier, carriername, sizeof(carriername));
+				if (teammates[2] != bs->flagcarrier) {
+					ClientName(teammates[2], name, sizeof(name));
+				} else {
+					ClientName(teammates[1], name, sizeof(name));
+				}
 				if (bs->flagcarrier == bs->client) {
-					BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
-					BotSayVoiceTeamOrder(bs, other, VOICECHAT_FOLLOWME);
+					BotAI_GiveRoleToTheBot(bs, bs->flagcarrier, carriername, ORDER_FOLLOWME, NULL);
+				} else {
+					BotAI_GiveRoleToTheBot(bs, bs->flagcarrier, name, ORDER_FOLLOWTEAMMATE, carriername);
 				}
-				else {
-					BotAI_BotInitialChat(bs, "cmd_accompany", name, carriername, NULL);
-					BotSayVoiceTeamOrder(bs, other, VOICECHAT_FOLLOWFLAGCARRIER);
-				}
-				BotSayTeamOrder(bs, other);
 				break;
 			}
 			default:
@@ -1422,10 +1212,7 @@ void Bot1FCTFOrders_TeamHasFlag(bot_state_t *bs) {
 					if (teammates[i] == bs->flagcarrier) {
 						continue;
 					}
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				ClientName(bs->flagcarrier, carriername, sizeof(carriername));
 				for (i = 0; i < attackers; i++) {
@@ -1434,16 +1221,12 @@ void Bot1FCTFOrders_TeamHasFlag(bot_state_t *bs) {
 						continue;
 					}
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
 					if (bs->flagcarrier == bs->client) {
-						BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
-						BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_FOLLOWME);
+						BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_FOLLOWME, NULL);
 					}
 					else {
-						BotAI_BotInitialChat(bs, "cmd_accompany", name, carriername, NULL);
-						BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_FOLLOWFLAGCARRIER);
+						BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_FOLLOWTEAMMATE, carriername);
 					}
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
 				}
 				//
 				break;
@@ -1464,7 +1247,7 @@ void Bot1FCTFOrders_EnemyHasFlag(bot_state_t *bs) {
 	int teammates[MAX_CLIENTS];
 	char name[MAX_NETNAME];
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	//sort team mates by travel time to base
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
@@ -1478,34 +1261,19 @@ void Bot1FCTFOrders_EnemyHasFlag(bot_state_t *bs) {
 			case 2:
 			{
 				//both defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the second one closest to the base will defend the base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will also defend the base
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_DEFENDTHEBASE, NULL);
 				break;
 			}
 			default:
@@ -1518,17 +1286,11 @@ void Bot1FCTFOrders_EnemyHasFlag(bot_state_t *bs) {
 				if (attackers > 1) attackers = 1;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_returnflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_RETURNOURFLAG, NULL);
 				}
 				//
 				break;
@@ -1542,34 +1304,19 @@ void Bot1FCTFOrders_EnemyHasFlag(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the others should go for the enemy flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				//
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_returnflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_RETURNOURFLAG, NULL);
 				break;
 			}
 			default:
@@ -1582,17 +1329,11 @@ void Bot1FCTFOrders_EnemyHasFlag(bot_state_t *bs) {
 				if (attackers > 2) attackers = 2;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_returnflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_RETURNOURFLAG, NULL);
 				}
 				//
 				break;
@@ -1613,7 +1354,7 @@ void Bot1FCTFOrders_EnemyDroppedFlag(bot_state_t *bs) {
 	int teammates[MAX_CLIENTS];
 	char name[MAX_NETNAME];
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	//sort team mates by travel time to base
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
@@ -1627,34 +1368,19 @@ void Bot1FCTFOrders_EnemyDroppedFlag(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the second one closest to the base will defend the base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			default:
@@ -1667,17 +1393,11 @@ void Bot1FCTFOrders_EnemyDroppedFlag(bot_state_t *bs) {
 				if (attackers > 4) attackers = 4;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 				//
 				break;
@@ -1691,34 +1411,19 @@ void Bot1FCTFOrders_EnemyDroppedFlag(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will get the flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the others should go for the enemy flag
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_GETTHEFLAG, NULL);
 				//
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_GETFLAG);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_GETTHEFLAG, NULL);
 				break;
 			}
 			default:
@@ -1731,17 +1436,11 @@ void Bot1FCTFOrders_EnemyDroppedFlag(bot_state_t *bs) {
 				if (attackers > 6) attackers = 6;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_GETFLAG);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_GETTHEFLAG, NULL);
 				}
 				//
 				break;
@@ -1776,7 +1475,7 @@ void BotObeliskOrders(bot_state_t *bs) {
 	int teammates[MAX_CLIENTS];
 	char name[MAX_NETNAME];
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	//sort team mates by travel time to base
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
@@ -1790,34 +1489,19 @@ void BotObeliskOrders(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will attack the enemy base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_ATTACKTHEENEMYBASE, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the one second closest to the base also defends the base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other one attacks the enemy base
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_ATTACKTHEENEMYBASE, NULL);
 				break;
 			}
 			default:
@@ -1830,17 +1514,11 @@ void BotObeliskOrders(bot_state_t *bs) {
 				if (attackers > 4) attackers = 4;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_OFFENSE);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_ATTACKTHEENEMYBASE, NULL);
 				}
 				//
 				break;
@@ -1854,34 +1532,19 @@ void BotObeliskOrders(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will attack the enemy base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_ATTACKTHEENEMYBASE, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the others attack the enemy base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_ATTACKTHEENEMYBASE, NULL);
 				//
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_ATTACKTHEENEMYBASE, NULL);
 				break;
 			}
 			default:
@@ -1894,17 +1557,11 @@ void BotObeliskOrders(bot_state_t *bs) {
 				if (attackers > 7) attackers = 7;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_OFFENSE);
+					BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_ATTACKTHEENEMYBASE, NULL);
 				}
 				//
 				break;
@@ -1925,7 +1582,7 @@ void BotHarvesterOrders(bot_state_t *bs) {
 	int teammates[MAX_CLIENTS];
 	char name[MAX_NETNAME];
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
 	//sort team mates by travel time to base
 	numteammates = BotSortTeamMatesByBaseTravelTime(bs, teammates, sizeof(teammates));
@@ -1939,34 +1596,19 @@ void BotHarvesterOrders(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will harvest
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_harvest", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_HARVESTSOMESKULLS, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the one second closest to the base also defends the base
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other one goes harvesting
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_harvest", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_HARVESTSOMESKULLS, NULL);
 				break;
 			}
 			default:
@@ -1979,17 +1621,11 @@ void BotHarvesterOrders(bot_state_t *bs) {
 				if (attackers > 4) attackers = 4;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_harvest", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_OFFENSE);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_HARVESTSOMESKULLS, NULL);
 				}
 				//
 				break;
@@ -2003,34 +1639,19 @@ void BotHarvesterOrders(bot_state_t *bs) {
 			case 2:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the other will harvest
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_harvest", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_HARVESTSOMESKULLS, NULL);
 				break;
 			}
 			case 3:
 			{
 				//the one closest to the base will defend the base
-				ClientName(teammates[0], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-				BotSayTeamOrder(bs, teammates[0]);
-				BotSayVoiceTeamOrder(bs, teammates[0], VOICECHAT_DEFEND);
+				BotAI_GiveRoleToTheBot(bs, teammates[0], name, ORDER_DEFENDTHEBASE, NULL);
 				//the others go harvesting
-				ClientName(teammates[1], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_harvest", name, NULL);
-				BotSayTeamOrder(bs, teammates[1]);
-				BotSayVoiceTeamOrder(bs, teammates[1], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[1], name, ORDER_HARVESTSOMESKULLS, NULL);
 				//
-				ClientName(teammates[2], name, sizeof(name));
-				BotAI_BotInitialChat(bs, "cmd_harvest", name, NULL);
-				BotSayTeamOrder(bs, teammates[2]);
-				BotSayVoiceTeamOrder(bs, teammates[2], VOICECHAT_OFFENSE);
+				BotAI_GiveRoleToTheBot(bs, teammates[2], name, ORDER_HARVESTSOMESKULLS, NULL);
 				break;
 			}
 			default:
@@ -2043,17 +1664,11 @@ void BotHarvesterOrders(bot_state_t *bs) {
 				if (attackers > 7) attackers = 7;
 				for (i = 0; i < defenders; i++) {
 					//
-					ClientName(teammates[i], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
-					BotSayTeamOrder(bs, teammates[i]);
-					BotSayVoiceTeamOrder(bs, teammates[i], VOICECHAT_DEFEND);
+					BotAI_GiveRoleToTheBot(bs, teammates[i], name, ORDER_DEFENDTHEBASE, NULL);
 				}
 				for (i = 0; i < attackers; i++) {
 					//
-					ClientName(teammates[numteammates - i - 1], name, sizeof(name));
-					BotAI_BotInitialChat(bs, "cmd_harvest", name, NULL);
-					BotSayTeamOrder(bs, teammates[numteammates - i - 1]);
-					BotSayVoiceTeamOrder(bs, teammates[numteammates - i - 1], VOICECHAT_OFFENSE);
+					BotAI_GiveRoleToTheBot(bs, teammates[numteammates - i - 1], name, ORDER_HARVESTSOMESKULLS, NULL);
 				}
 				//
 				break;
@@ -2082,7 +1697,7 @@ int FindHumanTeamLeader(bot_state_t *bs) {
 						// if not yet ordered to do anything
 						if ( !BotSetLastOrderedTask(bs) ) {
 							// go on defense by default
-							if (bot_nochat.integer<3)BotVoiceChat_Defend(bs, i, SAY_TELL);
+							if (bot_nochat.integer<3) BotVoiceChat_Defend(bs, i, SAY_TELL);
 						}
 						return qtrue;
 					}
@@ -2104,11 +1719,10 @@ void BotTeamAI(bot_state_t *bs) {
 	int numteammates;
 	char netname[MAX_NETNAME];
 
-        if (bot_nochat.integer>2) return;
+	if (bot_nochat.integer>2) return;
 
-	//
-	if (!G_IsATeamGametype(gametype))
-		return;
+	// Not valid for non-team-based gametypes.
+	if (!G_IsATeamGametype(gametype)) return;
 	// make sure we've got a valid team leader
 	if (!BotValidTeamLeader(bs)) {
 		//
@@ -2117,8 +1731,7 @@ void BotTeamAI(bot_state_t *bs) {
 			if (!bs->askteamleader_time && !bs->becometeamleader_time) {
 				if (bs->entergame_time + 10 > FloatTime()) {
 					bs->askteamleader_time = FloatTime() + 5 + random() * 10;
-				}
-				else {
+				} else {
 					bs->becometeamleader_time = FloatTime() + 5 + random() * 10;
 				}
 			}
@@ -2270,6 +1883,96 @@ void BotTeamAI(bot_state_t *bs) {
 			}
 			break;
 		}
+		case GT_DOMINATION:
+		{
+			// Here there be orders for Domination. Soon.
+			break;
+		}
 	}
 }
 
+void BotAI_GiveRoleToTheBot(bot_state_t *bs, int teammate, char *name, int order, char *botToFollow) {
+	if (bot_nochat.integer >= 3) {
+		return;
+	}
+
+	ClientName(teammate, name, sizeof(name));
+	switch(order) {
+		case ORDER_GETTHEFLAG:
+		{
+			BotAI_BotInitialChat(bs, "cmd_getflag", name, NULL);
+			BotSayTeamOrder(bs, teammate);
+			BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_GETFLAG);
+			break;
+		}
+		case ORDER_FOLLOWME:
+		{
+			BotAI_BotInitialChat(bs, "cmd_accompanyme", name, NULL);
+			BotSayTeamOrder(bs, teammate);
+			BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_FOLLOWME);
+			break;
+		}
+		case ORDER_FOLLOWTEAMMATE:
+		{
+			if (!(botToFollow)) {
+				return;
+			}
+			ClientName(teammate, name, sizeof(name));
+			BotAI_BotInitialChat(bs, "cmd_accompany", name, botToFollow, NULL);
+			BotSayTeamOrder(bs, teammate);
+			BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_FOLLOWFLAGCARRIER);
+			break;
+		}
+		case ORDER_DEFENDTHEBASE:
+		{
+			BotAI_BotInitialChat(bs, "cmd_defendbase", name, NULL);
+			BotSayTeamOrder(bs, teammate);
+			BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_DEFEND);
+			break;
+		}
+		case ORDER_TAKEPOINTA:
+		{
+			BotAI_BotInitialChat(bs, "cmd_takea", name, NULL);
+			BotSayTeamOrder(bs, teammate);
+			//BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_TAKEA);
+			BotSayVoiceTeamOrder(bs, teammate, NULL);
+			break;
+		}
+		case ORDER_TAKEPOINTB:
+		{
+			BotAI_BotInitialChat(bs, "cmd_takeb", name, NULL);
+			BotSayTeamOrder(bs, teammate);
+			//BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_TAKEB);
+			BotSayVoiceTeamOrder(bs, teammate, NULL);
+			break;
+		}
+		case ORDER_ATTACKTHEENEMYBASE:
+		{
+			BotAI_BotInitialChat(bs, "cmd_attackenemybase", name, NULL);
+			BotSayTeamOrder(bs, teammate);
+			BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_OFFENSE);
+			break;
+		}
+		case ORDER_RETURNOURFLAG:
+		{
+			BotAI_BotInitialChat(bs, "cmd_returnflag", name, NULL);
+			BotSayTeamOrder(bs, teammate);
+			//BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_RETURNOURFLAG);
+			BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_GETFLAG);
+			break;
+		}
+		case ORDER_HARVESTSOMESKULLS:
+		{
+			BotAI_BotInitialChat(bs, "cmd_harvest", name, NULL);
+			BotSayTeamOrder(bs, teammate);
+			//BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_HARVESTSKULLS);
+			BotSayVoiceTeamOrder(bs, teammate, VOICECHAT_OFFENSE);
+			break;
+		}
+		default:
+		{
+			// Here goes the command for roaming.
+			break;
+		}
+	}
+}

--- a/code/game/ai_team.h
+++ b/code/game/ai_team.h
@@ -30,10 +30,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  *****************************************************************************/
 
+#define ORDER_GETTHEFLAG			1
+#define ORDER_FOLLOWME			2
+#define ORDER_FOLLOWTEAMMATE		3
+#define ORDER_DEFENDTHEBASE		4
+#define ORDER_TAKEPOINTA			5
+#define ORDER_TAKEPOINTB			6
+#define ORDER_ATTACKTHEENEMYBASE	7
+#define ORDER_RETURNOURFLAG		8
+#define ORDER_HARVESTSOMESKULLS	9
+
 void BotTeamAI(bot_state_t *bs);
 int BotGetTeamMateTaskPreference(bot_state_t *bs, int teammate);
 void BotSetTeamMateTaskPreference(bot_state_t *bs, int teammate, int preference);
 void BotVoiceChat(bot_state_t *bs, int toclient, char *voicechat);
 void BotVoiceChatOnly(bot_state_t *bs, int toclient, char *voicechat);
 
-
+void BotAI_GiveRoleToTheBot(bot_state_t *bs, int teammate, char *name, int order, char *botToFollow);


### PR DESCRIPTION
This commit aims to make bot team formations easier to create by moving redundant pieces of code to a new function, as well as creating new bot orders.

For the future, we should create functions for Single Domination and more formations for Double Domination.

In general:
* Simplified the code by sending redundant pieces of code to new function BotAI_GiveRoleToTheBot().
* Deleted BotDDOrders_Standard(). Its content is now inside of BotDDOrders. We shall see in the future.
* Calls to the voicelines and chatlines were grouped by role. This should also make easier to add more roles in the future (such as those for Domination).