### PR TITLE
[Testing required] elimination_keepItems

### DIFF
--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -188,8 +188,7 @@ int BotAI_GetEntityState( int entityNum, entityState_t *state ) {
 	memset( state, 0, sizeof(entityState_t) );
 	if (!ent->inuse) return qfalse;
 	if (!ent->r.linked) return qfalse;
-	if ( !(G_IsARoundBasedGametype(g_gametype.integer) ||g_instantgib.integer || g_rockets.integer || g_elimination_allgametypes.integer)
-	       && (ent->r.svFlags & SVF_NOCLIENT) ) {
+	if (!G_HasEliminationRules(g_gametype.integer) && ent->r.svFlags & SVF_NOCLIENT) {
 		return qfalse;
 	}
 	memcpy( state, &ent->s, sizeof(entityState_t) );
@@ -1526,8 +1525,7 @@ int BotAIStartFrame(int time) {
 				trap_BotLibUpdateEntity(i, NULL);
 				continue;
 			}
-			if ( !(G_IsARoundBasedGametype(g_gametype.integer) ||g_instantgib.integer || g_rockets.integer || g_elimination_allgametypes.integer)
-				   && ent->r.svFlags & SVF_NOCLIENT) {
+			if ( !G_HasEliminationRules(g_gametype.integer) && ent->r.svFlags & SVF_NOCLIENT) {
 				trap_BotLibUpdateEntity(i, NULL);
 				continue;
 			}

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -133,11 +133,8 @@ void TossClientItems( gentity_t *self )
 		}
 	}
 
-	if (g_instantgib.integer || g_rockets.integer || g_gametype.integer == GT_CTF_ELIMINATION || g_elimination_allgametypes.integer) {
-		//Nothing!
-	}
-	else if ( weapon > WP_MACHINEGUN && weapon != WP_GRAPPLING_HOOK &&
-	          self->client->ps.ammo[ weapon ] ) {
+	if ((!G_HasEliminationRules(g_gametype.integer) || (G_IsARoundBasedGametype(g_gametype.integer) && !G_UsesTeamFlags(g_gametype.integer))) &&
+			(weapon > WP_MACHINEGUN && weapon != WP_GRAPPLING_HOOK && self->client->ps.ammo[weapon])) {
 		// find the item type for this weapon
 		item = BG_FindItemForWeapon( weapon );
 

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1115,6 +1115,7 @@ extern vmCvar_t g_elimination_mine;
 extern vmCvar_t g_elimination_nail;
 //If lockspectator: 0=no limit, 1 = cannot follow enemy, 2 = must follow friend
 extern vmCvar_t g_elimination_lockspectator;
+extern vmCvar_t g_elimination_keepItems;
 extern vmCvar_t g_rockets;
 //new in elimination Beta2
 extern vmCvar_t g_instantgib;
@@ -1431,4 +1432,5 @@ qboolean G_IsATeamGametype(int check);	/* Whether the gametype is team-based or 
 qboolean G_UsesTeamFlags(int check);	/* Whether the gametype uses the red and blue flags. */
 qboolean G_UsesTheWhiteFlag(int check);	/* Whether the gametype uses the neutral flag. */
 qboolean G_IsARoundBasedGametype(int check);	/* Whether the gametype uses the neutral flag. */
+qboolean G_HasEliminationRules(int check);	/* Whether the current game uses Elimination rules (all weapons at start, no pickups). */
 /* /Neon_Knight */

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -130,6 +130,7 @@ vmCvar_t g_elimination_chain;
 vmCvar_t g_elimination_mine;
 vmCvar_t g_elimination_nail;
 vmCvar_t g_elimination_lockspectator;
+vmCvar_t g_elimination_keepItems;
 vmCvar_t g_rockets;
 //dmn_clowns suggestions (with my idea of implementing):
 vmCvar_t g_instantgib;
@@ -339,6 +340,8 @@ static cvarTable_t gameCvarTable[] = {
 	{ &g_elimination_ctf_oneway, "elimination_ctf_oneway", "0", CVAR_ARCHIVE, 0, qtrue },
 
 	{ &g_elimination_lockspectator, "elimination_lockspectator", "0", 0, qtrue },
+
+	{ &g_elimination_keepItems, "elimination_keepItems", "0", CVAR_ARCHIVE, qtrue },
 
 	{ &g_awardpushing, "g_awardpushing", "1", CVAR_ARCHIVE, 0, qtrue },
 
@@ -2871,5 +2874,36 @@ Checks if the gametype has a round-based system.
  */
 qboolean G_IsARoundBasedGametype(int check) {
 	return GAMETYPE_IS_ROUND_BASED(check);
+}
+/*
+===================
+G_HasEliminationRules
+
+Checks if the gametype uses Elimination (all weapons at start, no pickups) rules.
+===================
+ */
+qboolean G_HasEliminationRules(int check) {
+	// The gametype doesn't use Elimination rules if:
+	if (G_IsARoundBasedGametype (check)) {
+		// Is a round-based no-item game.
+		if (!g_elimination_keepItems.integer) {
+			return qtrue;
+		}
+	}
+	else {
+		// Is a non-round-based Elimination game.
+		if (g_elimination_allgametypes.integer) {
+			return qtrue;
+		}
+	}
+	// Is an Instagib match.
+	if (g_instantgib.integer) {
+		return qtrue;
+	}
+	// Is an All Rockets match.
+	if (g_rockets.integer) {
+		return qtrue;
+	}
+	return qfalse;
 }
 /* /Neon_Knight */


### PR DESCRIPTION
Here's the promised initial request for elimination_keepItems that appeared in #86.

[Here's also a test pk3.](https://cdn.discordapp.com/attachments/405518544382590987/673724175290204180/z_oax_v2.pk3)

In order to keep consistency across all of the Elimination modes, I had to create a new function that resumes all the checks for an Elimination-based ruleset.

What needs to be tested here?

* Item spawn in Elimination, CTF Elimination and LMS (in current master OAX there's a bug in LMS where items are spawned, this PR also solves that bug).
* Item spawn in Instagib.
* Item spawn in All Rockets.
* Item spawn in Elimination_AllGametypes.

Ideally, only key objectives should spawn and work in these modes. And in the case of Elimination, items other than key objectives should spawn only if **elimination_keepItems** is enabled.

**Once we tackle all of the bugs and quirks, then we can proceed to separate bunches of items, as mentioned #86.**