### PR TITLE
[Ready] Backports from ioQuake3 (gamecode)

### DIFF
--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -1760,7 +1760,7 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 	}
 
 	// make sure we aren't looking at cg.predictedPlayerEntity for LG
-	nonPredictedCent = &cg_entities[cent->currentState.clientNum];
+	nonPredictedCent = &cg_entities[cent->currentState.number];
 
 	// if the index of the nonPredictedCent is not the same as the clientNum
 	// then this is a fake player (like on teh single player podiums), so

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -911,14 +911,15 @@ void SetTeam( gentity_t *ent, const char *s ) {
 		CheckTeamLeader( oldTeam );
 	}
 
-	BroadcastTeamChange( client, oldTeam );
-
 	// get and distribute relevent paramters
 	ClientUserinfoChanged( clientNum );
 	// client hasn't spawned yet, they sent an early team command, teampref userinfo, or g_teamAutoJoin is enabled
 	if ( client->pers.connected != CON_CONNECTED ) {
 		return;
 	}
+
+	BroadcastTeamChange( client, oldTeam );
+
 	ClientBegin( clientNum );
 }
 

--- a/code/q3_ui/ui_teamorders.c
+++ b/code/q3_ui/ui_teamorders.c
@@ -408,7 +408,7 @@ static void UI_TeamOrdersMenu_BuildBotList( void )
 	int		numPlayers;
 	int		isBot;
 	int		n;
-	char	playerTeam = '3';
+	char	playerTeam;
 	char	botTeam;
 	char	info[MAX_INFO_STRING];
 
@@ -425,13 +425,15 @@ static void UI_TeamOrdersMenu_BuildBotList( void )
 	numPlayers = atoi( Info_ValueForKey( info, "sv_maxclients" ) );
 	teamOrdersMenuInfo.gametype = atoi( Info_ValueForKey( info, "g_gametype" ) );
 
-	for( n = 0; n < numPlayers && teamOrdersMenuInfo.numBots < 9; n++ ) {
-		trap_GetConfigString( CS_PLAYERS + n, info, MAX_INFO_STRING );
+	trap_GetConfigString( CS_PLAYERS + cs.clientNum, info, MAX_INFO_STRING );
+	playerTeam = *Info_ValueForKey( info, "t" );
 
+	for( n = 0; n < numPlayers && teamOrdersMenuInfo.numBots < 9; n++ ) {
 		if( n == cs.clientNum ) {
-			playerTeam = *Info_ValueForKey( info, "t" );
 			continue;
 		}
+
+		trap_GetConfigString( CS_PLAYERS + n, info, MAX_INFO_STRING );
 
 		isBot = atoi( Info_ValueForKey( info, "skill" ) );
 		if( !isBot ) {

--- a/code/q3_ui/ui_video.c
+++ b/code/q3_ui/ui_video.c
@@ -364,6 +364,7 @@ static int resToRatio[ MAX_RESOLUTIONS ];
 
 static char resbuf[ MAX_STRING_CHARS ];
 static const char* detectedResolutions[ MAX_RESOLUTIONS ];
+static char currentResolution[ 20 ];
 
 static const char** resolutions = builtinResolutions;
 static qboolean resolutionsDetected = qfalse;
@@ -496,7 +497,7 @@ GraphicsOptions_GetResolutions
 */
 static void GraphicsOptions_GetResolutions( void )
 {
-    Q_strncpyz(resbuf, UI_Cvar_VariableString("r_availableModes"), sizeof(resbuf));
+    trap_Cvar_VariableStringBuffer("r_availableModes", resbuf, sizeof(resbuf));
     if(*resbuf)
     {
         char* s = resbuf;
@@ -510,10 +511,25 @@ static void GraphicsOptions_GetResolutions( void )
         }
         detectedResolutions[ i ] = NULL;
 
-        if( i > 0 )
+		// add custom resolution if not in mode list
+		if ( i < ARRAY_LEN(detectedResolutions)-1 )
         {
-            resolutions = detectedResolutions;
-            resolutionsDetected = qtrue;
+			Com_sprintf( currentResolution, sizeof ( currentResolution ), "%dx%d", uis.glconfig.vidWidth, uis.glconfig.vidHeight );
+
+			for( i = 0; detectedResolutions[ i ]; i++ )
+			{
+				if ( strcmp( detectedResolutions[ i ], currentResolution ) == 0 )
+					break;
+			}
+
+			if ( detectedResolutions[ i ] == NULL )
+			{
+				detectedResolutions[ i++ ] = currentResolution;
+				detectedResolutions[ i ] = NULL;
+			}
+		
+		resolutions = detectedResolutions;
+		resolutionsDetected = qtrue;
         }
     }
 }

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -3984,6 +3984,7 @@ static void UI_Update(const char *name)
 			trap_Cvar_SetValue( "r_stencilbits", 8 );
 			trap_Cvar_SetValue( "r_picmip", 0 );
 			trap_Cvar_SetValue( "r_mode", 4 );
+			trap_Cvar_Set( "ui_videomode", "800x600" );
 			trap_Cvar_SetValue( "r_texturebits", 32 );
 			trap_Cvar_SetValue( "r_fastSky", 0 );
 			trap_Cvar_SetValue( "r_inGameVideo", 1 );
@@ -4001,6 +4002,7 @@ static void UI_Update(const char *name)
 			trap_Cvar_Reset( "r_stencilbits" );
 			trap_Cvar_SetValue( "r_picmip", 1 );
 			trap_Cvar_SetValue( "r_mode", 3 );
+			trap_Cvar_Set( "ui_videomode", "640x480" );
 			trap_Cvar_SetValue( "r_texturebits", 0 );
 			trap_Cvar_SetValue( "r_fastSky", 0 );
 			trap_Cvar_SetValue( "r_inGameVideo", 1 );
@@ -4018,6 +4020,7 @@ static void UI_Update(const char *name)
 			trap_Cvar_Reset( "r_stencilbits" );
 			trap_Cvar_SetValue( "r_picmip", 1 );
 			trap_Cvar_SetValue( "r_mode", 3 );
+			trap_Cvar_Set( "ui_videomode", "640x480" );
 			trap_Cvar_SetValue( "r_texturebits", 0 );
 			trap_Cvar_SetValue( "cg_shadows", 0 );
 			trap_Cvar_SetValue( "r_fastSky", 1 );
@@ -4034,6 +4037,7 @@ static void UI_Update(const char *name)
 			trap_Cvar_SetValue( "r_depthbits", 16 );
 			trap_Cvar_SetValue( "r_stencilbits", 0 );
 			trap_Cvar_SetValue( "r_mode", 3 );
+			trap_Cvar_Set( "ui_videomode", "640x480" );
 			trap_Cvar_SetValue( "r_picmip", 2 );
 			trap_Cvar_SetValue( "r_texturebits", 16 );
 			trap_Cvar_SetValue( "cg_shadows", 0 );
@@ -6354,6 +6358,8 @@ void _UI_Init( qboolean inGameLoad, int randomSeed )
 	// cache redundant calulations
 	trap_GetGlconfig( &uiInfo.uiDC.glconfig );
 
+	trap_Cvar_Set("ui_videomode", va( "%dx%d", uiInfo.uiDC.glconfig.vidWidth, uiInfo.uiDC.glconfig.vidHeight ) );
+
 	// for 640x480 virtualized screen
 	uiInfo.uiDC.yscale = uiInfo.uiDC.glconfig.vidHeight * (1.0/480.0);
 	uiInfo.uiDC.xscale = uiInfo.uiDC.glconfig.vidWidth * (1.0/640.0);
@@ -7342,6 +7348,7 @@ static cvarTable_t		cvarTable[] = {
 // leilei
 	{ &ui_colors, "ui_colors", "0x1e3072 0x7286d0 0x1fd1b2 0x606060", CVAR_ARCHIVE},
 	{ &ui_developer, "developer", "0", CVAR_CHEAT },
+	{ NULL, "ui_videomode", "", CVAR_ROM },
 	{ NULL, "g_localTeamPref", "", 0 },
 };
 


### PR DESCRIPTION
ioquake/ioq3@c61417b8: Add current (custom) resolution to Q3 UI video mode list
ioquake/ioq3@9fcb2bb3: Override video mode list in Team Arena UI
ioquake/ioq3@f717a839: Fix lightning gun handling for corpses and single player podiums
ioquake/ioq3@dc0c3e7b: Fix team orders menu not listing clients with lower clientnums
ioquake/ioq3@a6e66700: Fix duplicate team join center print for bots and g_teamAutoJoin
