### PR TITLE
[Testing required] Enhanced AI checks for Grappling Hook handling

### DIFF
--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -1557,7 +1557,8 @@ int AINode_Seek_ActivateEntity(bot_state_t *bs) {
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	// if they have the Grappling Hook
+	if (BotCanAndWantsToUseTheGrapple(bs)) bs->tfl |= TFL_GRAPPLEHOOK;
 	// if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	// map specific code
@@ -1770,7 +1771,8 @@ int AINode_Seek_NBG(bot_state_t *bs) {
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	// if they have the Grappling Hook
+	if (BotCanAndWantsToUseTheGrapple(bs)) bs->tfl |= TFL_GRAPPLEHOOK;
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -1913,7 +1915,8 @@ int AINode_Seek_LTG(bot_state_t *bs)
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	// if they have the Grappling Hook
+	if (BotCanAndWantsToUseTheGrapple(bs)) bs->tfl |= TFL_GRAPPLEHOOK;
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -2191,7 +2194,8 @@ int AINode_Battle_Fight(bot_state_t *bs) {
 	BotBattleUseItems(bs);
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	// if they have the Grappling Hook
+	if (BotCanAndWantsToUseTheGrapple(bs)) bs->tfl |= TFL_GRAPPLEHOOK;
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -2284,7 +2288,8 @@ int AINode_Battle_Chase(bot_state_t *bs)
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	// if they have the Grappling Hook
+	if (BotCanAndWantsToUseTheGrapple(bs)) bs->tfl |= TFL_GRAPPLEHOOK;
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -2421,7 +2426,7 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	if (BotCanAndWantsToUseTheGrapple(bs)) bs->tfl |= TFL_GRAPPLEHOOK;
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//map specific code
@@ -2600,7 +2605,8 @@ int AINode_Battle_NBG(bot_state_t *bs) {
 	}
 	//
 	bs->tfl = TFL_DEFAULT;
-	if (bot_grapple.integer) bs->tfl |= TFL_GRAPPLEHOOK;
+	// if they have the Grappling Hook
+	if (BotCanAndWantsToUseTheGrapple(bs)) bs->tfl |= TFL_GRAPPLEHOOK;
 	//if in lava or slime the bot should be able to get out
 	if (BotInLavaOrSlime(bs)) bs->tfl |= TFL_LAVA|TFL_SLIME;
 	//
@@ -2694,4 +2700,3 @@ int AINode_Battle_NBG(bot_state_t *bs) {
 	//
 	return qtrue;
 }
-

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -5526,7 +5526,7 @@ int BotCanAndWantsToUseTheGrapple(bot_state_t *bs) {
 	}
 	// * if their own bot file settings allow for it
 	grappler = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_GRAPPLE_USER, 0, 1);
-	if (grappler < 0.5) {
+	if (random() < grappler) {
 		return qfalse;
 	}
 	// Else they'll be happy to use it

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -5506,3 +5506,29 @@ BotShutdownDeathmatchAI
 void BotShutdownDeathmatchAI(void) {
 	altroutegoals_setup = qfalse;
 }
+
+/*
+==================
+BotCanAndWantsToUseTheGrapple
+Before using the Grappling Hook, runs a series of checks.
+==================
+*/
+int BotCanAndWantsToUseTheGrapple(bot_state_t *bs) {
+	float grappler;
+	// Bots won't use the grapple if:
+	// * grappling for them is disabled
+	if (!bot_grapple.integer) {
+		return qfalse;
+	}
+	// * they don't have the Grappling Hook
+	if (!bs->inventory[INVENTORY_GRAPPLINGHOOK]) {
+		return qfalse;
+	}
+	// * if their own bot file settings allow for it
+	grappler = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_GRAPPLE_USER, 0, 1);
+	if (grappler < 0.5) {
+		return qfalse;
+	}
+	// Else they'll be happy to use it
+	return qtrue;
+}

--- a/code/game/ai_dmq3.h
+++ b/code/game/ai_dmq3.h
@@ -92,6 +92,8 @@ int BotWantsToChase(bot_state_t *bs);
 int BotWantsToHelp(bot_state_t *bs);
 //returns true if the bot can and wants to rocketjump
 int BotCanAndWantsToRocketJump(bot_state_t *bs);
+// returns true if the bot has the Grappling Hook and wants to use it
+int BotCanAndWantsToUseTheGrapple(bot_state_t *bs);
 // returns true if the bot has a persistant powerup and a weapon
 int BotHasPersistantPowerupAndWeapon(bot_state_t *bs);
 //returns true if the bot wants to and goes camping


### PR DESCRIPTION
Well, what it says in the tin.

**[Here's a test pk3](https://www.dropbox.com/s/hu0fd56xzy06hp4/z_oax-classicui-grapplinghookforbots.pk3?dl=0). _(Updated March 20, 2022, 18:34 GMT-3)_ - [Related forum thread](http://openarena.ws/board/index.php?topic=5458.0).**

**Overview**

While in Q3A (and up to OA 0.8.1) the Grappling Hook was left as just a dummied out weapon, post-0.8.1 it has been gradually rebuilt as a weapon, filling the blanks where needed until the weapon achieved a somewhat acceptable "functional" status in 0.8.8. However, there are many problems with it regarding AI handling:

> The grapple AI logic for bots has many bugs: it's unclear if they try to pick-up the grapple or not... if they fire the grapple and miss the edge of the target wall, they try again without correcting the aim... if they have to go to a place where they would have used grapple but don't have it yet, they start pointlessly firing at that place with standard weapons.
> -- [OA Wiki](https://openarena.fandom.com/wiki/Bugs) - Also related OA forum posts: [1](http://openarena.ws/board/index.php?topic=1908.msg47648#msg47648) - [2](http://openarena.ws/board/index.php?topic=4679.msg47628#msg47628)

I can make the checks required for the bots to stop trying to get the Grapple when they don't have it, but there are stuff which I don't really feel confident to do. Any kind of help in the form of code edits or snippets is welcome.

**What needs to be tested?**

* AI behavior when using the Grappling Hook

**Additional notes:**

In the current implementation (of this PK3), **bots will use the Grappling Hook if (in order):** the general grappling setting for them is ENABLED, they HAVE the GH in their inventory and their personal bot settings ALLOW for its usage.
