### PR TITLE
Fix: "Next round" Elimination countdown is also shown in Double Domination.

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1156,10 +1156,10 @@ static float CG_DrawDomStatus(float y) {
 
 /*
 =================
-CG_DrawEliminationTimer
+CG_DrawCountdownTimer
 =================
  */
-static float CG_DrawEliminationTimer(float y) {
+static float CG_DrawCountdownTimer(float y) {
 	char *s;
 	int w;
 	int mins, seconds, tens, sec;
@@ -1200,7 +1200,7 @@ static float CG_DrawEliminationTimer(float y) {
 		Lots of stuff
 		 ****/
 		if (cg.warmup == 0) {
-			st = va("Round in: %i", sec + 1);
+			st = va("New round in: %i", sec + 1);
 			if (sec != cg.warmupCount) {
 				cg.warmupCount = sec;
 				switch (sec) {
@@ -1610,8 +1610,8 @@ static void CG_DrawUpperRight(stereoFrame_t stereoFrame) {
 	if (cg_drawFPS.integer && (stereoFrame == STEREO_CENTER || stereoFrame == STEREO_RIGHT)) {
 		y = CG_DrawFPS(y);
 	}
-	if (CG_IsARoundBasedGametype(cgs.gametype)) {
-		y = CG_DrawEliminationTimer(y);
+	if (CG_IsARoundBasedGametype(cgs.gametype) || cgs.gametype == GT_DOUBLE_D) {
+		y = CG_DrawCountdownTimer(y);
 		/*if (cgs.clientinfo[ cg.clientNum ].isDead)
 			y = CG_DrawEliminationDeathMessage( y);*/
 	}

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -2247,7 +2247,6 @@ void CheckDoubleDomination( void )
 	}
 
 	if((level.pointStatusA == TEAM_NONE || level.pointStatusB == TEAM_NONE) && level.time>level.roundStartTime) {
-		trap_SendServerCommand( -1, "print \"A new round has started\n\"");
 		Team_SpawnDoubleDominationPoints();
 		SendScoreboardMessageToAllClients();
 	}


### PR DESCRIPTION
Back in Unreal Tournament 2004, after any team scored a point, the game would tell the players with a countdown when the next round was going to start. "New round in... 5... 4... 3... 2... 1...".

This small change does that for our version of DD as well.