### PR TITLE
Fix: Challenges now count Team DM wins

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -1409,6 +1409,9 @@ static void SendVictoryChallenge( void )
 	case GT_FFA:
 		award = GAMETYPES_FFA_WINS;
 		break;
+	case GT_TEAM:
+		award = GAMETYPES_TDM_WINS;
+		break;
 	case GT_TOURNAMENT:
 		award = GAMETYPES_TOURNEY_WINS;
 		break;


### PR DESCRIPTION
This small change allows tracking of Team Deathmatch wins for the Challenges.