### PR TITLE
[WIP Feature] Subgametype support: play SP missions in gametypes other than FFA

### DIFF
--- a/code/cgame/cg_consolecmds.c
+++ b/code/cgame/cg_consolecmds.c
@@ -393,7 +393,7 @@ static void CG_DenyOrder_f(void) {
 }
 
 static void CG_TaskOffense_f(void) {
-	if (CG_UsesTeamFlags(cgs.gametype)) {
+	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
 		trap_SendConsoleCommand(va("cmd vsay_team %s\n", VOICECHAT_ONGETFLAG));
 	} else {
 		trap_SendConsoleCommand(va("cmd vsay_team %s\n", VOICECHAT_ONOFFENSE));

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1760,7 +1760,7 @@ static float CG_DrawScores(float y) {
 		}
 
 		if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
-				CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
+				!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 			v = cgs.capturelimit;
 		} else {
 			v = cgs.fraglimit;

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -439,7 +439,7 @@ void CG_DrawFlagModel(float x, float y, float w, float h, int team, qboolean for
 
 		if (team == TEAM_RED) {
 			handle = cgs.media.redFlagModel;
-			if (cgs.gametype == GT_DOUBLE_D) {
+			if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 				if (cgs.redflag == TEAM_BLUE)
 					handle = cgs.media.blueFlagModel;
 				if (cgs.redflag == TEAM_FREE)
@@ -449,7 +449,7 @@ void CG_DrawFlagModel(float x, float y, float w, float h, int team, qboolean for
 			}
 		} else if (team == TEAM_BLUE) {
 			handle = cgs.media.blueFlagModel;
-			if (cgs.gametype == GT_DOUBLE_D) {
+			if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 				if (cgs.redflag == TEAM_BLUE)
 					handle = cgs.media.blueFlagModel;
 				if (cgs.redflag == TEAM_FREE)
@@ -650,7 +650,7 @@ static void CG_DrawStatusBar(void) {
 				cgs.media.armorModel, 0, origin, angles);
 	}
 
-	if (cgs.gametype == GT_HARVESTER) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		origin[0] = 90;
 		origin[1] = 0;
 		origin[2] = -10;
@@ -735,7 +735,7 @@ static void CG_DrawStatusBar(void) {
 	}
 
 	//Skulls!
-	if (cgs.gametype == GT_HARVESTER) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		value = ps->generic1;
 		if (value > 0) {
 			trap_R_SetColor(colors[0]);
@@ -924,7 +924,7 @@ static float CG_DrawPossessionString(float y) {
 	int w;
 	float distance;
 
-	if (cgs.gametype != GT_POSSESSION) {
+	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		return y;
 	}
 
@@ -1093,7 +1093,7 @@ static float CG_DrawCTFoneway(float y) {
 	int w;
 	vec4_t color;
 
-	if (cgs.gametype != GT_CTF_ELIMINATION)
+	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION))
 		return y;
 
 	memcpy(color, g_color_table[ColorIndex(COLOR_WHITE)], sizeof (color));
@@ -1449,7 +1449,9 @@ static float CG_DrawFollowMessage(float y) {
 	char *s;
 	int w;
 
-	if (!(cg.snap->ps.pm_flags & PMF_FOLLOW) || ((cgs.elimflags & EF_NO_FREESPEC) && CG_IsARoundBasedGametype(cgs.gametype) && CG_IsATeamGametype(cgs.gametype))) {
+	if (!(cg.snap->ps.pm_flags & PMF_FOLLOW) || ((cgs.elimflags & EF_NO_FREESPEC) &&
+			CG_IsARoundBasedGametype(cgs.gametype,cgs.subgametype) &&
+			CG_IsATeamGametype(cgs.gametype,cgs.subgametype))) {
 		return y;
 	}
 
@@ -1588,22 +1590,22 @@ static void CG_DrawUpperRight(stereoFrame_t stereoFrame) {
 
 	y = 0;
 
-	if (CG_IsATeamGametype(cgs.gametype) && cg_drawTeamOverlay.integer == 1) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && cg_drawTeamOverlay.integer == 1) {
 		y = CG_DrawTeamOverlay(y, qtrue, qtrue);
 	}
-	/*if ( cgs.gametype == GT_DOUBLE_D ) {
+	/*if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		y = CG_DrawDoubleDominationThings(y);
 	} 
-	else*/
-	if (cgs.gametype == GT_LMS && cg.showScores) {
+	else*/ if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS) && cg.showScores) {
 		y = CG_DrawLMSmode(y);
-	} else
-		if (cgs.gametype == GT_CTF_ELIMINATION) {
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
 		y = CG_DrawCTFoneway(y);
-	} else
-		if (cgs.gametype == GT_DOMINATION) {
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
 		y = CG_DrawDomStatus(y);
-	} else if (cgs.gametype == GT_POSSESSION) {
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		y = CG_DrawPossessionString(y);
 	}
 
@@ -1613,7 +1615,8 @@ static void CG_DrawUpperRight(stereoFrame_t stereoFrame) {
 	if (cg_drawFPS.integer && (stereoFrame == STEREO_CENTER || stereoFrame == STEREO_RIGHT)) {
 		y = CG_DrawFPS(y);
 	}
-	if (CG_IsARoundBasedGametype(cgs.gametype) || cgs.gametype == GT_DOUBLE_D) {
+	if (CG_IsARoundBasedGametype(cgs.gametype,cgs.subgametype) || cgs.gametype == GT_DOUBLE_D
+			|| (cgs.gametype == GT_SINGLE_PLAYER && cgs.subgametype == GT_DOUBLE_D)) {
 		y = CG_DrawCountdownTimer(y);
 		/*if (cgs.clientinfo[ cg.clientNum ].isDead)
 			y = CG_DrawEliminationDeathMessage( y);*/
@@ -1671,7 +1674,7 @@ static float CG_DrawScores(float y) {
 	y1 = y;
 
 	// draw from the right side to left
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		x = 640;
 		color[0] = 0.0f;
 		color[1] = 0.0f;
@@ -1686,7 +1689,7 @@ static float CG_DrawScores(float y) {
 		}
 		CG_DrawBigString(x + 4, y, s, 1.0F);
 
-		if (CG_UsesTeamFlags(cgs.gametype) && !CG_UsesTheWhiteFlag(cgs.gametype)) {
+		if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) && !CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype)) {
 			// Display flag status
 			item = BG_FindItemForPowerup(PW_BLUEFLAG);
 
@@ -1698,7 +1701,7 @@ static float CG_DrawScores(float y) {
 			}
 		}
 
-		if (cgs.gametype == GT_DOUBLE_D) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 			// Display Domination point status
 
 			y1 = y - 32; //BIGCHAR_HEIGHT - 8;
@@ -1720,7 +1723,7 @@ static float CG_DrawScores(float y) {
 		}
 		CG_DrawBigString(x + 4, y, s, 1.0F);
 
-		if (CG_UsesTeamFlags(cgs.gametype) && !CG_UsesTheWhiteFlag(cgs.gametype)) {
+		if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) && !CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype)) {
 			// Display flag status
 			item = BG_FindItemForPowerup(PW_REDFLAG);
 
@@ -1732,7 +1735,7 @@ static float CG_DrawScores(float y) {
 			}
 		}
 
-		if (cgs.gametype == GT_DOUBLE_D) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 			// Display Domination point status
 
 			y1 = y - 32; //BIGCHAR_HEIGHT - 8;
@@ -1751,12 +1754,13 @@ static float CG_DrawScores(float y) {
 			}
 		}
 
-		if (cgs.gametype == GT_OBELISK) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 			s = va("^1%3i%% ^4%3i%%", cg.redObeliskHealth, cg.blueObeliskHealth);
 			CG_DrawSmallString(x, y - 28, s, 1.0F);
 		}
 
-		if (CG_IsATeamGametype(cgs.gametype) && cgs.gametype != GT_TEAM) {
+		if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
+				CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 			v = cgs.capturelimit;
 		} else {
 			v = cgs.fraglimit;
@@ -1959,7 +1963,7 @@ static void CG_DrawLowerRight(void) {
 
 	y = 480 - ICON_SIZE;
 
-	if (CG_IsATeamGametype(cgs.gametype) && cg_drawTeamOverlay.integer == 2) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && cg_drawTeamOverlay.integer == 2) {
 		y = CG_DrawTeamOverlay(y, qtrue, qfalse);
 	}
 
@@ -2014,7 +2018,7 @@ static void CG_DrawLowerLeft(void) {
 
 	y = 480 - ICON_SIZE;
 
-	if (CG_IsATeamGametype(cgs.gametype) && cg_drawTeamOverlay.integer == 3) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && cg_drawTeamOverlay.integer == 3) {
 		y = CG_DrawTeamOverlay(y, qfalse, qfalse);
 	}
 
@@ -2563,7 +2567,7 @@ static void CG_DrawCenter1FctfString(void) {
 	char *line;
 	int status;
 
-	if (cgs.gametype != GT_1FCTF)
+	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
 		return;
 
 	status = cgs.flagStatus;
@@ -2607,7 +2611,7 @@ static void CG_DrawCenterDDString(void) {
 	static int lastDDSec = -100;
 
 
-	if (cgs.gametype != GT_DOUBLE_D)
+	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D))
 		return;
 
 
@@ -2985,9 +2989,9 @@ CG_DrawSpectator
  */
 static void CG_DrawSpectator(void) {
 	CG_DrawBigString(320 - 9 * 8, 440, "SPECTATOR", 1.0F);
-	if (cgs.gametype == GT_TOURNAMENT) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 		CG_DrawBigString(320 - 15 * 8, 460, "waiting to play", 1.0F);
-	} else if (CG_IsATeamGametype(cgs.gametype)) {
+	} else if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		CG_DrawBigString(320 - 39 * 8, 460, "press ESC and use the JOIN menu to play", 1.0F);
 	}
 }
@@ -3102,7 +3106,7 @@ static qboolean CG_DrawScoreboard(void) {
 
 
 	if (menuScoreboard == NULL) {
-		if (CG_IsATeamGametype(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 			menuScoreboard = Menus_FindByName("teamscore_menu");
 		} else {
 			menuScoreboard = Menus_FindByName("score_menu");
@@ -3126,7 +3130,7 @@ static qboolean CG_DrawScoreboard(void) {
 #else
 	char *s;
 	int w;
-	if (cg.respawnTime && cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR && (!CG_IsARoundBasedGametype(cgs.gametype))) {
+	if (cg.respawnTime && cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR && !CG_IsARoundBasedGametype(cgs.gametype,cgs.subgametype)) {
 		if (cg.respawnTime > cg.time) {
 			s = va("Respawn in: %2.2f", ((double) cg.respawnTime - (double) cg.time) / 1000.0);
 			w = CG_DrawStrlen(s) * SMALLCHAR_WIDTH;
@@ -3324,7 +3328,7 @@ static void CG_DrawWarmup(void) {
 		return;
 	}
 
-	if (cgs.gametype == GT_TOURNAMENT) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 		// find the two active players
 		ci1 = NULL;
 		ci2 = NULL;
@@ -3355,29 +3359,29 @@ static void CG_DrawWarmup(void) {
 #endif
 		}
 	} else {
-		if (cgs.gametype == GT_FFA) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_FFA)) {
 			s = "Free For All";
-		} else if (cgs.gametype == GT_TEAM) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 			s = "Team Deathmatch";
-		} else if (cgs.gametype == GT_CTF) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF)) {
 			s = "Capture the Flag";
-		} else if (cgs.gametype == GT_ELIMINATION) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
 			s = "Elimination";
-		} else if (cgs.gametype == GT_CTF_ELIMINATION) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
 			s = "CTF Elimination";
-		} else if (cgs.gametype == GT_LMS) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS)) {
 			s = "Last Man Standing";
-		} else if (cgs.gametype == GT_DOUBLE_D) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 			s = "Double Domination";
-		} else if (cgs.gametype == GT_1FCTF) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 			s = "One Flag CTF";
-		} else if (cgs.gametype == GT_OBELISK) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 			s = "Overload";
-		} else if (cgs.gametype == GT_HARVESTER) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 			s = "Harvester";
-		} else if (cgs.gametype == GT_DOMINATION) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
 			s = "Domination";
-		} else if (cgs.gametype == GT_POSSESSION) {
+		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 			s = "Possession";
 		} else {
 			s = "";
@@ -3536,7 +3540,7 @@ static void CG_Draw2D(stereoFrame_t stereoFrame) {
 		}
 	}
 #ifndef MISSIONPACK
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		CG_DrawTeamInfo();
 	}
 #endif

--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -439,7 +439,7 @@ void CG_DrawFlagModel(float x, float y, float w, float h, int team, qboolean for
 
 		if (team == TEAM_RED) {
 			handle = cgs.media.redFlagModel;
-			if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+			if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 				if (cgs.redflag == TEAM_BLUE)
 					handle = cgs.media.blueFlagModel;
 				if (cgs.redflag == TEAM_FREE)
@@ -449,7 +449,7 @@ void CG_DrawFlagModel(float x, float y, float w, float h, int team, qboolean for
 			}
 		} else if (team == TEAM_BLUE) {
 			handle = cgs.media.blueFlagModel;
-			if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+			if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 				if (cgs.redflag == TEAM_BLUE)
 					handle = cgs.media.blueFlagModel;
 				if (cgs.redflag == TEAM_FREE)
@@ -650,7 +650,7 @@ static void CG_DrawStatusBar(void) {
 				cgs.media.armorModel, 0, origin, angles);
 	}
 
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		origin[0] = 90;
 		origin[1] = 0;
 		origin[2] = -10;
@@ -735,7 +735,7 @@ static void CG_DrawStatusBar(void) {
 	}
 
 	//Skulls!
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		value = ps->generic1;
 		if (value > 0) {
 			trap_R_SetColor(colors[0]);
@@ -924,7 +924,7 @@ static float CG_DrawPossessionString(float y) {
 	int w;
 	float distance;
 
-	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
+	if (!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		return y;
 	}
 
@@ -1093,7 +1093,7 @@ static float CG_DrawCTFoneway(float y) {
 	int w;
 	vec4_t color;
 
-	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION))
+	if (!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION))
 		return y;
 
 	memcpy(color, g_color_table[ColorIndex(COLOR_WHITE)], sizeof (color));
@@ -1593,19 +1593,19 @@ static void CG_DrawUpperRight(stereoFrame_t stereoFrame) {
 	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && cg_drawTeamOverlay.integer == 1) {
 		y = CG_DrawTeamOverlay(y, qtrue, qtrue);
 	}
-	/*if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+	/*if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		y = CG_DrawDoubleDominationThings(y);
 	} 
-	else*/ if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS) && cg.showScores) {
+	else*/ if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_LMS) && cg.showScores) {
 		y = CG_DrawLMSmode(y);
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
 		y = CG_DrawCTFoneway(y);
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
 		y = CG_DrawDomStatus(y);
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		y = CG_DrawPossessionString(y);
 	}
 
@@ -1701,7 +1701,7 @@ static float CG_DrawScores(float y) {
 			}
 		}
 
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 			// Display Domination point status
 
 			y1 = y - 32; //BIGCHAR_HEIGHT - 8;
@@ -1735,7 +1735,7 @@ static float CG_DrawScores(float y) {
 			}
 		}
 
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 			// Display Domination point status
 
 			y1 = y - 32; //BIGCHAR_HEIGHT - 8;
@@ -1754,13 +1754,13 @@ static float CG_DrawScores(float y) {
 			}
 		}
 
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 			s = va("^1%3i%% ^4%3i%%", cg.redObeliskHealth, cg.blueObeliskHealth);
 			CG_DrawSmallString(x, y - 28, s, 1.0F);
 		}
 
 		if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
-				!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
+				!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 			v = cgs.capturelimit;
 		} else {
 			v = cgs.fraglimit;
@@ -2567,7 +2567,7 @@ static void CG_DrawCenter1FctfString(void) {
 	char *line;
 	int status;
 
-	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
+	if (!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF))
 		return;
 
 	status = cgs.flagStatus;
@@ -2611,7 +2611,7 @@ static void CG_DrawCenterDDString(void) {
 	static int lastDDSec = -100;
 
 
-	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D))
+	if (!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D))
 		return;
 
 
@@ -2989,7 +2989,7 @@ CG_DrawSpectator
  */
 static void CG_DrawSpectator(void) {
 	CG_DrawBigString(320 - 9 * 8, 440, "SPECTATOR", 1.0F);
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 		CG_DrawBigString(320 - 15 * 8, 460, "waiting to play", 1.0F);
 	} else if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		CG_DrawBigString(320 - 39 * 8, 460, "press ESC and use the JOIN menu to play", 1.0F);
@@ -3328,7 +3328,7 @@ static void CG_DrawWarmup(void) {
 		return;
 	}
 
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 		// find the two active players
 		ci1 = NULL;
 		ci2 = NULL;
@@ -3359,29 +3359,29 @@ static void CG_DrawWarmup(void) {
 #endif
 		}
 	} else {
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_FFA)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_FFA)) {
 			s = "Free For All";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 			s = "Team Deathmatch";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF)) {
 			s = "Capture the Flag";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
 			s = "Elimination";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
 			s = "CTF Elimination";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_LMS)) {
 			s = "Last Man Standing";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 			s = "Double Domination";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 			s = "One Flag CTF";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 			s = "Overload";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 			s = "Harvester";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
 			s = "Domination";
-		} else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
+		} else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 			s = "Possession";
 		} else {
 			s = "";

--- a/code/cgame/cg_ents.c
+++ b/code/cgame/cg_ents.c
@@ -882,7 +882,7 @@ static void CG_TeamBase( centity_t *cent ) {
 		}
 		trap_R_AddRefEntityToScene( &model );
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 		// show the obelisk
 		memset(&model, 0, sizeof(model));
 		model.reType = RT_MODEL;
@@ -976,7 +976,7 @@ static void CG_TeamBase( centity_t *cent ) {
 			trap_R_AddRefEntityToScene( &model );
 		}
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		// show harvester model
 		memset(&model, 0, sizeof(model));
 		model.reType = RT_MODEL;

--- a/code/cgame/cg_ents.c
+++ b/code/cgame/cg_ents.c
@@ -864,7 +864,7 @@ static void CG_TeamBase( centity_t *cent ) {
 	int t, h;
 	float c;
 
-	if ( CG_UsesTeamFlags(cgs.gametype) ) {
+	if ( CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) ) {
 		// show the flag base
 		memset(&model, 0, sizeof(model));
 		model.reType = RT_MODEL;
@@ -882,7 +882,7 @@ static void CG_TeamBase( centity_t *cent ) {
 		}
 		trap_R_AddRefEntityToScene( &model );
 	}
-	else if ( cgs.gametype == GT_OBELISK ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 		// show the obelisk
 		memset(&model, 0, sizeof(model));
 		model.reType = RT_MODEL;
@@ -976,7 +976,7 @@ static void CG_TeamBase( centity_t *cent ) {
 			trap_R_AddRefEntityToScene( &model );
 		}
 	}
-	else if ( cgs.gametype == GT_HARVESTER ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		// show harvester model
 		memset(&model, 0, sizeof(model));
 		model.reType = RT_MODEL;

--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -254,7 +254,7 @@ static void CG_Obituary(entityState_t *ent) {
 	if (attacker == cg.snap->ps.clientNum) {
 		char *s;
 
-		if (!(CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && !(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)))) {
+		if (!(CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && !(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM)))) {
 			s = va("You fragged %s\n%s place with %i", targetName,
 					CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1),
 					cg.snap->ps.persistant[PERS_SCORE]);
@@ -1295,12 +1295,12 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 					if (cg.snap->ps.powerups[PW_BLUEFLAG] || cg.snap->ps.powerups[PW_NEUTRALFLAG]) {
 					} else {
 						if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
-							if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
+							if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF))
 								CG_AddBufferedSound(cgs.media.yourTeamTookTheFlagSound);
 							else
 								CG_AddBufferedSound(cgs.media.enemyTookYourFlagSound);
 						} else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
-							if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
+							if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF))
 								CG_AddBufferedSound(cgs.media.enemyTookTheFlagSound);
 							else
 								CG_AddBufferedSound(cgs.media.yourTeamTookEnemyFlagSound);
@@ -1312,12 +1312,12 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 					if (cg.snap->ps.powerups[PW_REDFLAG] || cg.snap->ps.powerups[PW_NEUTRALFLAG]) {
 					} else {
 						if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
-							if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
+							if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF))
 								CG_AddBufferedSound(cgs.media.yourTeamTookTheFlagSound);
 							else
 								CG_AddBufferedSound(cgs.media.enemyTookYourFlagSound);
 						} else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
-							if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
+							if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF))
 								CG_AddBufferedSound(cgs.media.enemyTookTheFlagSound);
 							else
 								CG_AddBufferedSound(cgs.media.yourTeamTookEnemyFlagSound);

--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -254,9 +254,7 @@ static void CG_Obituary(entityState_t *ent) {
 	if (attacker == cg.snap->ps.clientNum) {
 		char *s;
 
-		if (!CG_IsATeamGametype(cgs.gametype) && !CG_UsesTeamFlags(cgs.gametype) &&
-				!CG_UsesTheWhiteFlag(cgs.gametype) && !CG_IsARoundBasedGametype(cgs.gametype) &&
-				cgs.gametype != GT_DOUBLE_D && cgs.gametype != GT_DOMINATION) {
+		if (!(CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && !(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)))) {
 			s = va("You fragged %s\n%s place with %i", targetName,
 					CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1),
 					cg.snap->ps.persistant[PERS_SCORE]);
@@ -1297,12 +1295,12 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 					if (cg.snap->ps.powerups[PW_BLUEFLAG] || cg.snap->ps.powerups[PW_NEUTRALFLAG]) {
 					} else {
 						if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
-							if (cgs.gametype == GT_1FCTF)
+							if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
 								CG_AddBufferedSound(cgs.media.yourTeamTookTheFlagSound);
 							else
 								CG_AddBufferedSound(cgs.media.enemyTookYourFlagSound);
 						} else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
-							if (cgs.gametype == GT_1FCTF)
+							if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
 								CG_AddBufferedSound(cgs.media.enemyTookTheFlagSound);
 							else
 								CG_AddBufferedSound(cgs.media.yourTeamTookEnemyFlagSound);
@@ -1314,12 +1312,12 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 					if (cg.snap->ps.powerups[PW_REDFLAG] || cg.snap->ps.powerups[PW_NEUTRALFLAG]) {
 					} else {
 						if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
-							if (cgs.gametype == GT_1FCTF)
+							if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
 								CG_AddBufferedSound(cgs.media.yourTeamTookTheFlagSound);
 							else
 								CG_AddBufferedSound(cgs.media.enemyTookYourFlagSound);
 						} else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
-							if (cgs.gametype == GT_1FCTF)
+							if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF))
 								CG_AddBufferedSound(cgs.media.enemyTookTheFlagSound);
 							else
 								CG_AddBufferedSound(cgs.media.yourTeamTookEnemyFlagSound);

--- a/code/cgame/cg_info.c
+++ b/code/cgame/cg_info.c
@@ -234,52 +234,50 @@ void CG_DrawInformation( void ) {
 	}
 
 	// game type
-	switch ( cgs.gametype ) {
-	case GT_FFA:
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_FFA)) {
 		s = "Free For All";
-		break;
-	case GT_SINGLE_PLAYER:
-		s = "Single Player";
-		break;
-	case GT_TOURNAMENT:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 		s = "Tournament";
-		break;
-	case GT_TEAM:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 		s = "Team Deathmatch";
-		break;
-	case GT_CTF:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF)) {
 		s = "Capture The Flag";
-		break;
-	case GT_1FCTF:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 		s = "One Flag CTF";
-		break;
-	case GT_OBELISK:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 		s = "Overload";
-		break;
-	case GT_HARVESTER:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		s = "Harvester";
-		break;
-	case GT_ELIMINATION:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
 		s = "Elimination";
-		break;
-	case GT_CTF_ELIMINATION:
-		s = " CTF Elimination";
-		break;
-	case GT_LMS:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
+		s = "CTF Elimination";
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS)) {
 		s = "Last Man Standing";
-		break;
-	case GT_DOUBLE_D:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		s = "Double Domination";
-		break;
-    case GT_DOMINATION:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
 		s = "Domination";
-		break;
-	case GT_POSSESSION:
+	}
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		s = "Possession";
-		break;
-	default:
+	}
+	else if (cgs.gametype == GT_SINGLE_PLAYER) {
+		s = "Single Player";
+	}
+	else {
 		s = "Unknown Gametype";
-		break;
 	}
 	UI_DrawProportionalString( 320, y, s,
 		UI_CENTER|UI_SMALLFONT|UI_DROPSHADOW, colorWhite );
@@ -292,7 +290,7 @@ void CG_DrawInformation( void ) {
 		y += PROP_HEIGHT;
 	}
 
-	if (!CG_IsATeamGametype(cgs.gametype)) {
+	if (!(CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && !(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)))) {
 		value = atoi( Info_ValueForKey( info, "fraglimit" ) );
 		if ( value ) {
 			UI_DrawProportionalString( 320, y, va( "fraglimit %i", value ),
@@ -300,8 +298,7 @@ void CG_DrawInformation( void ) {
 			y += PROP_HEIGHT;
 		}
 	}
-
-	if (CG_IsATeamGametype(cgs.gametype) && cgs.gametype != GT_TEAM) {
+	else {
 		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 		if ( value ) {
 			UI_DrawProportionalString( 320, y, va( "capturelimit %i", value ),

--- a/code/cgame/cg_info.c
+++ b/code/cgame/cg_info.c
@@ -290,18 +290,19 @@ void CG_DrawInformation( void ) {
 		y += PROP_HEIGHT;
 	}
 
-	if (!(CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && !(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)))) {
-		value = atoi( Info_ValueForKey( info, "fraglimit" ) );
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
+			!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
+		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 		if ( value ) {
-			UI_DrawProportionalString( 320, y, va( "fraglimit %i", value ),
+			UI_DrawProportionalString( 320, y, va( "capturelimit %i", value ),
 				UI_CENTER|UI_SMALLFONT|UI_DROPSHADOW, colorWhite );
 			y += PROP_HEIGHT;
 		}
 	}
 	else {
-		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
+		value = atoi( Info_ValueForKey( info, "fraglimit" ) );
 		if ( value ) {
-			UI_DrawProportionalString( 320, y, va( "capturelimit %i", value ),
+			UI_DrawProportionalString( 320, y, va( "fraglimit %i", value ),
 				UI_CENTER|UI_SMALLFONT|UI_DROPSHADOW, colorWhite );
 			y += PROP_HEIGHT;
 		}

--- a/code/cgame/cg_info.c
+++ b/code/cgame/cg_info.c
@@ -234,43 +234,43 @@ void CG_DrawInformation( void ) {
 	}
 
 	// game type
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_FFA)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_FFA)) {
 		s = "Free For All";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 		s = "Tournament";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 		s = "Team Deathmatch";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF)) {
 		s = "Capture The Flag";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 		s = "One Flag CTF";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 		s = "Overload";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		s = "Harvester";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
 		s = "Elimination";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
 		s = "CTF Elimination";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_LMS)) {
 		s = "Last Man Standing";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		s = "Double Domination";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
 		s = "Domination";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		s = "Possession";
 	}
 	else if (cgs.gametype == GT_SINGLE_PLAYER) {
@@ -291,7 +291,7 @@ void CG_DrawInformation( void ) {
 	}
 
 	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
-			!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
+			!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 		if ( value ) {
 			UI_DrawProportionalString( 320, y, va( "capturelimit %i", value ),

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1171,6 +1171,7 @@ typedef struct {
 
 	// parsed from serverinfo
 	gametype_t		gametype;
+	gametype_t		subgametype;
 	int				dmflags;
         int                             videoflags;
         int				elimflags;
@@ -2038,9 +2039,11 @@ void	trap_R_LFX_ParticleEffect( int effect, const vec3_t origin, const vec3_t ve
 
 // LEILEI ENHANCEMENT
 
-/* Neon_Knight: Useful check in order to have code consistency. */
-qboolean CG_IsATeamGametype(int check);	/* Whether the gametype is team-based or not.*/
-qboolean CG_UsesTeamFlags(int check);	/* Whether the gametype uses the red and blue flags. */
-qboolean CG_UsesTheWhiteFlag(int check);	/* Whether the gametype uses the neutral flag. */
-qboolean CG_IsARoundBasedGametype(int check);	/* Whether the gametype uses the neutral flag. */
+/* Neon_Knight: Useful check in order to have code consistency.
+Extended in order to also account for subgametypes. */
+qboolean CG_IsATeamGametype(int gametype, int subgametype);	/* Whether the gametype is team-based or not.*/
+qboolean CG_UsesTeamFlags(int gametype, int subgametype);	/* Whether the gametype uses the red and blue flags. */
+qboolean CG_UsesTheWhiteFlag(int gametype, int subgametype);	/* Whether the gametype uses the neutral flag. */
+qboolean CG_IsARoundBasedGametype(int gametype, int subgametype);	/* Whether the gametype is round-based. */
+qboolean CG_SingleGametypeCheck(int gametype, int subgametype, int check);	/* Whether the game takes place in a particular gametype. */
 /* /Neon_Knight */

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -2045,5 +2045,5 @@ qboolean CG_IsATeamGametype(int gametype, int subgametype);	/* Whether the gamet
 qboolean CG_UsesTeamFlags(int gametype, int subgametype);	/* Whether the gametype uses the red and blue flags. */
 qboolean CG_UsesTheWhiteFlag(int gametype, int subgametype);	/* Whether the gametype uses the neutral flag. */
 qboolean CG_IsARoundBasedGametype(int gametype, int subgametype);	/* Whether the gametype is round-based. */
-qboolean CG_SingleGametypeCheck(int gametype, int subgametype, int check);	/* Whether the game takes place in a particular gametype. */
+qboolean CG_IsGametype(int gametype, int subgametype, int check);	/* Whether the game takes place in a particular gametype. */
 /* /Neon_Knight */

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -837,7 +837,7 @@ static void CG_RegisterSounds(void) {
 			cgs.media.enemyTookTheFlagSound = trap_S_RegisterSound("sound/teamplay/voc_enemy_1flag.wav", qtrue);
 		}
 
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK) || cg_buildScript.integer) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_OBELISK) || cg_buildScript.integer) {
 			cgs.media.yourBaseIsUnderAttackSound = trap_S_RegisterSound("sound/teamplay/voc_base_attack.wav", qtrue);
 			// loadingscreen
 #ifdef SCRIPTHUD
@@ -1166,7 +1166,7 @@ static void CG_RegisterGraphics(void) {
 	cgs.media.hastePuffShader = trap_R_RegisterShader("hasteSmokePuff");
 
 	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) ||
-			CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER) ||
+			CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER) ||
 			cg_buildScript.integer) {
 		cgs.media.redCubeModel = trap_R_RegisterModel("models/powerups/orb/r_orb.md3");
 		cgs.media.blueCubeModel = trap_R_RegisterModel("models/powerups/orb/b_orb.md3");
@@ -1182,7 +1182,7 @@ static void CG_RegisterGraphics(void) {
 	}
 
 	//For Double Domination:
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		cgs.media.ddPointSkinA[TEAM_RED] = trap_R_RegisterShaderNoMip("icons/icona_red");
 		cgs.media.ddPointSkinA[TEAM_BLUE] = trap_R_RegisterShaderNoMip("icons/icona_blue");
 		cgs.media.ddPointSkinA[TEAM_FREE] = trap_R_RegisterShaderNoMip("icons/icona_white");
@@ -1196,7 +1196,7 @@ static void CG_RegisterGraphics(void) {
 
 	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) ||
 			CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype) ||
-			CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER) ||
+			CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER) ||
 			cg_buildScript.integer) {
 		cgs.media.redFlagModel = trap_R_RegisterModel("models/flags/r_flag.md3");
 		cgs.media.blueFlagModel = trap_R_RegisterModel("models/flags/b_flag.md3");
@@ -1227,7 +1227,7 @@ static void CG_RegisterGraphics(void) {
 		cgs.media.flagShader[3] = trap_R_RegisterShaderNoMip("icons/iconf_neutral3");
 	}
 
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK) || cg_buildScript.integer) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_OBELISK) || cg_buildScript.integer) {
 		cgs.media.rocketExplosionShader = trap_R_RegisterShader("rocketExplosion");
 		cgs.media.overloadBaseModel = trap_R_RegisterModel("models/powerups/overload_base.md3");
 		cgs.media.overloadTargetModel = trap_R_RegisterModel("models/powerups/overload_target.md3");
@@ -1235,7 +1235,7 @@ static void CG_RegisterGraphics(void) {
 		cgs.media.overloadEnergyModel = trap_R_RegisterModel("models/powerups/overload_energy.md3");
 	}
 
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER) || cg_buildScript.integer) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER) || cg_buildScript.integer) {
 		cgs.media.harvesterModel = trap_R_RegisterModel("models/powerups/harvester/harvester.md3");
 		cgs.media.harvesterRedSkin = trap_R_RegisterSkin("models/powerups/harvester/red.skin");
 		cgs.media.harvesterBlueSkin = trap_R_RegisterSkin("models/powerups/harvester/blue.skin");
@@ -2137,7 +2137,7 @@ static const char *CG_FeederItemText(float feederID, int index, int column, qhan
 					return "Ready";
 				}
 				if (team == -1) {
-					if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
+					if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 						return va("%i/%i", info->wins, info->losses);
 					} else if (info->infoValid && info->team == TEAM_SPECTATOR) {
 						return "Spectator";
@@ -2777,13 +2777,13 @@ qboolean CG_IsARoundBasedGametype(int gametype, int subgametype) {
 }
 /*
 ===================
-CG_SingleGametypeCheck
+CG_IsGametype
 
 Checks if the game takes place in a particular gametype.
 Replaces all direct gametype calls.
 ===================
  */
-qboolean CG_SingleGametypeCheck(int gametype, int subgametype, int check) {
+qboolean CG_IsGametype(int gametype, int subgametype, int check) {
 	if (gametype != GT_SINGLE_PLAYER && gametype == check) {
 		return qtrue;
 	}

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -803,7 +803,7 @@ static void CG_RegisterSounds(void) {
 	// N_G: Another condition that makes no sense to me, see for
 	// yourself if you really meant this
 	// Sago: Makes perfect sense: Load team game stuff if the gametype is a teamgame and not an exception (like GT_LMS)
-	if (CG_IsATeamGametype(cgs.gametype) || cg_buildScript.integer) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) || cg_buildScript.integer) {
 
 		cgs.media.captureAwardSound = trap_S_RegisterSound("sound/teamplay/flagcapture_yourteam.wav", qtrue);
 		cgs.media.redLeadsSound = trap_S_RegisterSound("sound/feedback/redleads.wav", qtrue);
@@ -823,21 +823,21 @@ static void CG_RegisterSounds(void) {
 		cgs.media.takenYourTeamSound = trap_S_RegisterSound("sound/teamplay/flagtaken_yourteam.wav", qtrue);
 		cgs.media.takenOpponentSound = trap_S_RegisterSound("sound/teamplay/flagtaken_opponent.wav", qtrue);
 
-		if ((CG_UsesTeamFlags(cgs.gametype) && !CG_UsesTheWhiteFlag(cgs.gametype)) || cg_buildScript.integer) {
+		if ((CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) && !CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype)) || cg_buildScript.integer) {
 			cgs.media.redFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/voc_red_returned.wav", qtrue);
 			cgs.media.blueFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/voc_blue_returned.wav", qtrue);
 			cgs.media.enemyTookYourFlagSound = trap_S_RegisterSound("sound/teamplay/voc_enemy_flag.wav", qtrue);
 			cgs.media.yourTeamTookEnemyFlagSound = trap_S_RegisterSound("sound/teamplay/voc_team_flag.wav", qtrue);
 		}
 
-		if (CG_UsesTheWhiteFlag(cgs.gametype) || cg_buildScript.integer) {
+		if (CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype) || cg_buildScript.integer) {
 			// FIXME: get a replacement for this sound ?
 			cgs.media.neutralFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/flagreturn_opponent.wav", qtrue);
 			cgs.media.yourTeamTookTheFlagSound = trap_S_RegisterSound("sound/teamplay/voc_team_1flag.wav", qtrue);
 			cgs.media.enemyTookTheFlagSound = trap_S_RegisterSound("sound/teamplay/voc_enemy_1flag.wav", qtrue);
 		}
 
-		if (cgs.gametype == GT_OBELISK || cg_buildScript.integer) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK) || cg_buildScript.integer) {
 			cgs.media.yourBaseIsUnderAttackSound = trap_S_RegisterSound("sound/teamplay/voc_base_attack.wav", qtrue);
 			// loadingscreen
 #ifdef SCRIPTHUD
@@ -849,7 +849,7 @@ static void CG_RegisterSounds(void) {
 	}
 
 
-	if (CG_UsesTeamFlags(cgs.gametype) || CG_UsesTheWhiteFlag(cgs.gametype) || cg_buildScript.integer) {
+	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) || CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype) || cg_buildScript.integer) {
 		cgs.media.youHaveFlagSound = trap_S_RegisterSound("sound/teamplay/voc_you_flag.wav", qtrue);
 		cgs.media.holyShitSound = trap_S_RegisterSound("sound/feedback/voc_holyshit.wav", qtrue);
 	}
@@ -1165,14 +1165,16 @@ static void CG_RegisterGraphics(void) {
 	cgs.media.regenShader = trap_R_RegisterShader("powerups/regen");
 	cgs.media.hastePuffShader = trap_R_RegisterShader("hasteSmokePuff");
 
-	if (CG_UsesTeamFlags(cgs.gametype) || cgs.gametype == GT_HARVESTER || cg_buildScript.integer) {
+	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) ||
+			CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER) ||
+			cg_buildScript.integer) {
 		cgs.media.redCubeModel = trap_R_RegisterModel("models/powerups/orb/r_orb.md3");
 		cgs.media.blueCubeModel = trap_R_RegisterModel("models/powerups/orb/b_orb.md3");
 		cgs.media.redCubeIcon = trap_R_RegisterShader("icons/skull_red");
 		cgs.media.blueCubeIcon = trap_R_RegisterShader("icons/skull_blue");
 	}
 
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		cgs.media.redOverlay = trap_R_RegisterShader("playeroverlays/playerSuit1_Red");
 		cgs.media.blueOverlay = trap_R_RegisterShader("playeroverlays/playerSuit1_Blue");
 	} else {
@@ -1180,7 +1182,7 @@ static void CG_RegisterGraphics(void) {
 	}
 
 	//For Double Domination:
-	if (cgs.gametype == GT_DOUBLE_D) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		cgs.media.ddPointSkinA[TEAM_RED] = trap_R_RegisterShaderNoMip("icons/icona_red");
 		cgs.media.ddPointSkinA[TEAM_BLUE] = trap_R_RegisterShaderNoMip("icons/icona_blue");
 		cgs.media.ddPointSkinA[TEAM_FREE] = trap_R_RegisterShaderNoMip("icons/icona_white");
@@ -1192,7 +1194,10 @@ static void CG_RegisterGraphics(void) {
 		cgs.media.ddPointSkinB[TEAM_NONE] = trap_R_RegisterShaderNoMip("icons/noammo");
 	}
 
-	if (CG_UsesTeamFlags(cgs.gametype) || CG_UsesTheWhiteFlag(cgs.gametype) || cgs.gametype == GT_HARVESTER || cg_buildScript.integer) {
+	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) ||
+			CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype) ||
+			CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER) ||
+			cg_buildScript.integer) {
 		cgs.media.redFlagModel = trap_R_RegisterModel("models/flags/r_flag.md3");
 		cgs.media.blueFlagModel = trap_R_RegisterModel("models/flags/b_flag.md3");
 		cgs.media.neutralFlagModel = trap_R_RegisterModel("models/flags/n_flag.md3");
@@ -1214,7 +1219,7 @@ static void CG_RegisterGraphics(void) {
 		cgs.media.neutralFlagBaseModel = trap_R_RegisterModel("models/mapobjects/flagbase/ntrl_base.md3");
 	}
 
-	if (CG_UsesTheWhiteFlag(cgs.gametype) || cg_buildScript.integer) {
+	if (CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype) || cg_buildScript.integer) {
 		cgs.media.neutralFlagModel = trap_R_RegisterModel("models/flags/n_flag.md3");
 		cgs.media.flagShader[0] = trap_R_RegisterShaderNoMip("icons/iconf_neutral1");
 		cgs.media.flagShader[1] = trap_R_RegisterShaderNoMip("icons/iconf_red2");
@@ -1222,7 +1227,7 @@ static void CG_RegisterGraphics(void) {
 		cgs.media.flagShader[3] = trap_R_RegisterShaderNoMip("icons/iconf_neutral3");
 	}
 
-	if (cgs.gametype == GT_OBELISK || cg_buildScript.integer) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK) || cg_buildScript.integer) {
 		cgs.media.rocketExplosionShader = trap_R_RegisterShader("rocketExplosion");
 		cgs.media.overloadBaseModel = trap_R_RegisterModel("models/powerups/overload_base.md3");
 		cgs.media.overloadTargetModel = trap_R_RegisterModel("models/powerups/overload_target.md3");
@@ -1230,7 +1235,7 @@ static void CG_RegisterGraphics(void) {
 		cgs.media.overloadEnergyModel = trap_R_RegisterModel("models/powerups/overload_energy.md3");
 	}
 
-	if (cgs.gametype == GT_HARVESTER || cg_buildScript.integer) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER) || cg_buildScript.integer) {
 		cgs.media.harvesterModel = trap_R_RegisterModel("models/powerups/harvester/harvester.md3");
 		cgs.media.harvesterRedSkin = trap_R_RegisterSkin("models/powerups/harvester/red.skin");
 		cgs.media.harvesterBlueSkin = trap_R_RegisterSkin("models/powerups/harvester/blue.skin");
@@ -1240,7 +1245,7 @@ static void CG_RegisterGraphics(void) {
 	cgs.media.redKamikazeShader = trap_R_RegisterShader("models/weaphits/kamikred");
 	cgs.media.dustPuffShader = trap_R_RegisterShader("hasteSmokePuff");
 
-	if (CG_IsATeamGametype(cgs.gametype) || cg_buildScript.integer) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) || cg_buildScript.integer) {
 
 		cgs.media.friendShader = trap_R_RegisterShader("sprites/foe");
 		cgs.media.redQuadShader = trap_R_RegisterShader("powerups/blueflag");
@@ -2047,7 +2052,7 @@ void CG_SetScoreSelection(void *p) {
 		return;
 	}
 
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		int feeder = FEEDER_REDTEAM_LIST;
 		i = red;
 		if (cg.scores[cg.selectedScore].team == TEAM_BLUE) {
@@ -2064,7 +2069,7 @@ void CG_SetScoreSelection(void *p) {
 
 static clientInfo_t * CG_InfoFromScoreIndex(int index, int team, int *scoreIndex) {
 	int i, count;
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		count = 0;
 		for (i = 0; i < cg.numScores; i++) {
 			if (cg.scores[i].team == team) {
@@ -2132,7 +2137,7 @@ static const char *CG_FeederItemText(float feederID, int index, int column, qhan
 					return "Ready";
 				}
 				if (team == -1) {
-					if (cgs.gametype == GT_TOURNAMENT) {
+					if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 						return va("%i/%i", info->wins, info->losses);
 					} else if (info->infoValid && info->team == TEAM_SPECTATOR) {
 						return "Spectator";
@@ -2171,7 +2176,7 @@ static qhandle_t CG_FeederItemImage(float feederID, int index) {
 }
 
 static void CG_FeederSelection(float feederID, int index) {
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		int i, count;
 		int team = (feederID == FEEDER_REDTEAM_LIST) ? TEAM_RED : TEAM_BLUE;
 		count = 0;
@@ -2713,8 +2718,14 @@ CG_IsATeamGametype
 Checks if the gametype is a team-based game.
 ===================
  */
-qboolean CG_IsATeamGametype(int gametype) {
-	return GAMETYPE_IS_A_TEAM_GAME(gametype);
+qboolean CG_IsATeamGametype(int gametype, int subgametype) {
+	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_IS_A_TEAM_GAME(gametype)) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && GAMETYPE_IS_A_TEAM_GAME(subgametype)) {
+		return qtrue;
+	}
+	return qfalse;
 }
 /*
 ===================
@@ -2723,8 +2734,14 @@ CG_UsesTeamFlags
 Checks if the gametype makes use of the red and blue flags.
 ===================
  */
-qboolean CG_UsesTeamFlags(int check) {
-	return GAMETYPE_USES_RED_AND_BLUE_FLAG(check);
+qboolean CG_UsesTeamFlags(int gametype, int subgametype) {
+	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_USES_RED_AND_BLUE_FLAG(gametype)) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && GAMETYPE_USES_RED_AND_BLUE_FLAG(subgametype)) {
+		return qtrue;
+	}
+	return qfalse;
 }
 /*
 ===================
@@ -2733,8 +2750,14 @@ CG_UsesTheWhiteFlag
 Checks if the gametype makes use of the neutral flag.
 ===================
  */
-qboolean CG_UsesTheWhiteFlag(int check) {
-	return GAMETYPE_USES_WHITE_FLAG(check);
+qboolean CG_UsesTheWhiteFlag(int gametype, int subgametype) {
+	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_USES_WHITE_FLAG(gametype)) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && GAMETYPE_USES_WHITE_FLAG(subgametype)) {
+		return qtrue;
+	}
+	return qfalse;
 }
 /*
 ===================
@@ -2743,7 +2766,30 @@ CG_IsARoundBasedGametype
 Checks if the gametype has a round-based system.
 ===================
  */
-qboolean CG_IsARoundBasedGametype(int check) {
-	return GAMETYPE_IS_ROUND_BASED(check);
+qboolean CG_IsARoundBasedGametype(int gametype, int subgametype) {
+	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_IS_ROUND_BASED(gametype)) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && GAMETYPE_IS_ROUND_BASED(subgametype)) {
+		return qtrue;
+	}
+	return qfalse;
+}
+/*
+===================
+CG_SingleGametypeCheck
+
+Checks if the game takes place in a particular gametype.
+Replaces all direct gametype calls.
+===================
+ */
+qboolean CG_SingleGametypeCheck(int gametype, int subgametype, int check) {
+	if (gametype != GT_SINGLE_PLAYER && gametype == check) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && subgametype != GT_SINGLE_PLAYER && subgametype == check) {
+		return qtrue;
+	}
+	return qfalse;
 }
 /* /Neon_Knight */

--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -696,7 +696,7 @@ static void CG_DrawBlueFlagName(rectDef_t *rect, float scale, vec4_t color, int 
 static void CG_DrawBlueFlagStatus(rectDef_t *rect, qhandle_t shader)
 {
 	if (!CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 			vec4_t color = {0, 0, 1, 1};
 			trap_R_SetColor(color);
 			CG_DrawPic( rect->x, rect->y, rect->w, rect->h, cgs.media.blueCubeIcon );
@@ -751,7 +751,7 @@ static void CG_DrawRedFlagName(rectDef_t *rect, float scale, vec4_t color, int t
 static void CG_DrawRedFlagStatus(rectDef_t *rect, qhandle_t shader)
 {
 	if (!CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 			vec4_t color = {1, 0, 0, 1};
 			trap_R_SetColor(color);
 			CG_DrawPic( rect->x, rect->y, rect->w, rect->h, cgs.media.redCubeIcon );
@@ -799,7 +799,7 @@ static void CG_HarvesterSkulls(rectDef_t *rect, float scale, vec4_t color, qbool
 	qhandle_t handle;
 	int value = cg.snap->ps.generic1;
 
-	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+	if (!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		return;
 	}
 
@@ -1026,7 +1026,7 @@ qboolean CG_OtherTeamHasFlag(void)
 {
 	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
 		int team = cg.snap->ps.persistant[PERS_TEAM];
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 			if (team == TEAM_RED && cgs.flagStatus == FLAG_TAKEN_BLUE) {
 				return qtrue;
 			}
@@ -1056,7 +1056,7 @@ qboolean CG_YourTeamHasFlag(void)
 {
 	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
 		int team = cg.snap->ps.persistant[PERS_TEAM];
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 			if (team == TEAM_RED && cgs.flagStatus == FLAG_TAKEN_RED) {
 				return qtrue;
 			}
@@ -1126,7 +1126,7 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_HARVESTER) {
-		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+		if(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 			return qtrue;
 		}
 		else {
@@ -1135,7 +1135,7 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_ONEFLAG) {
-		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
+		if(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 			return qtrue;
 		}
 		else {
@@ -1144,13 +1144,13 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_CTF) {
-		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF)) {
+		if(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF)) {
 			return qtrue;
 		}
 	}
 
 	if (flags & CG_SHOW_OBELISK) {
-		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
+		if(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 			return qtrue;
 		}
 		else {
@@ -1177,7 +1177,7 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_TOURNAMENT) {
-		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
+		if(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 			return qtrue;
 		}
 	}
@@ -1248,7 +1248,7 @@ static void CG_DrawKiller(rectDef_t *rect, float scale, vec4_t color, qhandle_t 
 static void CG_DrawCapFragLimit(rectDef_t *rect, float scale, vec4_t color, qhandle_t shader, int textStyle)
 {
 	int limit = (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
-		!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) ?
+		!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM)) ?
 		cgs.capturelimit : cgs.fraglimit;
 	CG_Text_Paint(rect->x, rect->y, scale, color, va("%2i", limit),0, 0, textStyle);
 }
@@ -1296,40 +1296,40 @@ static void CG_DrawGameStatus(rectDef_t *rect, float scale, vec4_t color, qhandl
 
 const char *CG_GameTypeString(void)
 {
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_FFA)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_FFA)) {
 		return "Free For All";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 		return "Team Deathmatch";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF)) {
 		return "Capture the Flag";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 		return "One Flag CTF";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 		return "Overload";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		return "Harvester";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
 		return "Elimination";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
 		return "CTF Elimination";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_LMS)) {
 		return "Last Man Standing";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		return "Double Domination";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
 		return "Domination";
 	}
-	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
+	else if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		return "Possession";
 	}
 	return "";
@@ -1980,7 +1980,7 @@ static void CG_DrawCaptureLimit( rectDef_t *rect, float text_x, float text_y, ve
 	info = CG_ConfigString( CS_SERVERINFO );
 	value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
-			!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM))
+			!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM))
 		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 	else
 		value = atoi( Info_ValueForKey( info, "fraglimit" ) );

--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -1248,7 +1248,7 @@ static void CG_DrawKiller(rectDef_t *rect, float scale, vec4_t color, qhandle_t 
 static void CG_DrawCapFragLimit(rectDef_t *rect, float scale, vec4_t color, qhandle_t shader, int textStyle)
 {
 	int limit = (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
-		CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) ?
+		!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) ?
 		cgs.capturelimit : cgs.fraglimit;
 	CG_Text_Paint(rect->x, rect->y, scale, color, va("%2i", limit),0, 0, textStyle);
 }
@@ -1979,7 +1979,8 @@ static void CG_DrawCaptureLimit( rectDef_t *rect, float text_x, float text_y, ve
 	int			value;
 	info = CG_ConfigString( CS_SERVERINFO );
 	value = atoi( Info_ValueForKey( info, "capturelimit" ) );
-	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && !CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM))
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
+			!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM))
 		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 	else
 		value = atoi( Info_ValueForKey( info, "fraglimit" ) );

--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -60,7 +60,7 @@ void CG_SetPrintString(int type, const char *p)
 
 void CG_CheckOrderPending(void)
 {
-	if (!CG_IsATeamGametype(cgs.gametype)) {
+	if (!CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		return;
 	}
 	if (cgs.orderPending) {
@@ -695,8 +695,8 @@ static void CG_DrawBlueFlagName(rectDef_t *rect, float scale, vec4_t color, int 
 
 static void CG_DrawBlueFlagStatus(rectDef_t *rect, qhandle_t shader)
 {
-	if (!CG_UsesTeamFlags(cgs.gametype)) {
-		if (cgs.gametype == GT_HARVESTER) {
+	if (!CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 			vec4_t color = {0, 0, 1, 1};
 			trap_R_SetColor(color);
 			CG_DrawPic( rect->x, rect->y, rect->w, rect->h, cgs.media.blueCubeIcon );
@@ -750,8 +750,8 @@ static void CG_DrawRedFlagName(rectDef_t *rect, float scale, vec4_t color, int t
 
 static void CG_DrawRedFlagStatus(rectDef_t *rect, qhandle_t shader)
 {
-	if (!CG_UsesTeamFlags(cgs.gametype)) {
-		if (cgs.gametype == GT_HARVESTER) {
+	if (!CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 			vec4_t color = {1, 0, 0, 1};
 			trap_R_SetColor(color);
 			CG_DrawPic( rect->x, rect->y, rect->w, rect->h, cgs.media.redCubeIcon );
@@ -799,7 +799,7 @@ static void CG_HarvesterSkulls(rectDef_t *rect, float scale, vec4_t color, qbool
 	qhandle_t handle;
 	int value = cg.snap->ps.generic1;
 
-	if (cgs.gametype != GT_HARVESTER) {
+	if (!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		return;
 	}
 
@@ -840,7 +840,7 @@ static void CG_HarvesterSkulls(rectDef_t *rect, float scale, vec4_t color, qbool
 
 static void CG_OneFlagStatus(rectDef_t *rect)
 {
-	if (!CG_UsesTheWhiteFlag(cgs.gametype)) {
+	if (!CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype)) {
 		return;
 	}
 	else {
@@ -872,7 +872,7 @@ static void CG_DrawCTFPowerUp(rectDef_t *rect)
 {
 	int		value;
 
-	if (!CG_IsATeamGametype(cgs.gametype)) {
+	if (!CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		return;
 	}
 	value = cg.snap->ps.stats[STAT_PERSISTANT_POWERUP];
@@ -1024,9 +1024,9 @@ float CG_GetValue(int ownerDraw)
 
 qboolean CG_OtherTeamHasFlag(void)
 {
-	if (CG_UsesTeamFlags(cgs.gametype)) {
+	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
 		int team = cg.snap->ps.persistant[PERS_TEAM];
-		if (cgs.gametype == GT_1FCTF) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 			if (team == TEAM_RED && cgs.flagStatus == FLAG_TAKEN_BLUE) {
 				return qtrue;
 			}
@@ -1054,9 +1054,9 @@ qboolean CG_OtherTeamHasFlag(void)
 
 qboolean CG_YourTeamHasFlag(void)
 {
-	if (CG_UsesTeamFlags(cgs.gametype)) {
+	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
 		int team = cg.snap->ps.persistant[PERS_TEAM];
-		if (cgs.gametype == GT_1FCTF) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 			if (team == TEAM_RED && cgs.flagStatus == FLAG_TAKEN_RED) {
 				return qtrue;
 			}
@@ -1114,19 +1114,19 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_ANYTEAMGAME) {
-		if(CG_IsATeamGametype(cgs.gametype)) {
+		if(CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 			return qtrue;
 		}
 	}
 
 	if (flags & CG_SHOW_ANYNONTEAMGAME) {
-		if(!CG_IsATeamGametype(cgs.gametype)) {
+		if(!CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 			return qtrue;
 		}
 	}
 
 	if (flags & CG_SHOW_HARVESTER) {
-		if( cgs.gametype == GT_HARVESTER ) {
+		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 			return qtrue;
 		}
 		else {
@@ -1135,7 +1135,7 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_ONEFLAG) {
-		if( cgs.gametype == GT_1FCTF ) {
+		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 			return qtrue;
 		}
 		else {
@@ -1144,13 +1144,13 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_CTF) {
-		if(CG_UsesTeamFlags(cgs.gametype) && !CG_UsesTheWhiteFlag(cgs.gametype)) {
+		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF)) {
 			return qtrue;
 		}
 	}
 
 	if (flags & CG_SHOW_OBELISK) {
-		if( cgs.gametype == GT_OBELISK ) {
+		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 			return qtrue;
 		}
 		else {
@@ -1177,7 +1177,7 @@ qboolean CG_OwnerDrawVisible(int flags)
 	}
 
 	if (flags & CG_SHOW_TOURNAMENT) {
-		if( cgs.gametype == GT_TOURNAMENT ) {
+		if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 			return qtrue;
 		}
 	}
@@ -1247,7 +1247,9 @@ static void CG_DrawKiller(rectDef_t *rect, float scale, vec4_t color, qhandle_t 
 
 static void CG_DrawCapFragLimit(rectDef_t *rect, float scale, vec4_t color, qhandle_t shader, int textStyle)
 {
-	int limit = (CG_IsATeamGametype(cgs.gametype) && cgs.gametype != GT_TEAM) ? cgs.capturelimit : cgs.fraglimit;
+	int limit = (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
+		CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) ?
+		cgs.capturelimit : cgs.fraglimit;
 	CG_Text_Paint(rect->x, rect->y, scale, color, va("%2i", limit),0, 0, textStyle);
 }
 
@@ -1268,7 +1270,7 @@ static void CG_Draw2ndPlace(rectDef_t *rect, float scale, vec4_t color, qhandle_
 const char *CG_GetGameStatusText(void)
 {
 	const char *s = "";
-	if (!CG_IsATeamGametype(cgs.gametype)) {
+	if (!CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		if (cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR ) {
 			s = va("%s place with %i",CG_PlaceString( cg.snap->ps.persistant[PERS_RANK] + 1 ),cg.snap->ps.persistant[PERS_SCORE] );
 		}
@@ -1294,40 +1296,40 @@ static void CG_DrawGameStatus(rectDef_t *rect, float scale, vec4_t color, qhandl
 
 const char *CG_GameTypeString(void)
 {
-	if ( cgs.gametype == GT_FFA ) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_FFA)) {
 		return "Free For All";
 	}
-	else if ( cgs.gametype == GT_TEAM ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM)) {
 		return "Team Deathmatch";
 	}
-	else if ( cgs.gametype == GT_CTF ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF)) {
 		return "Capture the Flag";
 	}
-	else if ( cgs.gametype == GT_1FCTF ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 		return "One Flag CTF";
 	}
-	else if ( cgs.gametype == GT_OBELISK ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_OBELISK)) {
 		return "Overload";
 	}
-	else if ( cgs.gametype == GT_HARVESTER ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		return "Harvester";
 	}
-	else if ( cgs.gametype == GT_ELIMINATION ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_ELIMINATION)) {
 		return "Elimination";
 	}
-	else if ( cgs.gametype == GT_CTF_ELIMINATION ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION)) {
 		return "CTF Elimination";
 	}
-	else if ( cgs.gametype == GT_LMS ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS)) {
 		return "Last Man Standing";
 	}
-	else if ( cgs.gametype == GT_DOUBLE_D ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		return "Double Domination";
 	}
-	else if ( cgs.gametype == GT_DOMINATION ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOMINATION)) {
 		return "Domination";
 	}
-	else if ( cgs.gametype == GT_POSSESSION ) {
+	else if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		return "Possession";
 	}
 	return "";
@@ -1977,7 +1979,7 @@ static void CG_DrawCaptureLimit( rectDef_t *rect, float text_x, float text_y, ve
 	int			value;
 	info = CG_ConfigString( CS_SERVERINFO );
 	value = atoi( Info_ValueForKey( info, "capturelimit" ) );
-	if (CG_IsATeamGametype(cgs.gametype) && cgs.gametype != GT_TEAM)
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && !CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM))
 		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 	else
 		value = atoi( Info_ValueForKey( info, "fraglimit" ) );

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -466,7 +466,7 @@ static qboolean CG_FindClientModelFile(char *filename, int length, clientInfo_t 
 	char *team, *charactersFolder;
 	int i;
 
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		switch (ci->team) {
 			case TEAM_BLUE:
 			{
@@ -495,7 +495,7 @@ static qboolean CG_FindClientModelFile(char *filename, int length, clientInfo_t 
 			if (CG_FileExists(filename)) {
 				return qtrue;
 			}
-			if (CG_IsATeamGametype(cgs.gametype)) {
+			if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 				if (i == 0 && teamName && *teamName) {
 					//								"models/players/characters/sergei/stroggs/lower_red.skin"
 					Com_sprintf(filename, length, "models/players/%s%s/%s%s_%s.%s", charactersFolder, modelName, teamName, base, team, ext);
@@ -538,7 +538,7 @@ static qboolean CG_FindClientHeadFile(char *filename, int length, clientInfo_t *
 	char *team, *headsFolder;
 	int i;
 
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		switch (ci->team) {
 			case TEAM_BLUE:
 			{
@@ -571,7 +571,7 @@ static qboolean CG_FindClientHeadFile(char *filename, int length, clientInfo_t *
 			if (CG_FileExists(filename)) {
 				return qtrue;
 			}
-			if (CG_IsATeamGametype(cgs.gametype)) {
+			if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 				if (i == 0 && teamName && *teamName) {
 					Com_sprintf(filename, length, "models/players/%s%s/%s%s_%s.%s", headsFolder, headModelName, teamName, base, team, ext);
 				} else {
@@ -857,7 +857,7 @@ static void CG_LoadClientInfo(int clientNum, clientInfo_t *ci) {
 
 	teamname[0] = 0;
 #ifdef MISSIONPACK
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		if (ci->team == TEAM_BLUE) {
 			Q_strncpyz(teamname, cg_blueTeamName.string, sizeof (teamname));
 		} else {
@@ -875,7 +875,7 @@ static void CG_LoadClientInfo(int clientNum, clientInfo_t *ci) {
 		}
 
 		// fall back to default team name
-		if (CG_IsATeamGametype(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 			// keep skin name
 			if (ci->team == TEAM_BLUE) {
 				Q_strncpyz(teamname, DEFAULT_BLUETEAM_NAME, sizeof (teamname));
@@ -908,7 +908,7 @@ static void CG_LoadClientInfo(int clientNum, clientInfo_t *ci) {
 
 	// sounds
 	dir = ci->modelName;
-	fallback = (CG_IsATeamGametype(cgs.gametype)) ? DEFAULT_TEAM_MODEL : DEFAULT_MODEL;
+	fallback = (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) ? DEFAULT_TEAM_MODEL : DEFAULT_MODEL;
 
 	for (i = 0; i < MAX_CUSTOM_SOUNDS; i++) {
 		s = cg_customSoundNames[i];
@@ -989,7 +989,7 @@ static qboolean CG_ScanForExistingClientInfo(clientInfo_t *ci) {
 				&& Q_strequal(ci->headSkinName, match->headSkinName)
 				&& Q_strequal(ci->blueTeam, match->blueTeam)
 				&& Q_strequal(ci->redTeam, match->redTeam)
-				&& (!CG_IsATeamGametype(cgs.gametype) || ci->team == match->team)) {
+				&& (!CG_IsATeamGametype(cgs.gametype,cgs.subgametype) || ci->team == match->team)) {
 			// this clientinfo is identical, so use it's handles
 
 			ci->deferred = qfalse;
@@ -1025,7 +1025,7 @@ static void CG_SetDeferredClientInfo(int clientNum, clientInfo_t *ci) {
 		}
 		if (!Q_strequal(ci->skinName, match->skinName) ||
 				!Q_strequal(ci->modelName, match->modelName) ||
-				(CG_IsATeamGametype(cgs.gametype) && ci->team != match->team)) {
+				(CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && ci->team != match->team)) {
 			continue;
 		}
 		// just load the real info cause it uses the same models and skins
@@ -1034,14 +1034,14 @@ static void CG_SetDeferredClientInfo(int clientNum, clientInfo_t *ci) {
 	}
 
 	// if we are in teamplay, only grab a model if the skin is correct
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		for (i = 0; i < cgs.maxclients; i++) {
 			match = &cgs.clientinfo[ i ];
 			if (!match->infoValid || match->deferred) {
 				continue;
 			}
 			if (!Q_strequal(ci->skinName, match->skinName) ||
-					(CG_IsATeamGametype(cgs.gametype) && ci->team != match->team)) {
+					(CG_IsATeamGametype(cgs.gametype,cgs.subgametype) && ci->team != match->team)) {
 				continue;
 			}
 			ci->deferred = qtrue;
@@ -1153,7 +1153,7 @@ void CG_NewClientInfo(int clientNum) {
 
 		/* Neon_Knight: Missionpack checks, if != 0, enables this. */
 		if (cg_missionpackChecks.integer) {
-			if (CG_IsATeamGametype(cgs.gametype)) {
+			if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 				Q_strncpyz(newInfo.modelName, DEFAULT_TEAM_MODEL, sizeof ( newInfo.modelName));
 				Q_strncpyz(newInfo.skinName, "default", sizeof ( newInfo.skinName));
 			}
@@ -1169,7 +1169,7 @@ void CG_NewClientInfo(int clientNum) {
 			Q_strncpyz(newInfo.modelName, modelStr, sizeof ( newInfo.modelName));
 		}
 		/* /Neon_Knight */
-		if (CG_IsATeamGametype(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 			// keep skin name
 			slash = strchr(v, '/');
 			if (slash) {
@@ -1200,7 +1200,7 @@ void CG_NewClientInfo(int clientNum) {
 
 		/* Neon_Knight: Missionpack checks, if != 0, enables this. */
 		if (cg_missionpackChecks.integer) {
-			if (CG_IsATeamGametype(cgs.gametype)) {
+			if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 				Q_strncpyz(newInfo.headModelName, DEFAULT_TEAM_MODEL, sizeof ( newInfo.headModelName));
 				Q_strncpyz(newInfo.headSkinName, "default", sizeof ( newInfo.headSkinName));
 			}
@@ -1217,7 +1217,7 @@ void CG_NewClientInfo(int clientNum) {
 		}
 		/* /Neon_Knight */
 
-		if (CG_IsATeamGametype(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 			// keep skin name
 			slash = strchr(v, '/');
 			if (slash) {
@@ -2250,7 +2250,7 @@ static void CG_PlayerSprites(centity_t *cent) {
 	team = cgs.clientinfo[ cent->currentState.clientNum ].team;
 	if (!(cent->currentState.eFlags & EF_DEAD) &&
 			cg.snap->ps.persistant[PERS_TEAM] == team &&
-			CG_IsATeamGametype(cgs.gametype)) {
+			CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		if (cg_drawFriend.integer) {
 			CG_PlayerFloatSprite(cent, cgs.media.friendShader);
 		}
@@ -2608,7 +2608,7 @@ void CG_Player(centity_t *cent) {
 		renderfx |= RF_SHADOW_PLANE;
 	}
 	renderfx |= RF_LIGHTING_ORIGIN; // use the same origin for all
-	if (cgs.gametype == GT_HARVESTER) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		CG_PlayerTokens(cent, renderfx);
 	}
 	//

--- a/code/cgame/cg_players.c
+++ b/code/cgame/cg_players.c
@@ -2608,7 +2608,7 @@ void CG_Player(centity_t *cent) {
 		renderfx |= RF_SHADOW_PLANE;
 	}
 	renderfx |= RF_LIGHTING_ORIGIN; // use the same origin for all
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_HARVESTER)) {
 		CG_PlayerTokens(cent, renderfx);
 	}
 	//

--- a/code/cgame/cg_playerstate.c
+++ b/code/cgame/cg_playerstate.c
@@ -434,7 +434,7 @@ void CG_CheckLocalSounds( playerState_t *ps, playerState_t *ops ) {
 					if (  ps->persistant[PERS_RANK] == 0 ) {
 						CG_AddBufferedSound(cgs.media.takenLeadSound);
 					} else if ( ps->persistant[PERS_RANK] == RANK_TIED_FLAG &&
-							!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
+							!CG_IsGametype(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 						CG_AddBufferedSound(cgs.media.tiedLeadSound);
 					} else if ( ps->persistant[PERS_RANK] != RANK_TIED_FLAG &&( ops->persistant[PERS_RANK] & ~RANK_TIED_FLAG ) == 0 ) {
 						CG_AddBufferedSound(cgs.media.lostLeadSound);
@@ -467,7 +467,7 @@ void CG_CheckLocalSounds( playerState_t *ps, playerState_t *ops ) {
 	if (!CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		highScore = cgs.scores1;
 
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM) && cgs.scores2 > highScore) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TEAM) && cgs.scores2 > highScore) {
 			highScore = cgs.scores2;
 		}
 

--- a/code/cgame/cg_playerstate.c
+++ b/code/cgame/cg_playerstate.c
@@ -415,7 +415,7 @@ void CG_CheckLocalSounds( playerState_t *ps, playerState_t *ops ) {
 	}
 
 	// check for flag pickup
-	if (CG_UsesTeamFlags(cgs.gametype)) {
+	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
 		if ((ps->powerups[PW_REDFLAG] != ops->powerups[PW_REDFLAG] && ps->powerups[PW_REDFLAG]) ||
 			(ps->powerups[PW_BLUEFLAG] != ops->powerups[PW_BLUEFLAG] && ps->powerups[PW_BLUEFLAG]) ||
 			(ps->powerups[PW_NEUTRALFLAG] != ops->powerups[PW_NEUTRALFLAG] && ps->powerups[PW_NEUTRALFLAG]) )
@@ -430,10 +430,11 @@ void CG_CheckLocalSounds( playerState_t *ps, playerState_t *ops ) {
 		if ( !cg.warmup ) {
 			// never play lead changes during warmup
 			if ( ps->persistant[PERS_RANK] != ops->persistant[PERS_RANK] ) {
-				if (!CG_IsATeamGametype(cgs.gametype)) {
+				if (!CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 					if (  ps->persistant[PERS_RANK] == 0 ) {
 						CG_AddBufferedSound(cgs.media.takenLeadSound);
-					} else if ( ps->persistant[PERS_RANK] == RANK_TIED_FLAG && cgs.gametype != GT_POSSESSION ) {
+					} else if ( ps->persistant[PERS_RANK] == RANK_TIED_FLAG &&
+							!CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 						CG_AddBufferedSound(cgs.media.tiedLeadSound);
 					} else if ( ps->persistant[PERS_RANK] != RANK_TIED_FLAG &&( ops->persistant[PERS_RANK] & ~RANK_TIED_FLAG ) == 0 ) {
 						CG_AddBufferedSound(cgs.media.lostLeadSound);
@@ -463,10 +464,10 @@ void CG_CheckLocalSounds( playerState_t *ps, playerState_t *ops ) {
 	}
 
 	// fraglimit warnings
-	if (!CG_IsATeamGametype(cgs.gametype)) {
+	if (!CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		highScore = cgs.scores1;
 
-		if (cgs.gametype == GT_TEAM && cgs.scores2 > highScore) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TEAM) && cgs.scores2 > highScore) {
 			highScore = cgs.scores2;
 		}
 

--- a/code/cgame/cg_predict.c
+++ b/code/cgame/cg_predict.c
@@ -263,17 +263,17 @@ static void CG_TouchItem( centity_t *cent ) {
 	//For instantgib
 	qboolean	canBePicked;
 
-	if(CG_IsARoundBasedGametype(cgs.gametype) && !CG_UsesTeamFlags(cgs.gametype))
+	if(CG_IsARoundBasedGametype(cgs.gametype,cgs.subgametype) && !CG_UsesTeamFlags(cgs.gametype,cgs.subgametype))
 		return; //No weapon pickup in elimination
 
-	if(CG_IsARoundBasedGametype(cgs.gametype) && cgs.roundStartTime > cgs.roundtime)
+	if(CG_IsARoundBasedGametype(cgs.gametype,cgs.subgametype) && cgs.roundStartTime > cgs.roundtime)
 		return; //We cannot pickup before the round has started
 
 	//normally we can
 	canBePicked = qtrue;
 
 	//But in instantgib, rocket arena, and CTF_ELIMINATION we normally can't:
-	if(cgs.nopickup || cgs.gametype == GT_CTF_ELIMINATION)
+	if(cgs.nopickup || CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION))
 		canBePicked = qfalse;
 
 	if ( !cg_predictItems.integer ) {
@@ -296,18 +296,18 @@ static void CG_TouchItem( centity_t *cent ) {
 
 	// Special case for flags.  
 	// We don't predict touching our own flag
-	if( cgs.gametype == GT_1FCTF ) {
+	if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 		if( item->giType == IT_TEAM && item->giTag != PW_NEUTRALFLAG ) {
 			return;
 		}
 	}
-	if (cgs.gametype == GT_POSSESSION) {
+	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		if( item->giType == IT_TEAM && item->giTag == PW_NEUTRALFLAG ) {
 			canBePicked = qtrue;
 		}
 	}
 	
-	if (cgs.gametype == GT_CTF || cgs.gametype == GT_CTF_ELIMINATION ) {
+	if (CG_UsesTeamFlags(cgs.gametype,cgs.subgametype)) {
 		if (cg.predictedPlayerState.persistant[PERS_TEAM] == TEAM_RED &&
 			item->giType == IT_TEAM && item->giTag == PW_REDFLAG)
 			return;
@@ -324,7 +324,7 @@ static void CG_TouchItem( centity_t *cent ) {
 	}
 
 	//Currently we don't predict anything in Double Domination because it looks like we take a flag
-	if( cgs.gametype == GT_DOUBLE_D ) {
+	if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		if(cgs.redflag == TEAM_NONE)
 			return; //Can never pick if just one flag is NONE (because then the other is too)
 		if(item->giTag == PW_REDFLAG){ //at point A

--- a/code/cgame/cg_predict.c
+++ b/code/cgame/cg_predict.c
@@ -273,7 +273,7 @@ static void CG_TouchItem( centity_t *cent ) {
 	canBePicked = qtrue;
 
 	//But in instantgib, rocket arena, and CTF_ELIMINATION we normally can't:
-	if(cgs.nopickup || CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION))
+	if(cgs.nopickup || CG_IsGametype(cgs.gametype,cgs.subgametype,GT_CTF_ELIMINATION))
 		canBePicked = qfalse;
 
 	if ( !cg_predictItems.integer ) {
@@ -296,12 +296,12 @@ static void CG_TouchItem( centity_t *cent ) {
 
 	// Special case for flags.  
 	// We don't predict touching our own flag
-	if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
+	if(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_1FCTF)) {
 		if( item->giType == IT_TEAM && item->giTag != PW_NEUTRALFLAG ) {
 			return;
 		}
 	}
-	if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
+	if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_POSSESSION)) {
 		if( item->giType == IT_TEAM && item->giTag == PW_NEUTRALFLAG ) {
 			canBePicked = qtrue;
 		}
@@ -324,7 +324,7 @@ static void CG_TouchItem( centity_t *cent ) {
 	}
 
 	//Currently we don't predict anything in Double Domination because it looks like we take a flag
-	if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+	if(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		if(cgs.redflag == TEAM_NONE)
 			return; //Can never pick if just one flag is NONE (because then the other is too)
 		if(item->giTag == PW_REDFLAG){ //at point A

--- a/code/cgame/cg_scoreboard.c
+++ b/code/cgame/cg_scoreboard.c
@@ -123,14 +123,14 @@ static void CG_DrawClientScore(int y, score_t *score, float *color, float fade, 
 			}
 		} else if (ci->handicap < 100) {
 			Com_sprintf(string, sizeof ( string), "%i", ci->handicap);
-			if (cgs.gametype == GT_TOURNAMENT)
+			if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT))
 				CG_DrawSmallStringColor(iconx, y - SMALLCHAR_HEIGHT / 2, string, color);
 			else
 				CG_DrawSmallStringColor(iconx, y, string, color);
 		}
 
 		// draw the wins / losses
-		if (cgs.gametype == GT_TOURNAMENT) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 			Com_sprintf(string, sizeof ( string), "%i/%i", ci->wins, ci->losses);
 			if (ci->handicap < 100 && !ci->botSkill) {
 				CG_DrawSmallStringColor(iconx, y + SMALLCHAR_HEIGHT / 2, string, color);
@@ -170,7 +170,7 @@ static void CG_DrawClientScore(int y, score_t *score, float *color, float fade, 
 		Com_sprintf(string, sizeof (string),
 				" SPECT %3i %4i %s", score->ping, score->time, ci->name);
 	} else {
-		/*if(cgs.gametype == GT_LMS)
+		/*if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS))
 			Com_sprintf(string, sizeof(string),
 				"%5i %4i %4i %s *%i*", score->score, score->ping, score->time, ci->name, ci->isDead);
 		else*/
@@ -190,7 +190,7 @@ static void CG_DrawClientScore(int y, score_t *score, float *color, float fade, 
 		localClient = qtrue;
 
 		if ((cg.snap->ps.persistant[PERS_TEAM] == TEAM_SPECTATOR) ||
-				CG_IsATeamGametype(cgs.gametype)) {
+				CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 			// Sago: I think this means that it doesn't matter if two players are tied in team game - only team score counts
 			rank = -1;
 		} else {
@@ -225,7 +225,7 @@ static void CG_DrawClientScore(int y, score_t *score, float *color, float fade, 
 	if (cg.snap->ps.stats[ STAT_CLIENTS_READY ] & (1 << score->client)) {
 		CG_DrawBigStringColor(iconx, y, "READY", color);
 	} else
-		if (cgs.gametype == GT_LMS) {
+		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS)) {
 		CG_DrawBigStringColor(iconx - 50, y, va("*%i*", ci->isDead), color);
 	} else
 		if (ci->isDead) {
@@ -324,7 +324,7 @@ qboolean CG_DrawOldScoreboard(void) {
 	}
 
 	// current rank
-	if (!CG_IsATeamGametype(cgs.gametype)) {
+	if (!CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		if (cg.snap->ps.persistant[PERS_TEAM] != TEAM_SPECTATOR) {
 			s = va("%s place with %i",
 					CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1),
@@ -374,7 +374,7 @@ qboolean CG_DrawOldScoreboard(void) {
 
 	localClient = qfalse;
 
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		//
 		// teamplay scoreboard
 		//
@@ -505,7 +505,7 @@ void CG_DrawTourneyScoreboard(void) {
 	// print the two scores
 
 	y = 160;
-	if (CG_IsATeamGametype(cgs.gametype)) {
+	if (CG_IsATeamGametype(cgs.gametype,cgs.subgametype)) {
 		//
 		// teamplay scoreboard
 		//

--- a/code/cgame/cg_scoreboard.c
+++ b/code/cgame/cg_scoreboard.c
@@ -123,14 +123,14 @@ static void CG_DrawClientScore(int y, score_t *score, float *color, float fade, 
 			}
 		} else if (ci->handicap < 100) {
 			Com_sprintf(string, sizeof ( string), "%i", ci->handicap);
-			if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT))
+			if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TOURNAMENT))
 				CG_DrawSmallStringColor(iconx, y - SMALLCHAR_HEIGHT / 2, string, color);
 			else
 				CG_DrawSmallStringColor(iconx, y, string, color);
 		}
 
 		// draw the wins / losses
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TOURNAMENT)) {
 			Com_sprintf(string, sizeof ( string), "%i/%i", ci->wins, ci->losses);
 			if (ci->handicap < 100 && !ci->botSkill) {
 				CG_DrawSmallStringColor(iconx, y + SMALLCHAR_HEIGHT / 2, string, color);
@@ -170,7 +170,7 @@ static void CG_DrawClientScore(int y, score_t *score, float *color, float fade, 
 		Com_sprintf(string, sizeof (string),
 				" SPECT %3i %4i %s", score->ping, score->time, ci->name);
 	} else {
-		/*if(CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS))
+		/*if(CG_IsGametype(cgs.gametype,cgs.subgametype,GT_LMS))
 			Com_sprintf(string, sizeof(string),
 				"%5i %4i %4i %s *%i*", score->score, score->ping, score->time, ci->name, ci->isDead);
 		else*/
@@ -225,7 +225,7 @@ static void CG_DrawClientScore(int y, score_t *score, float *color, float fade, 
 	if (cg.snap->ps.stats[ STAT_CLIENTS_READY ] & (1 << score->client)) {
 		CG_DrawBigStringColor(iconx, y, "READY", color);
 	} else
-		if (CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_LMS)) {
+		if (CG_IsGametype(cgs.gametype,cgs.subgametype,GT_LMS)) {
 		CG_DrawBigStringColor(iconx - 50, y, va("*%i*", ci->isDead), color);
 	} else
 		if (ci->isDead) {

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -428,7 +428,7 @@ void CG_SetConfigValues( void ) {
 	cgs.scores2 = atoi( CG_ConfigString( CS_SCORES2 ) );
 	cgs.levelStartTime = atoi( CG_ConfigString( CS_LEVEL_START_TIME ) );
 	if((CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) && !CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype)) ||
-			CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+			CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 		s = CG_ConfigString( CS_FLAGSTATUS );
 		cgs.redflag = s[0] - '0';
 		cgs.blueflag = s[1] - '0';
@@ -552,7 +552,7 @@ static void CG_ConfigStringModified( void ) {
 		CG_BuildSpectatorString();
 	} else if ( num == CS_FLAGSTATUS ) {
 		if((CG_UsesTeamFlags(cgs.gametype,cgs.subgametype) && CG_UsesTheWhiteFlag(cgs.gametype,cgs.subgametype)) ||
-				CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
+				CG_IsGametype(cgs.gametype,cgs.subgametype,GT_DOUBLE_D)) {
 			// format is rb where its red/blue, 0 is at base, 1 is taken, 2 is dropped
 			cgs.redflag = str[0] - '0';
 			cgs.blueflag = str[1] - '0';
@@ -679,7 +679,7 @@ static void CG_MapRestart( void ) {
 	// we really should clear more parts of cg here and stop sounds
 
 	// play the "fight" sound if this is a restart without warmup
-	if ( cg.warmup == 0 /* && CG_SingleGametypeCheck(cgs.gametype,cgs.subgametype,GT_TOURNAMENT) */) {
+	if ( cg.warmup == 0 /* && CG_IsGametype(cgs.gametype,cgs.subgametype,GT_TOURNAMENT) */) {
 		trap_S_StartLocalSound( cgs.media.countFightSound, CHAN_ANNOUNCER );
 		CG_CenterPrint( "FIGHT!", 120, GIANTCHAR_WIDTH*2 );
 	}

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -266,7 +266,7 @@ static void CG_OffsetThirdPersonView( void ) {
 	VectorCopy( cg.refdefViewAngles, focusAngles );
 
 	// if dead, look at killer
-	if ( (cg.predictedPlayerState.stats[STAT_HEALTH] <= 0) && !CG_IsARoundBasedGametype(cgs.gametype) ) {
+	if ( (cg.predictedPlayerState.stats[STAT_HEALTH] <= 0) && !CG_IsARoundBasedGametype(cgs.gametype,cgs.subgametype) ) {
 		focusAngles[YAW] = cg.predictedPlayerState.stats[STAT_DEAD_YAW];
 		cg.refdefViewAngles[YAW] = cg.predictedPlayerState.stats[STAT_DEAD_YAW];
 	}
@@ -435,7 +435,7 @@ static void CG_OffsetFirstPersonView( void ) {
 	VectorAdd (angles, cg.kick_angles, angles);
 
 	// add angles based on damage kick
-	if ( cg.damageTime && !CG_IsARoundBasedGametype(cgs.gametype)) {
+	if ( cg.damageTime && !CG_IsARoundBasedGametype(cgs.gametype,cgs.subgametype)) {
 		ratio = cg.time - cg.damageTime;
 		if ( ratio < DAMAGE_DEFLECT_TIME ) {
 			ratio /= DAMAGE_DEFLECT_TIME;

--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -3411,7 +3411,8 @@ void CG_FireWeapon( centity_t *cent )
 	int				c;
 	weaponInfo_t	*weap;
 
-	if(CG_IsARoundBasedGametype(cgs.gametype) && CG_IsATeamGametype(cgs.gametype) && cgs.roundStartTime>=cg.time)
+	if(CG_IsARoundBasedGametype(cgs.gametype,cgs.subgametype) && CG_IsATeamGametype(cgs.gametype,cgs.subgametype) &&
+			cgs.roundStartTime>=cg.time)
 		return; //if we havn't started in ELIMINATION then do not fire
 
 	ent = &cent->currentState;

--- a/code/game/ai_chat.c
+++ b/code/game/ai_chat.c
@@ -384,9 +384,9 @@ int BotChat_EnterGame(bot_state_t *bs) {
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	//don't chat in teamplay
-	if (G_IsATeamGametype(gametype)) return qfalse;
+	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENTEREXITGAME, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -417,9 +417,9 @@ int BotChat_ExitGame(bot_state_t *bs) {
 	if (bot_nochat.integer) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	//don't chat in teamplay
-	if (G_IsATeamGametype(gametype)) return qfalse;
+	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENTEREXITGAME, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -451,12 +451,12 @@ int BotChat_StartLevel(bot_state_t *bs) {
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	//don't chat in teamplay
-	if (G_IsATeamGametype(gametype)) {
+	if (G_IsATeamGametype(gametype,subgametype)) {
 	    trap_EA_Command(bs->client, "vtaunt");
 	    return qfalse;
 	}
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_STARTENDLEVEL, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -483,7 +483,7 @@ int BotChat_EndLevel(bot_state_t *bs) {
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	// teamplay
-	if (G_IsATeamGametype(gametype)) 
+	if (G_IsATeamGametype(gametype,subgametype))
 	{
 		if (BotIsFirstInRankings(bs)) {
 			trap_EA_Command(bs->client, "vtaunt");
@@ -491,7 +491,7 @@ int BotChat_EndLevel(bot_state_t *bs) {
 		return qtrue;
 	}
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_STARTENDLEVEL, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -543,7 +543,7 @@ int BotChat_Death(bot_state_t *bs) {
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_DEATH, 0, 1);
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chatting is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -555,7 +555,7 @@ int BotChat_Death(bot_state_t *bs) {
 	else
 		strcpy(name, "[world]");
 	//
-	if (G_IsATeamGametype(gametype) && BotSameTeam(bs, bs->lastkilledby)) {
+	if (G_IsATeamGametype(gametype,subgametype) && BotSameTeam(bs, bs->lastkilledby)) {
 		if (bs->lastkilledby == bs->client) return qfalse;
 		BotAI_BotInitialChat(bs, "death_teammate", name, NULL);
 		bs->chatto = CHAT_TEAM;
@@ -563,7 +563,7 @@ int BotChat_Death(bot_state_t *bs) {
 	else
 	{
 		//teamplay
-		if (G_IsATeamGametype(gametype)) {
+		if (G_IsATeamGametype(gametype,subgametype)) {
 			trap_EA_Command(bs->client, "vtaunt");
 			return qtrue;
 		}
@@ -642,7 +642,7 @@ int BotChat_Kill(bot_state_t *bs) {
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_KILL, 0, 1);
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -656,14 +656,14 @@ int BotChat_Kill(bot_state_t *bs) {
 	EasyClientName(bs->lastkilledplayer, name, 32);
 	//
 	bs->chatto = CHAT_ALL;
-	if (G_IsATeamGametype(gametype) && BotSameTeam(bs, bs->lastkilledplayer)) {
+	if (G_IsATeamGametype(gametype,subgametype) && BotSameTeam(bs, bs->lastkilledplayer)) {
 		BotAI_BotInitialChat(bs, "kill_teammate", name, NULL);
 		bs->chatto = CHAT_TEAM;
 	}
 	else
 	{
 		//don't chat in teamplay
-		if (G_IsATeamGametype(gametype)) {
+		if (G_IsATeamGametype(gametype,subgametype)) {
 			trap_EA_Command(bs->client, "vtaunt");
 			return qfalse;			// don't wait
 		}
@@ -706,9 +706,9 @@ int BotChat_EnemySuicide(bot_state_t *bs) {
 	//
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENEMYSUICIDE, 0, 1);
 	//don't chat in teamplay
-	if (G_IsATeamGametype(gametype)) return qfalse;
+	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -746,9 +746,9 @@ int BotChat_HitTalking(bot_state_t *bs) {
 	//
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITTALKING, 0, 1);
 	//don't chat in teamplay
-	if (G_IsATeamGametype(gametype)) return qfalse;
+	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -786,9 +786,9 @@ int BotChat_HitNoDeath(bot_state_t *bs) {
 	if (BotNumActivePlayers() <= 1) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITNODEATH, 0, 1);
 	//don't chat in teamplay
-	if (G_IsATeamGametype(gametype)) return qfalse;
+	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -824,9 +824,9 @@ int BotChat_HitNoKill(bot_state_t *bs) {
 	if (BotNumActivePlayers() <= 1) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_HITNOKILL, 0, 1);
 	//don't chat in teamplay
-	if (G_IsATeamGametype(gametype)) return qfalse;
+	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -860,7 +860,7 @@ int BotChat_Random(bot_state_t *bs) {
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	// don't chat in tournament mode
-	if (gametype == GT_TOURNAMENT) return qfalse;
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//don't chat when doing something important :)
 	if (bs->ltgtype == LTG_TEAMHELP ||
 		bs->ltgtype == LTG_TEAMACCOMPANY ||
@@ -884,7 +884,7 @@ int BotChat_Random(bot_state_t *bs) {
 	else {
 		EasyClientName(bs->lastkilledplayer, name, sizeof(name));
 	}
-	if (G_IsATeamGametype(gametype)) {
+	if (G_IsATeamGametype(gametype,subgametype)) {
 		trap_EA_Command(bs->client, "vtaunt");
 		return qfalse;			// don't wait
 	}

--- a/code/game/ai_chat.c
+++ b/code/game/ai_chat.c
@@ -386,7 +386,7 @@ int BotChat_EnterGame(bot_state_t *bs) {
 	//don't chat in teamplay
 	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENTEREXITGAME, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -419,7 +419,7 @@ int BotChat_ExitGame(bot_state_t *bs) {
 	//don't chat in teamplay
 	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_ENTEREXITGAME, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -456,7 +456,7 @@ int BotChat_StartLevel(bot_state_t *bs) {
 	    return qfalse;
 	}
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_STARTENDLEVEL, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -491,7 +491,7 @@ int BotChat_EndLevel(bot_state_t *bs) {
 		return qtrue;
 	}
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_STARTENDLEVEL, 0, 1);
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -543,7 +543,7 @@ int BotChat_Death(bot_state_t *bs) {
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_DEATH, 0, 1);
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chatting is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -642,7 +642,7 @@ int BotChat_Kill(bot_state_t *bs) {
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	rnd = trap_Characteristic_BFloat(bs->character, CHARACTERISTIC_CHAT_KILL, 0, 1);
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -708,7 +708,7 @@ int BotChat_EnemySuicide(bot_state_t *bs) {
 	//don't chat in teamplay
 	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd) return qfalse;
@@ -748,7 +748,7 @@ int BotChat_HitTalking(bot_state_t *bs) {
 	//don't chat in teamplay
 	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -788,7 +788,7 @@ int BotChat_HitNoDeath(bot_state_t *bs) {
 	//don't chat in teamplay
 	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -826,7 +826,7 @@ int BotChat_HitNoKill(bot_state_t *bs) {
 	//don't chat in teamplay
 	if (G_IsATeamGametype(gametype,subgametype)) return qfalse;
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//if fast chat is off
 	if (!bot_fastchat.integer) {
 		if (random() > rnd * 0.5) return qfalse;
@@ -860,7 +860,7 @@ int BotChat_Random(bot_state_t *bs) {
 	if (BotIsObserver(bs)) return qfalse;
 	if (bs->lastchat_time > FloatTime() - TIME_BETWEENCHATTING) return qfalse;
 	// don't chat in tournament mode
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
+	if (G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) return qfalse;
 	//don't chat when doing something important :)
 	if (bs->ltgtype == LTG_TEAMHELP ||
 		bs->ltgtype == LTG_TEAMACCOMPANY ||

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -487,7 +487,7 @@ void BotMatch_HelpAccompany(bot_state_t *bs, bot_match_t *match) {
 	bot_match_t teammatematch;
 	aas_entityinfo_t entinfo;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//get the team mate name
@@ -610,7 +610,7 @@ void BotMatch_DefendKeyArea(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//get the match variable
@@ -659,7 +659,7 @@ void BotMatch_TakeA(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//get the match variable
@@ -708,7 +708,7 @@ void BotMatch_TakeB(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//get the match variable
@@ -756,7 +756,7 @@ void BotMatch_GetItem(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//get the match variable
@@ -797,7 +797,7 @@ void BotMatch_Camp(bot_state_t *bs, bot_match_t *match) {
 	char itemname[MAX_MESSAGE_SIZE];
 	aas_entityinfo_t entinfo;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//
@@ -887,7 +887,7 @@ void BotMatch_Patrol(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//get the patrol waypoints
@@ -926,15 +926,15 @@ void BotMatch_GetFlag(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		if (!ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
-	else if (gametype == GT_1FCTF) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
 		if (!ctf_neutralflag.areanum || !ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
-	else if (gametype == GT_POSSESSION) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_POSSESSION)) {
 		if (!ctf_neutralflag.areanum)
 			return;
 	}
@@ -958,7 +958,7 @@ void BotMatch_GetFlag(bot_state_t *bs, bot_match_t *match) {
 	//set the team goal time
 	bs->teamgoal_time = FloatTime() + CTF_GETFLAG_TIME;
 	// get an alternate route in ctf
-	if (G_UsesTeamFlags(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype)) {
 		//get an alternative route goal towards the enemy base
 		BotGetAlternateRouteGoal(bs, BotOppositeTeam(bs));
 	}
@@ -980,11 +980,12 @@ void BotMatch_AttackEnemyBase(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		BotMatch_GetFlag(bs, match);
 	}
-	else if ((G_UsesTeamFlags(gametype) && G_UsesTheWhiteFlag(gametype)) ||
-			gametype == GT_HARVESTER || gametype == GT_OBELISK) {
+	else if ((G_UsesTeamFlags(gametype,subgametype) && G_UsesTheWhiteFlag(gametype,subgametype)) ||
+			(G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) ||
+			(G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK))) {
 		if (!redobelisk.areanum || !blueobelisk.areanum)
 			return;
 	}
@@ -1026,11 +1027,10 @@ void BotMatch_Harvest(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (gametype == GT_HARVESTER) {
-		if (!neutralobelisk.areanum || !redobelisk.areanum || !blueobelisk.areanum)
-			return;
+	if (!(G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER))) {
+		return;
 	}
-	else {
+	if (!neutralobelisk.areanum || !redobelisk.areanum || !blueobelisk.areanum) {
 		return;
 	}
 	//if not addressed to this bot
@@ -1068,11 +1068,12 @@ void BotMatch_RushBase(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		if (!ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
-	else if (gametype == GT_1FCTF || gametype == GT_HARVESTER) {
+	else if ((G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) ||
+			(G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER))) {
 		if (!redobelisk.areanum || !blueobelisk.areanum)
 			return;
 	}
@@ -1162,7 +1163,7 @@ void BotMatch_ReturnFlag(bot_state_t *bs, bot_match_t *match) {
 	int client;
 
 	//if not in CTF mode
-	if (G_UsesTeamFlags(gametype))
+	if (G_UsesTeamFlags(gametype,subgametype))
 		return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match))
@@ -1199,7 +1200,7 @@ void BotMatch_JoinSubteam(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//get the sub team name
@@ -1222,7 +1223,7 @@ void BotMatch_LeaveSubteam(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//
@@ -1242,7 +1243,7 @@ BotMatch_LeaveSubteam
 ==================
 */
 void BotMatch_WhichTeam(bot_state_t *bs, bot_match_t *match) {
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 
@@ -1268,7 +1269,7 @@ void BotMatch_CheckPoint(bot_state_t *bs, bot_match_t *match) {
 	vec3_t position;
 	bot_waypoint_t *cp;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//
 	trap_BotMatchVariable(match, POSITION, buf, MAX_MESSAGE_SIZE);
 	VectorClear(position);
@@ -1322,7 +1323,7 @@ void BotMatch_FormationSpace(bot_state_t *bs, bot_match_t *match) {
 	char buf[MAX_MESSAGE_SIZE];
 	float space;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//
@@ -1345,7 +1346,7 @@ void BotMatch_Dismiss(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	trap_BotMatchVariable(match, NETNAME, netname, sizeof(netname));
@@ -1370,7 +1371,7 @@ void BotMatch_Suicide(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//
@@ -1392,7 +1393,7 @@ void BotMatch_StartTeamLeaderShip(bot_state_t *bs, bot_match_t *match) {
 	int client;
 	char teammate[MAX_MESSAGE_SIZE];
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if chats for him or herself
 	if (match->subtype & ST_I) {
 		//get the team mate that will be the team leader
@@ -1418,7 +1419,7 @@ void BotMatch_StopTeamLeaderShip(bot_state_t *bs, bot_match_t *match) {
 	char teammate[MAX_MESSAGE_SIZE];
 	char netname[MAX_MESSAGE_SIZE];
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//get the team mate that stops being the team leader
 	trap_BotMatchVariable(match, TEAMMATE, teammate, sizeof(teammate));
 	//if chats for him or herself
@@ -1446,7 +1447,7 @@ BotMatch_WhoIsTeamLeader
 void BotMatch_WhoIsTeamLeader(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 
 	ClientName(bs->client, netname, sizeof(netname));
 	//if this bot IS the team leader
@@ -1650,7 +1651,7 @@ void BotMatch_WhereAreYou(bot_state_t *bs, bot_match_t *match) {
 		NULL
 	};
 	//
-	if (!G_IsATeamGametype(gametype))
+	if (!G_IsATeamGametype(gametype,subgametype))
 		return;
 
 	//if not addressed to this bot
@@ -1667,7 +1668,7 @@ void BotMatch_WhereAreYou(bot_state_t *bs, bot_match_t *match) {
 		}
 	}
 	if (bestitem != -1) {
-		if (G_UsesTeamFlags(gametype)) {
+		if (G_UsesTeamFlags(gametype,subgametype)) {
 			redtt = trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin, ctf_redflag.areanum, TFL_DEFAULT);
 			bluett = trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin, ctf_blueflag.areanum, TFL_DEFAULT);
 			if (redtt < (redtt + bluett) * 0.4) {
@@ -1680,7 +1681,8 @@ void BotMatch_WhereAreYou(bot_state_t *bs, bot_match_t *match) {
 				BotAI_BotInitialChat(bs, "location", nearbyitems[bestitem], NULL);
 			}
 		}
-		else if (gametype == GT_HARVESTER || gametype == GT_OBELISK) {
+		else if ((G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) ||
+				(G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK))) {
 			redtt = trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin, redobelisk.areanum, TFL_DEFAULT);
 			bluett = trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin, blueobelisk.areanum, TFL_DEFAULT);
 			if (redtt < (redtt + bluett) * 0.4) {
@@ -1712,7 +1714,7 @@ void BotMatch_LeadTheWay(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE], teammate[MAX_MESSAGE_SIZE];
 	int client, areanum, other;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 	//if someone asks for someone else
@@ -1781,7 +1783,7 @@ void BotMatch_Kill(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 	//if not addressed to this bot
 	if (!BotAddressedToBot(bs, match)) return;
 
@@ -1818,7 +1820,7 @@ void BotMatch_CTF(bot_state_t *bs, bot_match_t *match) {
 
 	char flag[128], netname[MAX_NETNAME];
 
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		trap_BotMatchVariable(match, FLAG, flag, sizeof(flag));
 		if (match->subtype & ST_GOTFLAG) {
 			if (Q_strequal(flag, "red")) {
@@ -1850,7 +1852,7 @@ void BotMatch_CTF(bot_state_t *bs, bot_match_t *match) {
 			bs->flagstatuschanged = 1;
 		}
 	}
-	else if (G_UsesTheWhiteFlag(gametype)) {
+	else if (G_UsesTheWhiteFlag(gametype,subgametype)) {
 		if (match->subtype & ST_1FCTFGOTFLAG) {
 			trap_BotMatchVariable(match, NETNAME, netname, sizeof(netname));
 			bs->flagcarrier = ClientFromName(netname);

--- a/code/game/ai_cmd.c
+++ b/code/game/ai_cmd.c
@@ -930,11 +930,11 @@ void BotMatch_GetFlag(bot_state_t *bs, bot_match_t *match) {
 		if (!ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		if (!ctf_neutralflag.areanum || !ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_POSSESSION)) {
+	else if (G_IsGametype(gametype,subgametype,GT_POSSESSION)) {
 		if (!ctf_neutralflag.areanum)
 			return;
 	}
@@ -984,8 +984,8 @@ void BotMatch_AttackEnemyBase(bot_state_t *bs, bot_match_t *match) {
 		BotMatch_GetFlag(bs, match);
 	}
 	else if ((G_UsesTeamFlags(gametype,subgametype) && G_UsesTheWhiteFlag(gametype,subgametype)) ||
-			(G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) ||
-			(G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK))) {
+			(G_IsGametype(gametype,subgametype,GT_HARVESTER)) ||
+			(G_IsGametype(gametype,subgametype,GT_OBELISK))) {
 		if (!redobelisk.areanum || !blueobelisk.areanum)
 			return;
 	}
@@ -1027,7 +1027,7 @@ void BotMatch_Harvest(bot_state_t *bs, bot_match_t *match) {
 	char netname[MAX_MESSAGE_SIZE];
 	int client;
 
-	if (!(G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER))) {
+	if (!(G_IsGametype(gametype,subgametype,GT_HARVESTER))) {
 		return;
 	}
 	if (!neutralobelisk.areanum || !redobelisk.areanum || !blueobelisk.areanum) {
@@ -1072,8 +1072,8 @@ void BotMatch_RushBase(bot_state_t *bs, bot_match_t *match) {
 		if (!ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
-	else if ((G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) ||
-			(G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER))) {
+	else if ((G_IsGametype(gametype,subgametype,GT_1FCTF)) ||
+			(G_IsGametype(gametype,subgametype,GT_HARVESTER))) {
 		if (!redobelisk.areanum || !blueobelisk.areanum)
 			return;
 	}
@@ -1681,8 +1681,8 @@ void BotMatch_WhereAreYou(bot_state_t *bs, bot_match_t *match) {
 				BotAI_BotInitialChat(bs, "location", nearbyitems[bestitem], NULL);
 			}
 		}
-		else if ((G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) ||
-				(G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK))) {
+		else if ((G_IsGametype(gametype,subgametype,GT_HARVESTER)) ||
+				(G_IsGametype(gametype,subgametype,GT_OBELISK))) {
 			redtt = trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin, redobelisk.areanum, TFL_DEFAULT);
 			bluett = trap_AAS_AreaTravelTimeToGoalArea(bs->areanum, bs->origin, blueobelisk.areanum, TFL_DEFAULT);
 			if (redtt < (redtt + bluett) * 0.4) {

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -922,7 +922,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 		}
 	}
 #endif //CTF
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		if (bs->ltgtype == LTG_GETFLAG) {
 			//check for bot typing status message
 			if (bs->teammessage_time && bs->teammessage_time < FloatTime()) {
@@ -1006,7 +1006,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			return BotGetItemLongTermGoal(bs, tfl, goal);
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		if (bs->ltgtype == LTG_ATTACKENEMYBASE &&
 				bs->attackaway_time < FloatTime()) {
 
@@ -1044,7 +1044,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			return qtrue;
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		//if rushing to the base
 		if (bs->ltgtype == LTG_RUSHBASE) {
 			switch(BotTeam(bs)) {
@@ -1972,7 +1972,7 @@ int AINode_Seek_LTG(bot_state_t *bs)
 			if (Bot1FCTFCarryingFlag(bs))
 				range = 50;
 		}
-		else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+		else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 			if (BotHarvesterCarryingCubes(bs))
 				range = 80;
 		}
@@ -2492,7 +2492,7 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 			if (Bot1FCTFCarryingFlag(bs))
 				range = 50;
 		}
-		else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+		else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 			if (BotHarvesterCarryingCubes(bs))
 				range = 80;
 		}

--- a/code/game/ai_dmnet.c
+++ b/code/game/ai_dmnet.c
@@ -837,7 +837,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 		return qtrue;
 	}
 #ifdef CTF
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		//if going for enemy flag
 		if (bs->ltgtype == LTG_GETFLAG) {
 			//check for bot typing status message
@@ -922,7 +922,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 		}
 	}
 #endif //CTF
-	else if (gametype == GT_1FCTF) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
 		if (bs->ltgtype == LTG_GETFLAG) {
 			//check for bot typing status message
 			if (bs->teammessage_time && bs->teammessage_time < FloatTime()) {
@@ -1006,7 +1006,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			return BotGetItemLongTermGoal(bs, tfl, goal);
 		}
 	}
-	else if (gametype == GT_OBELISK) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
 		if (bs->ltgtype == LTG_ATTACKENEMYBASE &&
 				bs->attackaway_time < FloatTime()) {
 
@@ -1044,7 +1044,7 @@ int BotGetLongTermGoal(bot_state_t *bs, int tfl, int retreat, bot_goal_t *goal) 
 			return qtrue;
 		}
 	}
-	else if (gametype == GT_HARVESTER) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
 		//if rushing to the base
 		if (bs->ltgtype == LTG_RUSHBASE) {
 			switch(BotTeam(bs)) {
@@ -1962,17 +1962,17 @@ int AINode_Seek_LTG(bot_state_t *bs)
 		else range = 150;
 		//
 #ifdef CTF
-		if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+		if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 			//if carrying a flag the bot shouldn't be distracted too much
 			if (BotCTFCarryingFlag(bs))
 				range = 50;
 		}
 #endif //CTF
-		else if (G_UsesTheWhiteFlag(gametype)) {
+		else if (G_UsesTheWhiteFlag(gametype,subgametype)) {
 			if (Bot1FCTFCarryingFlag(bs))
 				range = 50;
 		}
-		else if (gametype == GT_HARVESTER) {
+		else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
 			if (BotHarvesterCarryingCubes(bs))
 				range = 80;
 		}
@@ -2482,17 +2482,17 @@ int AINode_Battle_Retreat(bot_state_t *bs) {
 		bs->check_time = FloatTime() + 1;
 		range = 150;
 #ifdef CTF
-		if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+		if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 			//if carrying a flag the bot shouldn't be distracted too much
 			if (BotCTFCarryingFlag(bs))
 				range = 50;
 		}
 #endif //CTF
-		else if (G_UsesTheWhiteFlag(gametype)) {
+		else if (G_UsesTheWhiteFlag(gametype,subgametype)) {
 			if (Bot1FCTFCarryingFlag(bs))
 				range = 50;
 		}
-		else if (gametype == GT_HARVESTER) {
+		else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
 			if (BotHarvesterCarryingCubes(bs))
 				range = 80;
 		}

--- a/code/game/ai_dmq3.c
+++ b/code/game/ai_dmq3.c
@@ -340,7 +340,7 @@ EntityCarriesCubes
 qboolean EntityCarriesCubes(aas_entityinfo_t *entinfo) {
 	entityState_t state;
 
-	if (!G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER))
+	if (!G_IsGametype(gametype,subgametype,GT_HARVESTER))
 		return qfalse;
 	//FIXME: get this info from the aas_entityinfo_t ?
 	BotAI_GetEntityState(entinfo->number, &state);
@@ -367,7 +367,7 @@ BotHarvesterCarryingCubes
 ==================
  */
 int BotHarvesterCarryingCubes(bot_state_t *bs) {
-	if (!G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) return qfalse;
+	if (!G_IsGametype(gametype,subgametype,GT_HARVESTER)) return qfalse;
 
 	if (bs->inventory[INVENTORY_REDCUBE] > 0) return qtrue;
 	if (bs->inventory[INVENTORY_BLUECUBE] > 0) return qtrue;
@@ -407,7 +407,7 @@ void BotSetTeamStatus(bot_state_t *bs) {
 		case LTG_TEAMACCOMPANY:
 			BotEntityInfo(bs->teammate, &entinfo);
 			if ((G_UsesTeamFlags(gametype,subgametype) && EntityCarriesFlag(&entinfo)) ||
-				(G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER) && EntityCarriesCubes(&entinfo))) {
+				(G_IsGametype(gametype,subgametype,GT_HARVESTER) && EntityCarriesCubes(&entinfo))) {
 				teamtask = TEAMTASK_ESCORT;
 			} else {
 				teamtask = TEAMTASK_FOLLOW;
@@ -1434,9 +1434,9 @@ void BotTeamGoals(bot_state_t *bs, int retreat) {
 			BotCTFRetreatGoals(bs);
 		} else if (G_UsesTheWhiteFlag(gametype,subgametype)) {
 			Bot1FCTFRetreatGoals(bs);
-		} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+		} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 			BotObeliskRetreatGoals(bs);
-		} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+		} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 			BotHarvesterRetreatGoals(bs);
 		}
 	} else {
@@ -1445,17 +1445,17 @@ void BotTeamGoals(bot_state_t *bs, int retreat) {
 			BotCTFSeekGoals(bs);
 		} else if (G_UsesTheWhiteFlag(gametype,subgametype)) {
 			Bot1FCTFSeekGoals(bs);
-		} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+		} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 			BotObeliskSeekGoals(bs);
-		} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+		} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 			BotHarvesterSeekGoals(bs);
 		}
 	}
 
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_DOUBLE_D)) //Don't care about retreat
+	if (G_IsGametype(gametype,subgametype,GT_DOUBLE_D)) //Don't care about retreat
 		BotDDSeekGoals(bs);
 
-	//if(G_SingleGametypeCheck(gametype,subgametype,GT_DOMINATION)) //Don't care about retreat
+	//if(G_IsGametype(gametype,subgametype,GT_DOMINATION)) //Don't care about retreat
 	//	BotDomSeekGoals(bs);
 
 	// reset the order time which is used to see if
@@ -1632,10 +1632,10 @@ int BotSynonymContext(bot_state_t *bs) {
 	if (G_UsesTeamFlags(gametype,subgametype)) {
 		if (BotTeam(bs) == TEAM_RED) context |= CONTEXT_CTFREDTEAM;
 		else context |= CONTEXT_CTFBLUETEAM;
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		if (BotTeam(bs) == TEAM_RED) context |= CONTEXT_OBELISKREDTEAM;
 		else context |= CONTEXT_OBELISKBLUETEAM;
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		if (BotTeam(bs) == TEAM_RED) context |= CONTEXT_HARVESTERREDTEAM;
 		else context |= CONTEXT_HARVESTERBLUETEAM;
 	}
@@ -1712,7 +1712,7 @@ BotCheckItemPickup
 void BotCheckItemPickup(bot_state_t *bs, int *oldinventory) {
 	int offence, leader;
 
-	if (!(G_IsATeamGametype(gametype,subgametype) && !(G_SingleGametypeCheck(gametype,subgametype,GT_TEAM))))
+	if (!(G_IsATeamGametype(gametype,subgametype) && !(G_IsGametype(gametype,subgametype,GT_TEAM))))
 		return;
 
 	offence = -1;
@@ -1756,7 +1756,7 @@ void BotCheckItemPickup(bot_state_t *bs, int *oldinventory) {
 							((!(G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype))) ||
 							((bs->redflagstatus == 0) &&
 							(bs->blueflagstatus == 0))) &&
-							((!G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) ||
+							((!G_IsGametype(gametype,subgametype,GT_1FCTF)) ||
 							(bs->neutralflagstatus == 0))) {
 						// tell the leader we want to be on offence
 						BotVoiceChat(bs, leader, VOICECHAT_WANTONOFFENSE);
@@ -1780,7 +1780,7 @@ void BotCheckItemPickup(bot_state_t *bs, int *oldinventory) {
 						((!(G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype))) ||
 						((bs->redflagstatus == 0) &&
 						(bs->blueflagstatus == 0))) &&
-						((!G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) ||
+						((!G_IsGametype(gametype,subgametype,GT_1FCTF)) ||
 						(bs->neutralflagstatus == 0))) {
 
 					// tell the leader we want to be on defense
@@ -1923,7 +1923,7 @@ void BotUseKamikaze(bot_state_t *bs) {
 				return;
 			}
 		}
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		//never use kamikaze if the team flag carrier is visible
 		if (Bot1FCTFCarryingFlag(bs))
 			return;
@@ -1943,7 +1943,7 @@ void BotUseKamikaze(bot_state_t *bs) {
 				return;
 			}
 		}
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		switch (BotTeam(bs)) {
 			case TEAM_RED: goal = &blueobelisk;
 				break;
@@ -1961,7 +1961,7 @@ void BotUseKamikaze(bot_state_t *bs) {
 				return;
 			}
 		}
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		//
 		if (BotHarvesterCarryingCubes(bs))
 			return;
@@ -2034,7 +2034,7 @@ void BotUseInvulnerability(bot_state_t *bs) {
 				return;
 			}
 		}
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		//never use kamikaze if the team flag carrier is visible
 		if (Bot1FCTFCarryingFlag(bs))
 			return;
@@ -2059,7 +2059,7 @@ void BotUseInvulnerability(bot_state_t *bs) {
 				return;
 			}
 		}
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		switch (BotTeam(bs)) {
 			case TEAM_RED: goal = &blueobelisk;
 				break;
@@ -2077,7 +2077,7 @@ void BotUseInvulnerability(bot_state_t *bs) {
 				return;
 			}
 		}
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		//
 		if (BotHarvesterCarryingCubes(bs))
 			return;
@@ -2343,7 +2343,7 @@ int BotWantsToRetreat(bot_state_t *bs) {
 		//if carrying the flag then always retreat
 		if (Bot1FCTFCarryingFlag(bs))
 			return qtrue;
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		//the bots should be dedicated to attacking the enemy obelisk
 		if (bs->ltgtype == LTG_ATTACKENEMYBASE) {
 			if (bs->enemy != redobelisk.entitynum &&
@@ -2355,7 +2355,7 @@ int BotWantsToRetreat(bot_state_t *bs) {
 			return qtrue;
 		}
 		return qfalse;
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		//if carrying cubes then always retreat
 		if (BotHarvesterCarryingCubes(bs)) return qtrue;
 	}
@@ -2395,7 +2395,7 @@ int BotWantsToChase(bot_state_t *bs) {
 		BotEntityInfo(bs->enemy, &entinfo);
 		if (EntityCarriesFlag(&entinfo))
 			return qtrue;
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		//never chase if carrying the flag
 		if (Bot1FCTFCarryingFlag(bs))
 			return qfalse;
@@ -2403,7 +2403,7 @@ int BotWantsToChase(bot_state_t *bs) {
 		BotEntityInfo(bs->enemy, &entinfo);
 		if (EntityCarriesFlag(&entinfo))
 			return qtrue;
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		//the bots should be dedicated to attacking the enemy obelisk
 		if (bs->ltgtype == LTG_ATTACKENEMYBASE) {
 			if (bs->enemy != redobelisk.entitynum &&
@@ -2411,14 +2411,14 @@ int BotWantsToChase(bot_state_t *bs) {
 				return qfalse;
 			}
 		}
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		//never chase if carrying cubes
 		if (BotHarvesterCarryingCubes(bs)) return qfalse;
 
 		BotEntityInfo(bs->enemy, &entinfo);
 		// always chase if the enemy is carrying cubes
 		if (EntityCarriesCubes(&entinfo)) return qtrue;
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_POSSESSION)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_POSSESSION)) {
 		//always chase if the enemy is carrying a flag
 		BotEntityInfo(bs->enemy, &entinfo);
 		if (EntityCarriesFlag(&entinfo))
@@ -3012,7 +3012,7 @@ int BotFindEnemy(bot_state_t *bs, int curenemy) {
 	} else {
 		cursquaredist = 0;
 	}
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		vec3_t target;
 		bot_goal_t *goal;
 		bsp_trace_t trace;
@@ -4916,7 +4916,7 @@ void BotCheckEvents(bot_state_t *bs, entityState_t *state) {
 						bs->flagstatuschanged = qtrue;
 						break; //see BotMatch_CTF
 				}
-			} else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+			} else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 				switch (state->eventParm) {
 					case GTS_RED_CAPTURE:
 						bs->neutralflagstatus = 0;
@@ -5161,7 +5161,7 @@ void BotSetupAlternativeRouteGoals(void) {
 					ALTROUTEGOAL_CLUSTERPORTALS |
 					ALTROUTEGOAL_VIEWPORTALS);
 		}
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		if (trap_BotGetLevelItemGoal(-1, "Neutral Obelisk", &neutralobelisk) < 0)
 			BotAI_Print(PRT_WARNING, "One Flag CTF without Neutral Obelisk\n");
 		red_numaltroutegoals = trap_AAS_AlternativeRouteGoals(
@@ -5176,7 +5176,7 @@ void BotSetupAlternativeRouteGoals(void) {
 				blue_altroutegoals, MAX_ALTROUTEGOALS,
 				ALTROUTEGOAL_CLUSTERPORTALS |
 				ALTROUTEGOAL_VIEWPORTALS);
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		if (trap_BotGetLevelItemGoal(-1, "Neutral Obelisk", &neutralobelisk) < 0)
 			BotAI_Print(PRT_WARNING, "Obelisk without neutral obelisk\n");
 		//
@@ -5192,7 +5192,7 @@ void BotSetupAlternativeRouteGoals(void) {
 				blue_altroutegoals, MAX_ALTROUTEGOALS,
 				ALTROUTEGOAL_CLUSTERPORTALS |
 				ALTROUTEGOAL_VIEWPORTALS);
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		if (untrap_BotGetLevelItemGoal(-1, "Neutral Obelisk", &neutralobelisk) < 0)
 			BotAI_Print(PRT_WARNING, "Harvester without neutral obelisk\n");
 		//
@@ -5443,12 +5443,12 @@ void BotSetupDeathmatchAI(void) {
 			BotAI_Print(PRT_WARNING, "CTF without Red Flag\n");
 		if (untrap_BotGetLevelItemGoal(-1, "Blue Flag", &ctf_blueflag) < 0)
 			BotAI_Print(PRT_WARNING, "CTF without Blue Flag\n");
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_DOUBLE_D)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_DOUBLE_D)) {
 		if (untrap_BotGetLevelItemGoal(-1, "Red Flag", &ctf_redflag) < 0)
 			BotAI_Print(PRT_WARNING, "DD without Point A\n");
 		if (untrap_BotGetLevelItemGoal(-1, "Blue Flag", &ctf_blueflag) < 0)
 			BotAI_Print(PRT_WARNING, "DD without Point B\n");
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_DOMINATION)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_DOMINATION)) {
 		ent = untrap_BotGetLevelItemGoal(-1, "Domination point", &dom_points_bot[0]);
 		if (ent < 0)
 			BotAI_Print(PRT_WARNING, "Domination without a single domination point\n");
@@ -5463,21 +5463,21 @@ void BotSetupDeathmatchAI(void) {
 				BotSetEntityNumForGoal(&dom_points_bot[0], va("domination_point%i", i));
 		}
 		//MAX_DOMINATION_POINTS
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		if (untrap_BotGetLevelItemGoal(-1, "Neutral Flag", &ctf_neutralflag) < 0)
 			BotAI_Print(PRT_WARNING, "One Flag CTF without Neutral Flag\n");
 		if (untrap_BotGetLevelItemGoal(-1, "Red Flag", &ctf_redflag) < 0)
 			BotAI_Print(PRT_WARNING, "CTF without Red Flag\n");
 		if (untrap_BotGetLevelItemGoal(-1, "Blue Flag", &ctf_blueflag) < 0)
 			BotAI_Print(PRT_WARNING, "CTF without Blue Flag\n");
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		if (untrap_BotGetLevelItemGoal(-1, "Red Obelisk", &redobelisk) < 0)
 			BotAI_Print(PRT_WARNING, "Overload without red obelisk\n");
 		BotSetEntityNumForGoalWithActivator(&redobelisk, "team_redobelisk");
 		if (untrap_BotGetLevelItemGoal(-1, "Blue Obelisk", &blueobelisk) < 0)
 			BotAI_Print(PRT_WARNING, "Overload without blue obelisk\n");
 		BotSetEntityNumForGoalWithActivator(&blueobelisk, "team_blueobelisk");
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		if (untrap_BotGetLevelItemGoal(-1, "Red Obelisk", &redobelisk) < 0)
 			BotAI_Print(PRT_WARNING, "Harvester without red obelisk\n");
 		BotSetEntityNumForGoalWithActivator(&redobelisk, "team_redobelisk");
@@ -5487,7 +5487,7 @@ void BotSetupDeathmatchAI(void) {
 		if (untrap_BotGetLevelItemGoal(-1, "Neutral Obelisk", &neutralobelisk) < 0)
 			BotAI_Print(PRT_WARNING, "Harvester without neutral obelisk\n");
 		BotSetEntityNumForGoalWithActivator(&neutralobelisk, "team_neutralobelisk");
-	} else if (G_SingleGametypeCheck(gametype,subgametype,GT_POSSESSION)) {
+	} else if (G_IsGametype(gametype,subgametype,GT_POSSESSION)) {
 		if (untrap_BotGetLevelItemGoal(-1, "Neutral Flag", &ctf_neutralflag) < 0)
 			BotAI_Print(PRT_WARNING, "Possession without Neutral Flag\n");
 	}

--- a/code/game/ai_dmq3.h
+++ b/code/game/ai_dmq3.h
@@ -181,6 +181,7 @@ void BotMapScripts(bot_state_t *bs);
 #define CTF_SKIN_BLUETEAM	"blue"
 
 extern int gametype;		//game type
+extern int subgametype;		//sub game type for SP
 extern int maxclients;		//maximum number of clients
 
 extern vmCvar_t bot_grapple;

--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -188,7 +188,7 @@ int BotAI_GetEntityState( int entityNum, entityState_t *state ) {
 	memset( state, 0, sizeof(entityState_t) );
 	if (!ent->inuse) return qfalse;
 	if (!ent->r.linked) return qfalse;
-	if ( !(G_IsARoundBasedGametype(g_gametype.integer) ||g_instantgib.integer || g_rockets.integer || g_elimination_allgametypes.integer)
+	if ( !(G_IsARoundBasedGametype(gametype,subgametype) ||g_instantgib.integer || g_rockets.integer || g_elimination_allgametypes.integer)
 	       && (ent->r.svFlags & SVF_NOCLIENT) ) {
 		return qfalse;
 	}
@@ -292,19 +292,19 @@ void BotReportStatus(bot_state_t *bs) {
 	}
 
 	strcpy(flagstatus, "  ");
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		if (BotCTFCarryingFlag(bs)) {
 			if (BotTeam(bs) == TEAM_RED) strcpy(flagstatus, S_COLOR_RED"F ");
 			else strcpy(flagstatus, S_COLOR_BLUE"F ");
 		}
 	}
-	else if (gametype == GT_1FCTF) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
 		if (Bot1FCTFCarryingFlag(bs)) {
 			if (BotTeam(bs) == TEAM_RED) strcpy(flagstatus, S_COLOR_RED"F ");
 			else strcpy(flagstatus, S_COLOR_BLUE"F ");
 		}
 	}
-	else if (gametype == GT_HARVESTER) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
 		if (BotHarvesterCarryingCubes(bs)) {
 			if (BotTeam(bs) == TEAM_RED) Com_sprintf(flagstatus, sizeof(flagstatus), S_COLOR_RED"%2d", bs->inventory[INVENTORY_REDCUBE]);
 			else Com_sprintf(flagstatus, sizeof(flagstatus), S_COLOR_BLUE"%2d", bs->inventory[INVENTORY_BLUECUBE]);
@@ -454,17 +454,17 @@ void BotSetInfoConfigString(bot_state_t *bs) {
 	}
 
 	strcpy(carrying, "  ");
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		if (BotCTFCarryingFlag(bs)) {
 			strcpy(carrying, "F ");
 		}
 	}
-	else if (G_UsesTheWhiteFlag(gametype)) {
+	else if (G_UsesTheWhiteFlag(gametype,subgametype)) {
 		if (Bot1FCTFCarryingFlag(bs)) {
 			strcpy(carrying, "F ");
 		}
 	}
-	else if (gametype == GT_HARVESTER) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
 		if (BotHarvesterCarryingCubes(bs)) {
 			if (BotTeam(bs) == TEAM_RED) Com_sprintf(carrying, sizeof(carrying), "%2d", bs->inventory[INVENTORY_REDCUBE]);
 			else Com_sprintf(carrying, sizeof(carrying), "%2d", bs->inventory[INVENTORY_BLUECUBE]);
@@ -682,7 +682,7 @@ void BotInterbreeding(void) {
 	trap_Cvar_Update(&bot_interbreedchar);
 	if (!strlen(bot_interbreedchar.string)) return;
 	//make sure we are in tournament mode
-	if (gametype != GT_TOURNAMENT) {
+	if (!G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) {
 		trap_Cvar_Set("g_gametype", va("%d", GT_TOURNAMENT));
 		ExitLevel();
 		return;
@@ -1526,7 +1526,7 @@ int BotAIStartFrame(int time) {
 				trap_BotLibUpdateEntity(i, NULL);
 				continue;
 			}
-			if ( !(G_IsARoundBasedGametype(g_gametype.integer) ||g_instantgib.integer || g_rockets.integer || g_elimination_allgametypes.integer)
+			if ( !(G_IsARoundBasedGametype(gametype,subgametype) ||g_instantgib.integer || g_rockets.integer || g_elimination_allgametypes.integer)
 				   && ent->r.svFlags & SVF_NOCLIENT) {
 				trap_BotLibUpdateEntity(i, NULL);
 				continue;
@@ -1647,6 +1647,10 @@ int BotInitLibrary(void) {
 	trap_Cvar_VariableStringBuffer("g_gametype", buf, sizeof(buf));
 	if (!strlen(buf)) strcpy(buf, "0");
 	trap_BotLibVarSet("g_gametype", buf);
+	//sub game type
+	trap_Cvar_VariableStringBuffer("g_subgametype", buf, sizeof(buf));
+	if (!strlen(buf)) strcpy(buf, "0");
+	trap_BotLibVarSet("g_subgametype", buf);
 	//bot developer mode and log file
 	trap_BotLibVarSet("bot_developer", bot_developer.string);
 	trap_Cvar_VariableStringBuffer("logfile", buf, sizeof(buf));

--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -298,13 +298,13 @@ void BotReportStatus(bot_state_t *bs) {
 			else strcpy(flagstatus, S_COLOR_BLUE"F ");
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		if (Bot1FCTFCarryingFlag(bs)) {
 			if (BotTeam(bs) == TEAM_RED) strcpy(flagstatus, S_COLOR_RED"F ");
 			else strcpy(flagstatus, S_COLOR_BLUE"F ");
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		if (BotHarvesterCarryingCubes(bs)) {
 			if (BotTeam(bs) == TEAM_RED) Com_sprintf(flagstatus, sizeof(flagstatus), S_COLOR_RED"%2d", bs->inventory[INVENTORY_REDCUBE]);
 			else Com_sprintf(flagstatus, sizeof(flagstatus), S_COLOR_BLUE"%2d", bs->inventory[INVENTORY_BLUECUBE]);
@@ -464,7 +464,7 @@ void BotSetInfoConfigString(bot_state_t *bs) {
 			strcpy(carrying, "F ");
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		if (BotHarvesterCarryingCubes(bs)) {
 			if (BotTeam(bs) == TEAM_RED) Com_sprintf(carrying, sizeof(carrying), "%2d", bs->inventory[INVENTORY_REDCUBE]);
 			else Com_sprintf(carrying, sizeof(carrying), "%2d", bs->inventory[INVENTORY_BLUECUBE]);
@@ -682,7 +682,7 @@ void BotInterbreeding(void) {
 	trap_Cvar_Update(&bot_interbreedchar);
 	if (!strlen(bot_interbreedchar.string)) return;
 	//make sure we are in tournament mode
-	if (!G_SingleGametypeCheck(gametype,subgametype,GT_TOURNAMENT)) {
+	if (!G_IsGametype(gametype,subgametype,GT_TOURNAMENT)) {
 		trap_Cvar_Set("g_gametype", va("%d", GT_TOURNAMENT));
 		ExitLevel();
 		return;

--- a/code/game/ai_team.c
+++ b/code/game/ai_team.c
@@ -2197,7 +2197,7 @@ void BotTeamAI(bot_state_t *bs) {
 	//
 	numteammates = BotNumTeamMates(bs);
 	//give orders
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_TEAM)) {
+	if (G_IsGametype(gametype,subgametype,GT_TEAM)) {
 		if (bs->numteammates != numteammates || bs->forceorders) {
 			bs->teamgiveorders_time = FloatTime();
 			bs->numteammates = numteammates;
@@ -2210,8 +2210,8 @@ void BotTeamAI(bot_state_t *bs) {
 			bs->teamgiveorders_time = FloatTime() + 120;
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_CTF) ||
-			G_SingleGametypeCheck(gametype,subgametype,GT_CTF_ELIMINATION)) {
+	else if (G_IsGametype(gametype,subgametype,GT_CTF) ||
+			G_IsGametype(gametype,subgametype,GT_CTF_ELIMINATION)) {
 		//if the number of team mates changed or the flag status changed
 		//or someone wants to know what to do
 		if (bs->numteammates != numteammates || bs->flagstatuschanged || bs->forceorders || lastRoundNumber != level.roundNumber) {
@@ -2237,7 +2237,7 @@ void BotTeamAI(bot_state_t *bs) {
 			bs->teamgiveorders_time = 0;
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_DOUBLE_D)) {
+	else if (G_IsGametype(gametype,subgametype,GT_DOUBLE_D)) {
 		//if the number of team mates changed or the domination point status changed
 		//or someone wants to know what to do
 		if (bs->numteammates != numteammates || bs->flagstatuschanged || bs->forceorders) {
@@ -2253,7 +2253,7 @@ void BotTeamAI(bot_state_t *bs) {
 			bs->teamgiveorders_time = 0;
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		if (bs->numteammates != numteammates || bs->flagstatuschanged || bs->forceorders) {
 			bs->teamgiveorders_time = FloatTime();
 			bs->numteammates = numteammates;
@@ -2276,7 +2276,7 @@ void BotTeamAI(bot_state_t *bs) {
 			bs->teamgiveorders_time = 0;
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	else if (G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		if (bs->numteammates != numteammates || bs->forceorders) {
 			bs->teamgiveorders_time = FloatTime();
 			bs->numteammates = numteammates;
@@ -2289,7 +2289,7 @@ void BotTeamAI(bot_state_t *bs) {
 			bs->teamgiveorders_time = FloatTime() + 30;
 		}
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	else if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		if (bs->numteammates != numteammates || bs->forceorders) {
 			bs->teamgiveorders_time = FloatTime();
 			bs->numteammates = numteammates;

--- a/code/game/ai_vcmd.c
+++ b/code/game/ai_vcmd.c
@@ -71,11 +71,11 @@ BotVoiceChat_GetFlag
 */
 void BotVoiceChat_GetFlag(bot_state_t *bs, int client, int mode) {
 	//
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		if (!ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
-	else if (gametype == GT_1FCTF) {
+	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
 		if (!ctf_neutralflag.areanum || !ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
@@ -93,7 +93,7 @@ void BotVoiceChat_GetFlag(bot_state_t *bs, int client, int mode) {
 	//set the team goal time
 	bs->teamgoal_time = FloatTime() + CTF_GETFLAG_TIME;
 	// get an alternate route in ctf
-	if (G_UsesTeamFlags(gametype) && !G_UsesTheWhiteFlag(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype) && !G_UsesTheWhiteFlag(gametype,subgametype)) {
 		//get an alternative route goal towards the enemy base
 		BotGetAlternateRouteGoal(bs, BotOppositeTeam(bs));
 	}
@@ -112,11 +112,11 @@ BotVoiceChat_Offense
 ==================
 */
 void BotVoiceChat_Offense(bot_state_t *bs, int client, int mode) {
-	if (G_UsesTeamFlags(gametype)) {
+	if (G_UsesTeamFlags(gametype,subgametype)) {
 		BotVoiceChat_GetFlag(bs, client, mode);
 		return;
 	}
-	if (gametype == GT_HARVESTER) {
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
 		//
 		bs->decisionmaker = client;
 		bs->ordered = qtrue;
@@ -162,7 +162,8 @@ BotVoiceChat_Defend
 ==================
 */
 void BotVoiceChat_Defend(bot_state_t *bs, int client, int mode) {
-	if (gametype == GT_HARVESTER || gametype == GT_OBELISK) {
+	if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER) ||
+			G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
 		//
 		switch(BotTeam(bs)) {
 			case TEAM_RED: memcpy(&bs->teamgoal, &redobelisk, sizeof(bot_goal_t)); break;
@@ -171,7 +172,7 @@ void BotVoiceChat_Defend(bot_state_t *bs, int client, int mode) {
 		}
 	}
 	else
-		if (G_UsesTeamFlags(gametype)) {
+		if (G_UsesTeamFlags(gametype,subgametype)) {
                     //
                     switch(BotTeam(bs)) {
 			case TEAM_RED: memcpy(&bs->teamgoal, &ctf_redflag, sizeof(bot_goal_t)); break;
@@ -368,7 +369,7 @@ BotVoiceChat_ReturnFlag
 */
 void BotVoiceChat_ReturnFlag(bot_state_t *bs, int client, int mode) {
 	//if not in CTF mode
-	if (!G_UsesTeamFlags(gametype)) {
+	if (!G_UsesTeamFlags(gametype,subgametype)) {
 		return;
 	}
 	//
@@ -419,7 +420,7 @@ BotVoiceChat_WhoIsLeader
 void BotVoiceChat_WhoIsLeader(bot_state_t *bs, int client, int mode) {
 	char netname[MAX_MESSAGE_SIZE];
 
-	if (!G_IsATeamGametype(gametype)) return;
+	if (!G_IsATeamGametype(gametype,subgametype)) return;
 
 	ClientName(bs->client, netname, sizeof(netname));
 	//if this bot IS the team leader
@@ -497,7 +498,7 @@ int BotVoiceChatCommand(bot_state_t *bs, int mode, char *voiceChat) {
 	int i, clientNum;
 	char *ptr, buf[MAX_MESSAGE_SIZE], *cmd;
 
-	if (!G_IsATeamGametype(gametype)) {
+	if (!G_IsATeamGametype(gametype,subgametype)) {
 		return qfalse;
 	}
 

--- a/code/game/ai_vcmd.c
+++ b/code/game/ai_vcmd.c
@@ -75,7 +75,7 @@ void BotVoiceChat_GetFlag(bot_state_t *bs, int client, int mode) {
 		if (!ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
-	else if (G_SingleGametypeCheck(gametype,subgametype,GT_1FCTF)) {
+	else if (G_IsGametype(gametype,subgametype,GT_1FCTF)) {
 		if (!ctf_neutralflag.areanum || !ctf_redflag.areanum || !ctf_blueflag.areanum)
 			return;
 	}
@@ -116,7 +116,7 @@ void BotVoiceChat_Offense(bot_state_t *bs, int client, int mode) {
 		BotVoiceChat_GetFlag(bs, client, mode);
 		return;
 	}
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER)) {
+	if (G_IsGametype(gametype,subgametype,GT_HARVESTER)) {
 		//
 		bs->decisionmaker = client;
 		bs->ordered = qtrue;
@@ -162,8 +162,8 @@ BotVoiceChat_Defend
 ==================
 */
 void BotVoiceChat_Defend(bot_state_t *bs, int client, int mode) {
-	if (G_SingleGametypeCheck(gametype,subgametype,GT_HARVESTER) ||
-			G_SingleGametypeCheck(gametype,subgametype,GT_OBELISK)) {
+	if (G_IsGametype(gametype,subgametype,GT_HARVESTER) ||
+			G_IsGametype(gametype,subgametype,GT_OBELISK)) {
 		//
 		switch(BotTeam(bs)) {
 			case TEAM_RED: memcpy(&bs->teamgoal, &redobelisk, sizeof(bot_goal_t)); break;

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -320,7 +320,8 @@ void SpectatorThink( gentity_t *ent, usercmd_t *ucmd ) {
 
 	client = ent->client;
 
-	if ( G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer) &&
+	if ( G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
+			G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) &&
 			client->sess.spectatorState != SPECTATOR_FOLLOW &&
 			g_elimination_lockspectator.integer>1 &&
 			ent->client->sess.sessionTeam != TEAM_SPECTATOR ) {
@@ -367,9 +368,10 @@ void SpectatorThink( gentity_t *ent, usercmd_t *ucmd ) {
 	}
 
 	if ( ( client->buttons & BUTTON_USE_HOLDABLE ) && ! ( client->oldbuttons & BUTTON_USE_HOLDABLE ) ) {
-		if ( G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer) &&
-			g_elimination_lockspectator.integer>1 &&
-			ent->client->sess.sessionTeam != TEAM_SPECTATOR ) {
+		if ( G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
+				G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) &&
+				g_elimination_lockspectator.integer>1 &&
+				ent->client->sess.sessionTeam != TEAM_SPECTATOR ) {
 			return;
 		}
 		StopFollowing(ent);
@@ -461,13 +463,16 @@ static void ClientTimerActions( gentity_t *ent, int msec ) {
 			if ( ent->health > client->ps.stats[STAT_MAX_HEALTH] ) {
 				ent->health--;
 			}
-			if ( G_IsARoundBasedGametype(g_gametype.integer) && level.humansEliminated ) {
+			if ( G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && level.humansEliminated ) {
 				ent->damage=5;
 				G_Damage (ent, NULL, NULL, NULL, NULL, ent->damage, DAMAGE_NO_KNOCKBACK, MOD_UNKNOWN);
 			}
 			//Start killing players in LMS, if we are in overtime
-			else if (g_elimination_roundtime.integer&&g_gametype.integer==GT_LMS && TeamHealthCount( -1, TEAM_FREE ) != ent->health &&
-			         (level.roundNumber==level.roundNumberStarted)&&(level.time>=level.roundStartTime+1000*g_elimination_roundtime.integer)) {
+			else if (g_elimination_roundtime.integer &&
+					G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS) &&
+					TeamHealthCount( -1, TEAM_FREE ) != ent->health &&
+			        (level.roundNumber==level.roundNumberStarted) &&
+					(level.time>=level.roundStartTime+1000*g_elimination_roundtime.integer)) {
 				ent->damage=5;
 				G_Damage (ent, NULL, NULL, NULL, NULL, ent->damage, DAMAGE_NO_ARMOR, MOD_UNKNOWN);
 			}
@@ -484,7 +489,8 @@ static void ClientTimerActions( gentity_t *ent, int msec ) {
 			client->ps.stats[STAT_ARMOR]--;
 		}
 		
-		if (g_gametype.integer == GT_POSSESSION && ent->health > 0 && client->ps.powerups[PW_NEUTRALFLAG] ) {
+		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
+				ent->health > 0 && client->ps.powerups[PW_NEUTRALFLAG] ) {
 			AddScore(ent, ent->client->ps.origin, 1);
 			G_LogPrintf("POS: %i %i: %s^7 scored a point\n", ent->s.number, 1, client->pers.netname);
 		}
@@ -626,7 +632,7 @@ void ClientEvents( gentity_t *ent, int oldEventSequence ) {
 				ent->client->ps.powerups[ j ] = 0;
 			}
 
-			if ( g_gametype.integer == GT_HARVESTER ) {
+			if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 				if ( ent->client->ps.generic1 > 0 ) {
 					if ( ent->client->sess.sessionTeam == TEAM_RED ) {
 						item = BG_FindItem( "Blue Cube" );
@@ -1139,7 +1145,7 @@ void ClientThink_real( gentity_t *ent ) {
 		if ( ( level.time > client->respawnTime ) &&
 			( ( ( g_forcerespawn.integer > 0 ) && 
 			( level.time - client->respawnTime  > g_forcerespawn.integer * 1000 ) ) ||
-			( G_IsARoundBasedGametype(g_gametype.integer) &&
+			( G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
 			( level.time - client->respawnTime > 0 ) ) ||	
 			( ucmd->buttons & ( BUTTON_ATTACK | BUTTON_USE_HOLDABLE ) ) ) ) {
 

--- a/code/game/g_active.c
+++ b/code/game/g_active.c
@@ -469,7 +469,7 @@ static void ClientTimerActions( gentity_t *ent, int msec ) {
 			}
 			//Start killing players in LMS, if we are in overtime
 			else if (g_elimination_roundtime.integer &&
-					G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS) &&
+					G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS) &&
 					TeamHealthCount( -1, TEAM_FREE ) != ent->health &&
 			        (level.roundNumber==level.roundNumberStarted) &&
 					(level.time>=level.roundStartTime+1000*g_elimination_roundtime.integer)) {
@@ -489,7 +489,7 @@ static void ClientTimerActions( gentity_t *ent, int msec ) {
 			client->ps.stats[STAT_ARMOR]--;
 		}
 		
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
 				ent->health > 0 && client->ps.powerups[PW_NEUTRALFLAG] ) {
 			AddScore(ent, ent->client->ps.origin, 1);
 			G_LogPrintf("POS: %i %i: %s^7 scored a point\n", ent->s.number, 1, client->pers.netname);
@@ -632,7 +632,7 @@ void ClientEvents( gentity_t *ent, int oldEventSequence ) {
 				ent->client->ps.powerups[ j ] = 0;
 			}
 
-			if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+			if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 				if ( ent->client->ps.generic1 > 0 ) {
 					if ( ent->client->sess.sessionTeam == TEAM_RED ) {
 						item = BG_FindItem( "Blue Cube" );

--- a/code/game/g_arenas.c
+++ b/code/game/g_arenas.c
@@ -84,7 +84,7 @@ void UpdateTournamentInfo( void ) {
 		}
 #ifdef MISSIONPACK
 		won = qfalse;
-		if (G_IsATeamGametype(g_gametype.integer)) {
+		if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 			score1 = level.teamScores[TEAM_RED];
 			score2 = level.teamScores[TEAM_BLUE];
 			if (level.clients[playerClientNum].sess.sessionTeam	== TEAM_RED) {

--- a/code/game/g_bot.c
+++ b/code/game/g_bot.c
@@ -459,7 +459,7 @@ void G_CheckMinimumPlayers( void ) {
 			G_RemoveRandomBot( TEAM_BLUE );
 		}
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 		if (minplayers >= g_maxclients.integer) {
 			minplayers = g_maxclients.integer-1;
 		}
@@ -1070,7 +1070,7 @@ void G_InitBots( qboolean restart ) {
 
 		// We can put this safely as the SP check is already in place.
 		if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) &&
-				!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+				!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			strValue = Info_ValueForKey( arenainfo, "capturelimit" );
 			scoreLimit = atoi( strValue );
 			if ( scoreLimit ) {
@@ -1142,7 +1142,7 @@ void G_InitBots( qboolean restart ) {
 	} else {
 		if(bot_autominplayers.integer) {
 			//Set bot_minplayers
-			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
+			if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 				trap_Cvar_Set("bot_minplayers","2"); //Always 2 for Tourney
 			} else {
 				basedelay = MinSpawnpointCount()/2;

--- a/code/game/g_bot.c
+++ b/code/game/g_bot.c
@@ -1060,29 +1060,8 @@ void G_InitBots( qboolean restart ) {
 			g_subgametype.integer = GT_FFA;
 		}
 
-		if (g_subgametype.integer == GT_FFA || g_subgametype.integer == GT_TEAM ||
-				g_subgametype.integer == GT_TOURNAMENT || g_subgametype.integer == GT_LMS ||
-				g_subgametype.integer == GT_POSSESSION) {
-			strValue = Info_ValueForKey( arenainfo, "fraglimit" );
-			scoreLimit = atoi( strValue );
-			if ( scoreLimit ) {
-				trap_Cvar_Set( "fraglimit", strValue );
-			}
-			else {
-				switch (g_subgametype.integer) {
-					case GT_TEAM:
-						trap_Cvar_Set( "fraglimit", "50" );
-						break;
-					case GT_POSSESSION:
-						trap_Cvar_Set( "fraglimit", "150" );
-						break;
-					default:
-						trap_Cvar_Set( "fraglimit", "15" );
-						break;
-				}
-			}
-		}
-		else {
+		// We can put this safely as the SP check is already in place.
+		if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 			strValue = Info_ValueForKey( arenainfo, "capturelimit" );
 			scoreLimit = atoi( strValue );
 			if ( scoreLimit ) {
@@ -1102,6 +1081,26 @@ void G_InitBots( qboolean restart ) {
 						break;
 					default:
 						trap_Cvar_Set( "capturelimit", "8" );
+						break;
+				}
+			}
+		}
+		else {
+			strValue = Info_ValueForKey( arenainfo, "fraglimit" );
+			scoreLimit = atoi( strValue );
+			if ( scoreLimit ) {
+				trap_Cvar_Set( "fraglimit", strValue );
+			}
+			else {
+				switch (g_subgametype.integer) {
+					case GT_TEAM:
+						trap_Cvar_Set( "fraglimit", "50" );
+						break;
+					case GT_POSSESSION:
+						trap_Cvar_Set( "fraglimit", "150" );
+						break;
+					default:
+						trap_Cvar_Set( "fraglimit", "15" );
 						break;
 				}
 			}

--- a/code/game/g_bot.c
+++ b/code/game/g_bot.c
@@ -851,7 +851,7 @@ void Svcmd_BotList_f( void ) {
 G_SpawnBots
 ===============
 */
-static void G_SpawnBots( char *botList, int baseDelay ) {
+static void G_SpawnBots( char *botList, int baseDelay, int team ) {
 	char		*bot;
 	char		*p;
 	int			delay;
@@ -893,7 +893,15 @@ static void G_SpawnBots( char *botList, int baseDelay ) {
 
 		// we must add the bot this way, calling G_AddBot directly at this stage
 		// does "Bad Things"
-		trap_SendConsoleCommand( EXEC_INSERT, va("addbot %s %i free %i\n", bot, g_spSkill.integer, delay) );
+		if (team == TEAM_RED) {
+			trap_SendConsoleCommand( EXEC_INSERT, va("addbot %s %i red %i\n", bot, g_spSkill.integer, delay) );
+		}
+		else if (team == TEAM_BLUE) {
+			trap_SendConsoleCommand( EXEC_INSERT, va("addbot %s %i blue %i\n", bot, g_spSkill.integer, delay) );
+		}
+		else {
+			trap_SendConsoleCommand( EXEC_INSERT, va("addbot %s %i free %i\n", bot, g_spSkill.integer, delay) );
+		}
 
 		delay += BOT_BEGIN_DELAY_INCREMENT;
 	}
@@ -1032,36 +1040,37 @@ void G_InitBots( qboolean restart ) {
 		}
 
 		strValue = Info_ValueForKey( arenainfo, "sptype" );
-		if (strequals(strValue,"TeamDeathmatch")) {
+		if (strequals(strValue,"team")) {
 			g_subgametype.integer = GT_TEAM;
-		} else if (strequals(strValue,"Tournament")) {
+		} else if (strequals(strValue,"tourney")) {
 			g_subgametype.integer = GT_TOURNAMENT;
-		} else if (strequals(strValue,"CaptureTheFlag")) {
+		} else if (strequals(strValue,"ctf")) {
 			g_subgametype.integer = GT_CTF;
-		} else if (strequals(strValue,"OneFlagCTF")) {
+		} else if (strequals(strValue,"1fctf")) {
 			g_subgametype.integer = GT_1FCTF;
-		} else if (strequals(strValue,"Overload")) {
+		} else if (strequals(strValue,"obelisk")) {
 			g_subgametype.integer = GT_OBELISK;
-		} else if (strequals(strValue,"Harvester")) {
+		} else if (strequals(strValue,"harvester")) {
 			g_subgametype.integer = GT_HARVESTER;
-		} else if (strequals(strValue,"Elimination")) {
+		} else if (strequals(strValue,"elimination")) {
 			g_subgametype.integer = GT_ELIMINATION;
-		} else if (strequals(strValue,"CTFElimination")) {
+		} else if (strequals(strValue,"ctfelim")) {
 			g_subgametype.integer = GT_CTF_ELIMINATION;
-		} else if (strequals(strValue,"LastManStanding")) {
+		} else if (strequals(strValue,"lms")) {
 			g_subgametype.integer = GT_LMS;
-		} else if (strequals(strValue,"DoubleDomination")) {
+		} else if (strequals(strValue,"dd")) {
 			g_subgametype.integer = GT_DOUBLE_D;
-		} else if (strequals(strValue,"Domination")) {
+		} else if (strequals(strValue,"dom")) {
 			g_subgametype.integer = GT_DOMINATION;
-		} else if (strequals(strValue,"Possession")) {
+		} else if (strequals(strValue,"pos")) {
 			g_subgametype.integer = GT_POSSESSION;
 		} else {
 			g_subgametype.integer = GT_FFA;
 		}
 
 		// We can put this safely as the SP check is already in place.
-		if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
+		if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) &&
+				!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			strValue = Info_ValueForKey( arenainfo, "capturelimit" );
 			scoreLimit = atoi( strValue );
 			if ( scoreLimit ) {
@@ -1122,7 +1131,13 @@ void G_InitBots( qboolean restart ) {
 		}
 
 		if( !restart ) {
-			G_SpawnBots( Info_ValueForKey( arenainfo, "bots" ), basedelay );
+			if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
+				G_SpawnBots( Info_ValueForKey( arenainfo, "redbots" ), basedelay, TEAM_RED );
+				G_SpawnBots( Info_ValueForKey( arenainfo, "bluebots" ), basedelay, TEAM_BLUE );
+			}
+			else {
+				G_SpawnBots( Info_ValueForKey( arenainfo, "bots" ), basedelay, TEAM_FREE );
+			}
 		}
 	} else {
 		if(bot_autominplayers.integer) {

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -446,7 +446,7 @@ respawn
 void ClientRespawn( gentity_t *ent ) {
 	gentity_t	*tent;
 
-	if( !G_IsARoundBasedGametype(g_gametype.integer) && !ent->client->isEliminated)
+	if( !G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && !ent->client->isEliminated)
 	{
 		ent->client->isEliminated = qtrue; //must not be true in warmup
 	} else {
@@ -455,7 +455,7 @@ void ClientRespawn( gentity_t *ent ) {
 	}
 	CopyToBodyQue (ent); //Unlinks ent
 
-	if(g_gametype.integer==GT_LMS) {
+	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 		if(ent->client->pers.livesLeft>0)
 		{
 			ent->client->isEliminated = qfalse;
@@ -478,13 +478,13 @@ void ClientRespawn( gentity_t *ent ) {
 		}
 	}
 
-	if(G_IsARoundBasedGametype(g_gametype.integer) && ent->client->ps.pm_type == PM_SPECTATOR && ent->client->ps.stats[STAT_HEALTH] > 0) {
+	if(G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && ent->client->ps.pm_type == PM_SPECTATOR && ent->client->ps.stats[STAT_HEALTH] > 0) {
 		return;
 	}
 	ClientSpawn(ent);
 
 	// add a teleportation effect
-	if(!G_IsARoundBasedGametype(g_gametype.integer))
+	if(!G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer))
 	{	
 		tent = G_TempEntity( ent->client->ps.origin, EV_PLAYER_TELEPORT_IN );
 		tent->s.clientNum = ent->s.clientNum;
@@ -507,7 +507,7 @@ void respawnRound( gentity_t *ent ) {
 	ClientSpawn(ent);
 
 	// add a teleportation effect
-	if(!G_IsARoundBasedGametype(g_gametype.integer))
+	if(!G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer))
 	{
 		tent = G_TempEntity( ent->client->ps.origin, EV_PLAYER_TELEPORT_IN );
 		tent->s.clientNum = ent->s.clientNum;
@@ -620,7 +620,7 @@ Returns number of living players on a team
 team_t TeamLivingCount( int ignoreClientNum, int team ) {
 	int		i;
 	int		count = 0;
-	qboolean	isLMS = (g_gametype.integer==GT_LMS);
+	qboolean	isLMS = (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS));
 
 	for ( i = 0 ; i < level.maxclients ; i++ ) {
 		if ( i == ignoreClientNum ) {
@@ -645,7 +645,7 @@ team_t TeamLivingCount( int ignoreClientNum, int team ) {
 int TeamLivingHumanCount(int ignoreClientNum) {
 	int i;
 	int count = 0;
-	qboolean	isLMS = (g_gametype.integer==GT_LMS);
+	qboolean	isLMS = (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS));
 
 	for ( i = 0 ; i < level.maxclients ; i++ ) {
 		if ( i == ignoreClientNum ) {
@@ -1168,7 +1168,7 @@ void ClientUserinfoChanged( int clientNum ) {
 	if ( ( ( client->sess.sessionTeam == TEAM_SPECTATOR ) ||
 		( ( ( client->isEliminated ) /*||
 		( client->ps.pm_type == PM_SPECTATOR )*/ ) &&   //Sago: If this is true client.isEliminated or TEAM_SPECTATOR is true to and this is redundant
-		G_IsARoundBasedGametype(g_gametype.integer) ) ) &&
+		G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) ) ) &&
 		( client->sess.spectatorState == SPECTATOR_SCOREBOARD ) ) {
 
 		Q_strncpyz( client->pers.netname, "scoreboard", sizeof(client->pers.netname) );
@@ -1194,7 +1194,7 @@ void ClientUserinfoChanged( int clientNum ) {
 	client->ps.stats[STAT_MAX_HEALTH] = client->pers.maxHealth;
 
 	// set model
-	if(G_IsATeamGametype(g_gametype.integer)) {
+	if(G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		Q_strncpyz( model, Info_ValueForKey (userinfo, "team_model"), sizeof( model ) );
 		Q_strncpyz( headModel, Info_ValueForKey (userinfo, "team_headmodel"), sizeof( headModel ) );
 	} else {
@@ -1202,7 +1202,7 @@ void ClientUserinfoChanged( int clientNum ) {
 		Q_strncpyz( headModel, Info_ValueForKey (userinfo, "headmodel"), sizeof( headModel ) );
 	}
 
-	if (G_IsATeamGametype(g_gametype.integer) && !(ent->r.svFlags & SVF_BOT)) {
+	if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) && !(ent->r.svFlags & SVF_BOT)) {
 		client->pers.teamInfo = qtrue;
 	} else {
 		s = Info_ValueForKey( userinfo, "teamoverlay" );
@@ -1219,7 +1219,7 @@ void ClientUserinfoChanged( int clientNum ) {
 	teamLeader = client->sess.teamLeader;
 
 	// colors
-	if(G_IsATeamGametype(g_gametype.integer) && g_instantgib.integer) {
+	if(G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) && g_instantgib.integer) {
 		switch(client->sess.sessionTeam) {
 			case TEAM_RED:
 				c1[0] = COLOR_BLUE;
@@ -1391,7 +1391,7 @@ char *ClientConnect( int clientNum, qboolean firstTime, qboolean isBot ) {
 		trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " connected\n\"", client->pers.netname) );
 	}
 
-	if (G_IsATeamGametype(g_gametype.integer) && client->sess.sessionTeam != TEAM_SPECTATOR ) {
+	if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) && client->sess.sessionTeam != TEAM_SPECTATOR ) {
 		BroadcastTeamChange( client, -1 );
 	}
 
@@ -1485,7 +1485,7 @@ void ClientBegin( int clientNum ) {
 
 	//Elimination:
 	client->pers.roundReached = 0; //We will spawn in next round
-	if(g_gametype.integer == GT_LMS) {
+	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 		client->isEliminated = qtrue; //So player does not give a point in gamemode 2 and 3
 		//trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " will start dead\n\"", client->pers.netname) );
 	}
@@ -1504,7 +1504,7 @@ void ClientBegin( int clientNum ) {
 	countFree = TeamCount(-1,TEAM_FREE);
 	countRed = TeamCount(-1,TEAM_RED);
 	countBlue = TeamCount(-1,TEAM_BLUE);
-	if(!G_IsATeamGametype(g_gametype.integer))
+	if(!G_IsATeamGametype(g_gametype.integer,g_subgametype.integer))
 	{
 		if(countFree>level.teamSize)
 			level.teamSize=countFree;
@@ -1539,12 +1539,12 @@ void ClientBegin( int clientNum ) {
 	if( ( client->sess.sessionTeam != TEAM_SPECTATOR ) &&
 		( ( !( client->isEliminated ) /*&&
 		( ( !client->ps.pm_type ) == PM_SPECTATOR ) */ ) || //Sago: Yes, it made no sense 
-		( (!G_IsARoundBasedGametype(g_gametype.integer) || level.intermissiontime) ) ) ) {
+		( (!G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) || level.intermissiontime) ) ) ) {
 		// send event
 		tent = G_TempEntity( ent->client->ps.origin, EV_PLAYER_TELEPORT_IN );
 		tent->s.clientNum = ent->s.clientNum;
 
-		if ( g_gametype.integer != GT_TOURNAMENT  ) {
+		if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 			trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " entered the game\n\"", client->pers.netname) );
 		}
 	}
@@ -1554,7 +1554,7 @@ void ClientBegin( int clientNum ) {
 	G_LogPrintf( "ClientBegin: %i\n", clientNum );
 
 	//Send domination point names:
-	if(g_gametype.integer == GT_DOMINATION) {
+	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		DominationPointNamesMessage(ent);
 		DominationPointStatusMessage(ent);
 	}
@@ -1603,8 +1603,11 @@ void ClientSpawn(gentity_t *ent) {
 	//In Elimination the player should not spawn if he have already spawned in the round (but not for spectators)
 	// N_G: You've obviously wanted something ELSE
 	//Sago: Yes, the !level.intermissiontime is currently redundant but it might still be the bast place to make the test, CheckElimination in g_main makes sure the next if will fail and the rest of the things this block does might not affect if in Intermission (I'll just test that)
-	if((((G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer)) || (g_gametype.integer == GT_LMS && client->isEliminated)) && (!level.intermissiontime || level.warmupTime != 0)) && ( client->sess.sessionTeam != TEAM_SPECTATOR))
-	{
+	if((((G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
+			G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) ||
+			(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS) && client->isEliminated)) &&
+			(!level.intermissiontime || level.warmupTime != 0)) &&
+			( client->sess.sessionTeam != TEAM_SPECTATOR)) {
 		// N_G: Another condition that makes no sense to me, see for
 		// yourself if you really meant this
 		// Sago: I beleive the TeamCount is to make sure people can join even if the game can't start
@@ -1615,7 +1618,7 @@ void ClientSpawn(gentity_t *ent) {
 		{	
 			client->sess.spectatorState = SPECTATOR_FREE;
 			client->isEliminated = qtrue;
-			if(g_gametype.integer == GT_LMS) {
+			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 				G_LogPrintf( "LMS: %i %i %i: Player \"%s^7\" eliminated!\n", level.roundNumber, index, 1, client->pers.netname );
 			}
 			client->ps.pm_type = PM_SPECTATOR;
@@ -1638,8 +1641,9 @@ void ClientSpawn(gentity_t *ent) {
 		}
 	}
 
-	if(g_gametype.integer == GT_LMS && client->sess.sessionTeam != TEAM_SPECTATOR && (!level.intermissiontime || level.warmupTime != 0))
-	{
+	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS) &&
+		client->sess.sessionTeam != TEAM_SPECTATOR &&
+		(!level.intermissiontime || level.warmupTime != 0)) {
 		if(level.roundNumber==level.roundNumberStarted /*|| level.time<level.roundStartTime-g_elimination_activewarmup.integer*1000*/ && 1>client->pers.livesLeft)
 		{	
 			client->sess.spectatorState = SPECTATOR_FREE;
@@ -1664,16 +1668,18 @@ void ClientSpawn(gentity_t *ent) {
 	// find a spawn point
 	// do it before setting health back up, so farthest
 	// ranging doesn't count this client
-	if ((client->sess.sessionTeam == TEAM_SPECTATOR)  || ((client->ps.pm_type == PM_SPECTATOR || client->isEliminated )  &&
-		(G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer)))) {
+	if ((client->sess.sessionTeam == TEAM_SPECTATOR) ||
+			((client->ps.pm_type == PM_SPECTATOR || client->isEliminated)  &&
+			(G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
+			G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)))) {
 		spawnPoint = SelectSpectatorSpawnPoint ( spawn_origin, spawn_angles);
-	} else if (g_gametype.integer == GT_DOUBLE_D) {
+	} else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		//Double Domination uses special spawn points:
 		spawnPoint = SelectDoubleDominationSpawnPoint (client->sess.sessionTeam, spawn_origin, spawn_angles);
-	} else if (g_gametype.integer == GT_DOMINATION) {
+	} else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		//Domination uses special spawn points:
 		spawnPoint = SelectDominationSpawnPoint (client->sess.sessionTeam, spawn_origin, spawn_angles);
-	} else if (G_IsATeamGametype(g_gametype.integer)) {
+	} else if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		// all base oriented team games use the CTF spawn points
 		spawnPoint = SelectCTFSpawnPoint ( 
 						client->sess.sessionTeam, 
@@ -1780,10 +1786,10 @@ void ClientSpawn(gentity_t *ent) {
 
 	client->ps.clientNum = index;
 
-	if(!G_IsARoundBasedGametype(g_gametype.integer) && !g_elimination_allgametypes.integer)
+	if(!G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && !g_elimination_allgametypes.integer)
 	{
 		client->ps.stats[STAT_WEAPONS] = ( 1 << WP_MACHINEGUN );
-		if ( g_gametype.integer == GT_TEAM ) {
+		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			client->ps.ammo[WP_MACHINEGUN] = 50;
 		} else {
 			client->ps.ammo[WP_MACHINEGUN] = 100;
@@ -1874,7 +1880,7 @@ void ClientSpawn(gentity_t *ent) {
 
 	// the respawned flag will be cleared after the attack and jump keys come up
 	client->ps.pm_flags |= PMF_RESPAWNED;
-	if(G_IsARoundBasedGametype(g_gametype.integer)) {
+	if(G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer)) {
 		client->ps.pm_flags |= PMF_ELIMWARMUP;
 	}
 
@@ -1882,7 +1888,7 @@ void ClientSpawn(gentity_t *ent) {
 	SetClientViewAngle( ent, spawn_angles );
 
 	if ( (ent->client->sess.sessionTeam == TEAM_SPECTATOR) || ((client->ps.pm_type == PM_SPECTATOR || client->isEliminated) && 
-		G_IsARoundBasedGametype(g_gametype.integer))) {
+		G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer))) {
 	} else {
 		G_KillBox( ent );
 		trap_LinkEntity (ent);
@@ -1930,7 +1936,7 @@ void ClientSpawn(gentity_t *ent) {
 
 	// positively link the client, even if the command times are weird
 	if ( (ent->client->sess.sessionTeam != TEAM_SPECTATOR) || ( (!client->isEliminated || client->ps.pm_type != PM_SPECTATOR) && 
-		G_IsARoundBasedGametype(g_gametype.integer) ) ) {
+		G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) ) ) {
 		BG_PlayerStateToEntityState( &client->ps, &ent->s, qtrue );
 		VectorCopy( ent->client->ps.origin, ent->r.currentOrigin );
 		trap_LinkEntity( ent );
@@ -1997,14 +2003,14 @@ void ClientDisconnect( int clientNum ) {
 	&& ent->client->sess.sessionTeam != TEAM_SPECTATOR && i ) {
 		//Prevent a team from loosing point because of player leaving
 		int teamscore = 0;
-		if (g_gametype.integer == GT_TEAM) {
+		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			teamscore = level.teamScores[ ent->client->sess.sessionTeam ];
 		}
 		// Kill him (makes sure he loses flags, etc)
 		ent->flags &= ~FL_GODMODE;
 		ent->client->ps.stats[STAT_HEALTH] = ent->health = 0;
 		player_die (ent, ent, g_entities + ENTITYNUM_WORLD, 100000, MOD_SUICIDE);
-		if (g_gametype.integer == GT_TEAM) {
+		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			level.teamScores[ ent->client->sess.sessionTeam ] = teamscore;
 		}
 	}
@@ -2018,17 +2024,14 @@ void ClientDisconnect( int clientNum ) {
 	G_LogPrintf( "ClientDisconnect: %i\n", clientNum );
 
 	// if we are playing in tourney mode and losing, give a win to the other player
-	if ( (g_gametype.integer == GT_TOURNAMENT )
-		&& !level.intermissiontime
-		&& !level.warmupTime && level.sortedClients[1] == clientNum ) {
+	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT) &&
+			!level.intermissiontime && !level.warmupTime && level.sortedClients[1] == clientNum ) {
 		level.clients[ level.sortedClients[0] ].sess.wins++;
 		ClientUserinfoChanged( level.sortedClients[0] );
 	}
 
-	if( g_gametype.integer == GT_TOURNAMENT &&
-		ent->client->sess.sessionTeam == TEAM_FREE &&
-		level.intermissiontime ) {
-
+	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT) &&
+			ent->client->sess.sessionTeam == TEAM_FREE && level.intermissiontime ) {
 		trap_SendConsoleCommand( EXEC_APPEND, "map_restart 0\n" );
 		level.restarted = qtrue;
 		level.changemap = NULL;

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -455,7 +455,7 @@ void ClientRespawn( gentity_t *ent ) {
 	}
 	CopyToBodyQue (ent); //Unlinks ent
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 		if(ent->client->pers.livesLeft>0)
 		{
 			ent->client->isEliminated = qfalse;
@@ -620,7 +620,7 @@ Returns number of living players on a team
 team_t TeamLivingCount( int ignoreClientNum, int team ) {
 	int		i;
 	int		count = 0;
-	qboolean	isLMS = (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS));
+	qboolean	isLMS = (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS));
 
 	for ( i = 0 ; i < level.maxclients ; i++ ) {
 		if ( i == ignoreClientNum ) {
@@ -645,7 +645,7 @@ team_t TeamLivingCount( int ignoreClientNum, int team ) {
 int TeamLivingHumanCount(int ignoreClientNum) {
 	int i;
 	int count = 0;
-	qboolean	isLMS = (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS));
+	qboolean	isLMS = (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS));
 
 	for ( i = 0 ; i < level.maxclients ; i++ ) {
 		if ( i == ignoreClientNum ) {
@@ -1485,7 +1485,7 @@ void ClientBegin( int clientNum ) {
 
 	//Elimination:
 	client->pers.roundReached = 0; //We will spawn in next round
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 		client->isEliminated = qtrue; //So player does not give a point in gamemode 2 and 3
 		//trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " will start dead\n\"", client->pers.netname) );
 	}
@@ -1544,7 +1544,7 @@ void ClientBegin( int clientNum ) {
 		tent = G_TempEntity( ent->client->ps.origin, EV_PLAYER_TELEPORT_IN );
 		tent->s.clientNum = ent->s.clientNum;
 
-		if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
+		if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 			trap_SendServerCommand( -1, va("print \"%s" S_COLOR_WHITE " entered the game\n\"", client->pers.netname) );
 		}
 	}
@@ -1554,7 +1554,7 @@ void ClientBegin( int clientNum ) {
 	G_LogPrintf( "ClientBegin: %i\n", clientNum );
 
 	//Send domination point names:
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		DominationPointNamesMessage(ent);
 		DominationPointStatusMessage(ent);
 	}
@@ -1605,7 +1605,7 @@ void ClientSpawn(gentity_t *ent) {
 	//Sago: Yes, the !level.intermissiontime is currently redundant but it might still be the bast place to make the test, CheckElimination in g_main makes sure the next if will fail and the rest of the things this block does might not affect if in Intermission (I'll just test that)
 	if((((G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
 			G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) ||
-			(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS) && client->isEliminated)) &&
+			(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS) && client->isEliminated)) &&
 			(!level.intermissiontime || level.warmupTime != 0)) &&
 			( client->sess.sessionTeam != TEAM_SPECTATOR)) {
 		// N_G: Another condition that makes no sense to me, see for
@@ -1618,7 +1618,7 @@ void ClientSpawn(gentity_t *ent) {
 		{	
 			client->sess.spectatorState = SPECTATOR_FREE;
 			client->isEliminated = qtrue;
-			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
+			if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 				G_LogPrintf( "LMS: %i %i %i: Player \"%s^7\" eliminated!\n", level.roundNumber, index, 1, client->pers.netname );
 			}
 			client->ps.pm_type = PM_SPECTATOR;
@@ -1641,7 +1641,7 @@ void ClientSpawn(gentity_t *ent) {
 		}
 	}
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS) &&
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS) &&
 		client->sess.sessionTeam != TEAM_SPECTATOR &&
 		(!level.intermissiontime || level.warmupTime != 0)) {
 		if(level.roundNumber==level.roundNumberStarted /*|| level.time<level.roundStartTime-g_elimination_activewarmup.integer*1000*/ && 1>client->pers.livesLeft)
@@ -1673,10 +1673,10 @@ void ClientSpawn(gentity_t *ent) {
 			(G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
 			G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)))) {
 		spawnPoint = SelectSpectatorSpawnPoint ( spawn_origin, spawn_angles);
-	} else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+	} else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		//Double Domination uses special spawn points:
 		spawnPoint = SelectDoubleDominationSpawnPoint (client->sess.sessionTeam, spawn_origin, spawn_angles);
-	} else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
+	} else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		//Domination uses special spawn points:
 		spawnPoint = SelectDominationSpawnPoint (client->sess.sessionTeam, spawn_origin, spawn_angles);
 	} else if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
@@ -1789,7 +1789,7 @@ void ClientSpawn(gentity_t *ent) {
 	if(!G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && !g_elimination_allgametypes.integer)
 	{
 		client->ps.stats[STAT_WEAPONS] = ( 1 << WP_MACHINEGUN );
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			client->ps.ammo[WP_MACHINEGUN] = 50;
 		} else {
 			client->ps.ammo[WP_MACHINEGUN] = 100;
@@ -2003,14 +2003,14 @@ void ClientDisconnect( int clientNum ) {
 	&& ent->client->sess.sessionTeam != TEAM_SPECTATOR && i ) {
 		//Prevent a team from loosing point because of player leaving
 		int teamscore = 0;
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			teamscore = level.teamScores[ ent->client->sess.sessionTeam ];
 		}
 		// Kill him (makes sure he loses flags, etc)
 		ent->flags &= ~FL_GODMODE;
 		ent->client->ps.stats[STAT_HEALTH] = ent->health = 0;
 		player_die (ent, ent, g_entities + ENTITYNUM_WORLD, 100000, MOD_SUICIDE);
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			level.teamScores[ ent->client->sess.sessionTeam ] = teamscore;
 		}
 	}
@@ -2024,13 +2024,13 @@ void ClientDisconnect( int clientNum ) {
 	G_LogPrintf( "ClientDisconnect: %i\n", clientNum );
 
 	// if we are playing in tourney mode and losing, give a win to the other player
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT) &&
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT) &&
 			!level.intermissiontime && !level.warmupTime && level.sortedClients[1] == clientNum ) {
 		level.clients[ level.sortedClients[0] ].sess.wins++;
 		ClientUserinfoChanged( level.sortedClients[0] );
 	}
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT) &&
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT) &&
 			ent->client->sess.sessionTeam == TEAM_FREE && level.intermissiontime ) {
 		trap_SendConsoleCommand( EXEC_APPEND, "map_restart 0\n" );
 		level.restarted = qtrue;

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -1792,8 +1792,13 @@ void Cmd_CallVote_f( gentity_t *ent ) {
 	if ( Q_strequal( arg1, "g_gametype" ) ) {
 		char	s[MAX_STRING_CHARS];
 		i = atoi( arg2 );
-		if( i == GT_SINGLE_PLAYER || i < GT_FFA || i >= GT_MAX_GAME_TYPE) {
+		if( i < GT_FFA || i >= GT_MAX_GAME_TYPE) {
 			trap_SendServerCommand( ent-g_entities, "print \"Invalid gametype.\n\"" );
+			return;
+		}
+
+		if ( i == GT_SINGLE_PLAYER && (g_subgametype.integer < GT_FFA || g_subgametype.integer >= GT_MAX_GAME_TYPE)) {
+			trap_SendServerCommand( ent-g_entities, "print \"Invalid subgametype for SP.\n\"" );
 			return;
 		}
 

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -72,7 +72,7 @@ void DeathmatchScoreboardMessage( gentity_t *ent ) {
 		}
 		perfect = ( cl->ps.persistant[PERS_RANK] == 0 && cl->ps.persistant[PERS_KILLED] == 0 ) ? 1 : 0;
 
-		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
+		if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 			Com_sprintf (entry, sizeof(entry),
 				" %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i", level.sortedClients[i],
 				cl->ps.persistant[PERS_SCORE], ping, (level.time - cl->pers.enterTime)/60000,
@@ -826,7 +826,7 @@ void SetTeam( gentity_t *ent, const char *s ) {
 	}
 	if ( !force ) {
 		// override decision if limiting the players
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 			&& level.numNonSpectatorClients >= 2 ) {
 			team = TEAM_SPECTATOR;
 		} else if ( g_maxGameClients.integer > 0 && 
@@ -874,7 +874,7 @@ void SetTeam( gentity_t *ent, const char *s ) {
 	if ( oldTeam != TEAM_SPECTATOR ) {
 		int teamscore = -99;
 		//Prevent a team from loosing point because of player leaving team
-		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM) &&
+		if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM) &&
 				ent->client->ps.stats[STAT_HEALTH]) {
 			teamscore = level.teamScores[ ent->client->sess.sessionTeam ];
 		}
@@ -992,7 +992,7 @@ void Cmd_Team_f( gentity_t *ent ) {
 	}
 
 	// if they are playing a tournement game, count as a loss
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 		&& ent->client->sess.sessionTeam == TEAM_FREE ) {
 		ent->client->sess.losses++;
 	}
@@ -1050,7 +1050,7 @@ void Cmd_Follow_f( gentity_t *ent ) {
 	}
 
 	// if they are playing a tournement game, count as a loss
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 		&& ent->client->sess.sessionTeam == TEAM_FREE ) {
 		ent->client->sess.losses++;
 	}
@@ -1094,7 +1094,7 @@ void Cmd_FollowCycle_f( gentity_t *ent ) {
 	}
 
 	// if they are playing a tournement game, count as a loss
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 		&& ent->client->sess.sessionTeam == TEAM_FREE ) {
 		ent->client->sess.losses++;
 	}
@@ -1189,7 +1189,7 @@ static void G_SayTo( gentity_t *ent, gentity_t *other, int mode, int color, cons
 	if ((ent->r.svFlags & SVF_BOT) && g_bot_noChat.integer > 1) return;
 
 	// no chatting to players in tournements
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 		&& other->client->sess.sessionTeam == TEAM_FREE
 		&& ent->client->sess.sessionTeam != TEAM_FREE ) {
 		return;
@@ -1366,7 +1366,7 @@ static void G_VoiceTo( gentity_t *ent, gentity_t *other, int mode, const char *i
 		return;
 	}
 	// no chatting to players in tournements
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 		return;
 	}
 

--- a/code/game/g_cmds.c
+++ b/code/game/g_cmds.c
@@ -72,7 +72,7 @@ void DeathmatchScoreboardMessage( gentity_t *ent ) {
 		}
 		perfect = ( cl->ps.persistant[PERS_RANK] == 0 && cl->ps.persistant[PERS_KILLED] == 0 ) ? 1 : 0;
 
-		if(g_gametype.integer == GT_LMS) {
+		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 			Com_sprintf (entry, sizeof(entry),
 				" %i %i %i %i %i %i %i %i %i %i %i %i %i %i %i", level.sortedClients[i],
 				cl->ps.persistant[PERS_SCORE], ping, (level.time - cl->pers.enterTime)/60000,
@@ -785,7 +785,7 @@ void SetTeam( gentity_t *ent, const char *s ) {
 		team = TEAM_SPECTATOR;
 		specState = SPECTATOR_FREE;
 	} 
-	else if (G_IsATeamGametype(g_gametype.integer)) {
+	else if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		// if running a team game, assign player to one of the teams
 		specState = SPECTATOR_NOT;
 		if ( Q_strequal( s, "red" ) || Q_strequal( s, "r" ) ) {
@@ -826,7 +826,7 @@ void SetTeam( gentity_t *ent, const char *s ) {
 	}
 	if ( !force ) {
 		// override decision if limiting the players
-		if ( (g_gametype.integer == GT_TOURNAMENT)
+		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 			&& level.numNonSpectatorClients >= 2 ) {
 			team = TEAM_SPECTATOR;
 		} else if ( g_maxGameClients.integer > 0 && 
@@ -874,7 +874,8 @@ void SetTeam( gentity_t *ent, const char *s ) {
 	if ( oldTeam != TEAM_SPECTATOR ) {
 		int teamscore = -99;
 		//Prevent a team from loosing point because of player leaving team
-		if(g_gametype.integer == GT_TEAM && ent->client->ps.stats[STAT_HEALTH]) {
+		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM) &&
+				ent->client->ps.stats[STAT_HEALTH]) {
 			teamscore = level.teamScores[ ent->client->sess.sessionTeam ];
 		}
 		// Kill him (makes sure he loses flags, etc)
@@ -929,7 +930,7 @@ to free floating spectator mode
 =================
 */
 void StopFollowing( gentity_t *ent ) {
-	if(!G_IsARoundBasedGametype(g_gametype.integer))
+	if(!G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer))
 	{
 		//Shouldn't this already be the case?
 		ent->client->ps.persistant[ PERS_TEAM ] = TEAM_SPECTATOR;	
@@ -991,7 +992,7 @@ void Cmd_Team_f( gentity_t *ent ) {
 	}
 
 	// if they are playing a tournement game, count as a loss
-	if ( (g_gametype.integer == GT_TOURNAMENT )
+	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 		&& ent->client->sess.sessionTeam == TEAM_FREE ) {
 		ent->client->sess.losses++;
 	}
@@ -1039,14 +1040,17 @@ void Cmd_Follow_f( gentity_t *ent ) {
 		return;
 	}
 
-	if ( G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer) && g_elimination_lockspectator.integer
-		&&  ((ent->client->sess.sessionTeam == TEAM_RED && level.clients[ i ].sess.sessionTeam == TEAM_BLUE) ||
-			 (ent->client->sess.sessionTeam == TEAM_BLUE && level.clients[ i ].sess.sessionTeam == TEAM_RED) ) ) {
+	if ( G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
+			G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) &&
+			g_elimination_lockspectator.integer && ((ent->client->sess.sessionTeam == TEAM_RED &&
+			level.clients[ i ].sess.sessionTeam == TEAM_BLUE) ||
+			(ent->client->sess.sessionTeam == TEAM_BLUE &&
+			level.clients[ i ].sess.sessionTeam == TEAM_RED) ) ) {
 		return;
 	}
 
 	// if they are playing a tournement game, count as a loss
-	if ( (g_gametype.integer == GT_TOURNAMENT )
+	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 		&& ent->client->sess.sessionTeam == TEAM_FREE ) {
 		ent->client->sess.losses++;
 	}
@@ -1090,7 +1094,7 @@ void Cmd_FollowCycle_f( gentity_t *ent ) {
 	}
 
 	// if they are playing a tournement game, count as a loss
-	if ( (g_gametype.integer == GT_TOURNAMENT )
+	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 		&& ent->client->sess.sessionTeam == TEAM_FREE ) {
 		ent->client->sess.losses++;
 	}
@@ -1141,9 +1145,11 @@ void Cmd_FollowCycle_f( gentity_t *ent ) {
 		}
 
 		//Stop players from spectating players on the enemy team in elimination modes.
-		if ( (G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer)) && g_elimination_lockspectator.integer
-			&&  ((ent->client->sess.sessionTeam == TEAM_RED && level.clients[ clientnum ].sess.sessionTeam == TEAM_BLUE) ||
-				 (ent->client->sess.sessionTeam == TEAM_BLUE && level.clients[ clientnum ].sess.sessionTeam == TEAM_RED) ) ) {
+		if ( (G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
+				G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) &&
+				g_elimination_lockspectator.integer &&
+				((ent->client->sess.sessionTeam == TEAM_RED && level.clients[ clientnum ].sess.sessionTeam == TEAM_BLUE) ||
+				(ent->client->sess.sessionTeam == TEAM_BLUE && level.clients[ clientnum ].sess.sessionTeam == TEAM_RED) ) ) {
 			continue;
 		}
 
@@ -1183,7 +1189,7 @@ static void G_SayTo( gentity_t *ent, gentity_t *other, int mode, int color, cons
 	if ((ent->r.svFlags & SVF_BOT) && g_bot_noChat.integer > 1) return;
 
 	// no chatting to players in tournements
-	if ( (g_gametype.integer == GT_TOURNAMENT )
+	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)
 		&& other->client->sess.sessionTeam == TEAM_FREE
 		&& ent->client->sess.sessionTeam != TEAM_FREE ) {
 		return;
@@ -1213,7 +1219,7 @@ void G_Say( gentity_t *ent, gentity_t *target, int mode, const char *chatText ) 
 		return;
 	}
 
-	if ( !G_IsATeamGametype(g_gametype.integer) && mode == SAY_TEAM ) {
+	if ( !G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) && mode == SAY_TEAM ) {
 		mode = SAY_ALL;
 	}
 
@@ -1235,7 +1241,7 @@ void G_Say( gentity_t *ent, gentity_t *target, int mode, const char *chatText ) 
 		color = COLOR_CYAN;
 		break;
 	case SAY_TELL:
-		if (target && target->inuse && target->client && G_IsATeamGametype(g_gametype.integer) &&
+		if (target && target->inuse && target->client && G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) &&
 			target->client->sess.sessionTeam == ent->client->sess.sessionTeam &&
 			Team_GetLocationMsg(ent, location, sizeof(location)))
 			Com_sprintf (name, sizeof(name), EC"[%s%c%c"EC"] (%s)"EC": ", ent->client->pers.netname, Q_COLOR_ESCAPE, COLOR_WHITE, location );
@@ -1360,7 +1366,7 @@ static void G_VoiceTo( gentity_t *ent, gentity_t *other, int mode, const char *i
 		return;
 	}
 	// no chatting to players in tournements
-	if ( g_gametype.integer == GT_TOURNAMENT ) {
+	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 		return;
 	}
 
@@ -1384,7 +1390,7 @@ void G_Voice( gentity_t *ent, gentity_t *target, int mode, const char *id, qbool
 	int			j;
 	gentity_t	*other;
 
-	if ( !G_IsATeamGametype(g_gametype.integer) && mode == SAY_TEAM ) {
+	if ( !G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) && mode == SAY_TEAM ) {
 		mode = SAY_ALL;
 	}
 
@@ -1539,7 +1545,7 @@ static void Cmd_VoiceTaunt_f( gentity_t *ent ) {
 		}
 	}
 
-	if (G_IsATeamGametype(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		// praise a team mate who just got a reward
 		for(i = 0; i < MAX_CLIENTS; i++) {
 			who = g_entities + i;
@@ -1909,7 +1915,7 @@ void Cmd_CallVote_f( gentity_t *ent ) {
 		Com_sprintf( level.voteDisplayString, sizeof( level.voteDisplayString ), "Kick %s?" , level.clients[i].pers.netname );
 	} 
 	else if ( Q_strequal( arg1, "shuffle" ) ) {
-		if(!G_IsATeamGametype(g_gametype.integer)) { //Not a team game
+		if(!G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) { //Not a team game
 			trap_SendServerCommand( ent-g_entities, "print \"Can only be used in team games.\n\"" );
 			return;
 		}

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -86,7 +86,7 @@ void AddScore( gentity_t *ent, vec3_t origin, int score )
 		ScorePlum(ent, origin, score);
 		//
 		ent->client->ps.persistant[PERS_SCORE] += score;
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			int team = ent->client->ps.persistant[PERS_TEAM];
 			level.teamScores[ team ] += score;
 			G_LogPrintf("TeamScore: %i %i: Team %d now has %d points\n",
@@ -134,7 +134,7 @@ void TossClientItems( gentity_t *self )
 	}
 
 	if (g_instantgib.integer || g_rockets.integer ||
-			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) ||
+			G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) ||
 			g_elimination_allgametypes.integer) {
 		//Nothing!
 	}
@@ -148,7 +148,7 @@ void TossClientItems( gentity_t *self )
 	}
 
 	// drop all the powerups if not in teamplay
-	if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+	if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 		angle = 45;
 		for ( i = 1 ; i < PW_NUM_POWERUPS ; i++ ) {
 			if ( self->client->ps.powerups[ i ] > level.time ) {
@@ -586,7 +586,7 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 		attacker->client->lastkilled_client = self->s.number;
 
 		if ( attacker == self || OnSameTeam (self, attacker ) ) {
-			if(!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
+			if(!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
 					!G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
 					level.time < level.roundStartTime) {
 				if( (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) &&
@@ -597,8 +597,8 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 			}
 		}
 		else {
-			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS) &&
-					G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
+			if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS) &&
+					G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
 				AddScore( attacker, self->r.currentOrigin, 1 );
 			}
 
@@ -770,7 +770,7 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 		}
 	}
 	else {
-		if(!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
+		if(!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
 				!G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) &&
 				level.time < level.roundStartTime) {
 			if(self->client->ps.persistant[PERS_SCORE]>0 || level.numNonSpectatorClients<3) { 
@@ -799,7 +799,7 @@ void player_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int
 		}
 	}
 	TossClientPersistantPowerups( self );
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		TossClientCubes( self );
 	}
 	// if client is in a nodrop area, don't drop anything (but return CTF flags!)
@@ -1129,7 +1129,7 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker,
 		}
 		return;
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK) &&
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK) &&
 			CheckObeliskAttack( targ, attacker ) ) {
 		return;
 	}

--- a/code/game/g_elimination.c
+++ b/code/game/g_elimination.c
@@ -99,13 +99,13 @@ void StartEliminationRound(void) {
 	level.roundNumberStarted = level.roundNumber; //Set numbers
 	level.roundRedPlayers = countsLiving[TEAM_RED];
 	level.roundBluePlayers = countsLiving[TEAM_BLUE];
-	if(g_gametype.integer == GT_CTF_ELIMINATION) {
+	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 		Team_ReturnFlag( TEAM_RED );
 		Team_ReturnFlag( TEAM_BLUE );
 	}
-	if(g_gametype.integer == GT_ELIMINATION) {
+	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 		G_LogPrintf( "ELIMINATION: %i %i %i: Round %i has started!\n", level.roundNumber, -1, 0, level.roundNumber );
-	} else if(g_gametype.integer == GT_CTF_ELIMINATION) {
+	} else if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 		G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: Round %i has started!\n", level.roundNumber, -1, -1, 4, level.roundNumber );
 	}
 	SendEliminationMessageToAllClients();
@@ -188,7 +188,7 @@ void CheckElimination(void) {
 	int countHumans;
 
 	if ( level.numPlayingClients < 1 ) {
-		if( G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer) && ( level.time+1000*g_elimination_warmup.integer-500>level.roundStartTime )) {
+		if( G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) && ( level.time+1000*g_elimination_warmup.integer-500>level.roundStartTime )) {
 			RestartEliminationRound(); //For spectators
 		}
 		return;
@@ -203,7 +203,7 @@ void CheckElimination(void) {
 		return;
 	}	
 	
-	if(!(G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer))) {
+	if(!(G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && G_IsATeamGametype(g_gametype.integer,g_subgametype.integer))) {
 		return;
 	}
 
@@ -233,7 +233,7 @@ void CheckElimination(void) {
 			//Blue team has been eliminated!
 			trap_SendServerCommand( -1, "print \"Blue Team eliminated!\n\"");
 			AddTeamScore(level.intermission_origin,TEAM_RED,1);
-			if(g_gametype.integer == GT_ELIMINATION) {
+			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 				G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i by eleminating the enemy team!\n", level.roundNumber, TEAM_RED, 1, TeamName(TEAM_RED), level.roundNumber );
 			} else {
 				G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i by eleminating the enemy team!\n", level.roundNumber, -1, TEAM_RED, 6, TeamName(TEAM_RED), level.roundNumber );
@@ -246,7 +246,7 @@ void CheckElimination(void) {
 			//Red team eliminated!
 			trap_SendServerCommand( -1, "print \"Red Team eliminated!\n\"");
 			AddTeamScore(level.intermission_origin,TEAM_BLUE,1);
-			if(g_gametype.integer == GT_ELIMINATION) {
+			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 				G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i by eleminating the enemy team!\n", level.roundNumber, TEAM_BLUE, 1, TeamName(TEAM_BLUE), level.roundNumber );
 			} else {
 				G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i by eleminating the enemy team!\n", level.roundNumber, -1, TEAM_BLUE, 6, TeamName(TEAM_BLUE), level.roundNumber );
@@ -262,7 +262,8 @@ void CheckElimination(void) {
 		trap_SendServerCommand( -1, "print \"No teams eliminated.\n\"");
 
 		if(level.roundBluePlayers != 0 && level.roundRedPlayers != 0) {//We don't want to divide by zero. (should not be possible)
-			if(g_gametype.integer == GT_CTF_ELIMINATION && g_elimination_ctf_oneway.integer) {
+			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) &&
+					g_elimination_ctf_oneway.integer) {
 				//One way CTF, make defensice team the winner.
 				if ( (level.eliminationSides+level.roundNumber)%2 == 0 ) { //Red was attacking
 					trap_SendServerCommand( -1, "print \"Blue team defended the base\n\"");
@@ -280,7 +281,7 @@ void CheckElimination(void) {
 				//Red team has higher procentage survivors
 				trap_SendServerCommand( -1, "print \"Red team has most survivers!\n\"");
 				AddTeamScore(level.intermission_origin,TEAM_RED,1);
-				if(g_gametype.integer == GT_ELIMINATION) {
+				if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 					G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i due to more survivors!\n", level.roundNumber, TEAM_RED, 2, TeamName(TEAM_RED), level.roundNumber );
 				} else {
 					G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i due to more survivors!\n", level.roundNumber, -1, TEAM_RED, 7, TeamName(TEAM_RED), level.roundNumber );
@@ -291,7 +292,7 @@ void CheckElimination(void) {
 				//Blue team has higher procentage survivors
 				trap_SendServerCommand( -1, "print \"Blue team has most survivers!\n\"");
 				AddTeamScore(level.intermission_origin,TEAM_BLUE,1);	
-				if(g_gametype.integer == GT_ELIMINATION) {
+				if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 					G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i due to more survivors!\n", level.roundNumber, TEAM_BLUE, 2, TeamName(TEAM_BLUE), level.roundNumber );
 				} else {
 					G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i due to more survivors!\n", level.roundNumber, -1, TEAM_BLUE, 7, TeamName(TEAM_BLUE), level.roundNumber );
@@ -302,7 +303,7 @@ void CheckElimination(void) {
 				//Red team has more health
 				trap_SendServerCommand( -1, "print \"Red team has more health left!\n\"");
 				AddTeamScore(level.intermission_origin,TEAM_RED,1);
-				if(g_gametype.integer == GT_ELIMINATION) {
+				if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 					G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i due to more health left!\n", level.roundNumber, TEAM_RED, 3, TeamName(TEAM_RED), level.roundNumber );
 				} else {
 					G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i due to more health left!\n", level.roundNumber, -1, TEAM_RED, 8, TeamName(TEAM_RED), level.roundNumber );
@@ -313,7 +314,7 @@ void CheckElimination(void) {
 				//Blue team has more health
 				trap_SendServerCommand( -1, "print \"Blue team has more health left!\n\"");
 				AddTeamScore(level.intermission_origin,TEAM_BLUE,1);
-				if(g_gametype.integer == GT_ELIMINATION) {
+				if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 					G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i due to more health left!\n", level.roundNumber, TEAM_BLUE, 3, TeamName(TEAM_BLUE), level.roundNumber );
 				} else {
 					G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i due to more health left!\n", level.roundNumber, -1, TEAM_BLUE, 8, TeamName(TEAM_BLUE), level.roundNumber );
@@ -321,7 +322,7 @@ void CheckElimination(void) {
 			}
 		}
 		//Draw
-		if(g_gametype.integer == GT_ELIMINATION) {
+		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 			G_LogPrintf( "ELIMINATION: %i %i %i: Round %i ended in a draw!\n", level.roundNumber, -1, 4, level.roundNumber );
 		} else {
 			G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: Round %i ended in a draw!\n", level.roundNumber, -1, -1, 9, level.roundNumber );
@@ -395,7 +396,7 @@ void CheckLMS(void) {
 		return;
 	}
 	
-	if (g_gametype.integer != GT_LMS) {
+	if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 		return;
 	}
 	

--- a/code/game/g_elimination.c
+++ b/code/game/g_elimination.c
@@ -99,13 +99,13 @@ void StartEliminationRound(void) {
 	level.roundNumberStarted = level.roundNumber; //Set numbers
 	level.roundRedPlayers = countsLiving[TEAM_RED];
 	level.roundBluePlayers = countsLiving[TEAM_BLUE];
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 		Team_ReturnFlag( TEAM_RED );
 		Team_ReturnFlag( TEAM_BLUE );
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 		G_LogPrintf( "ELIMINATION: %i %i %i: Round %i has started!\n", level.roundNumber, -1, 0, level.roundNumber );
-	} else if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+	} else if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 		G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: Round %i has started!\n", level.roundNumber, -1, -1, 4, level.roundNumber );
 	}
 	SendEliminationMessageToAllClients();
@@ -233,7 +233,7 @@ void CheckElimination(void) {
 			//Blue team has been eliminated!
 			trap_SendServerCommand( -1, "print \"Blue Team eliminated!\n\"");
 			AddTeamScore(level.intermission_origin,TEAM_RED,1);
-			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+			if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 				G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i by eleminating the enemy team!\n", level.roundNumber, TEAM_RED, 1, TeamName(TEAM_RED), level.roundNumber );
 			} else {
 				G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i by eleminating the enemy team!\n", level.roundNumber, -1, TEAM_RED, 6, TeamName(TEAM_RED), level.roundNumber );
@@ -246,7 +246,7 @@ void CheckElimination(void) {
 			//Red team eliminated!
 			trap_SendServerCommand( -1, "print \"Red Team eliminated!\n\"");
 			AddTeamScore(level.intermission_origin,TEAM_BLUE,1);
-			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+			if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 				G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i by eleminating the enemy team!\n", level.roundNumber, TEAM_BLUE, 1, TeamName(TEAM_BLUE), level.roundNumber );
 			} else {
 				G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i by eleminating the enemy team!\n", level.roundNumber, -1, TEAM_BLUE, 6, TeamName(TEAM_BLUE), level.roundNumber );
@@ -262,7 +262,7 @@ void CheckElimination(void) {
 		trap_SendServerCommand( -1, "print \"No teams eliminated.\n\"");
 
 		if(level.roundBluePlayers != 0 && level.roundRedPlayers != 0) {//We don't want to divide by zero. (should not be possible)
-			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) &&
+			if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) &&
 					g_elimination_ctf_oneway.integer) {
 				//One way CTF, make defensice team the winner.
 				if ( (level.eliminationSides+level.roundNumber)%2 == 0 ) { //Red was attacking
@@ -281,7 +281,7 @@ void CheckElimination(void) {
 				//Red team has higher procentage survivors
 				trap_SendServerCommand( -1, "print \"Red team has most survivers!\n\"");
 				AddTeamScore(level.intermission_origin,TEAM_RED,1);
-				if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+				if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 					G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i due to more survivors!\n", level.roundNumber, TEAM_RED, 2, TeamName(TEAM_RED), level.roundNumber );
 				} else {
 					G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i due to more survivors!\n", level.roundNumber, -1, TEAM_RED, 7, TeamName(TEAM_RED), level.roundNumber );
@@ -292,7 +292,7 @@ void CheckElimination(void) {
 				//Blue team has higher procentage survivors
 				trap_SendServerCommand( -1, "print \"Blue team has most survivers!\n\"");
 				AddTeamScore(level.intermission_origin,TEAM_BLUE,1);	
-				if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+				if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 					G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i due to more survivors!\n", level.roundNumber, TEAM_BLUE, 2, TeamName(TEAM_BLUE), level.roundNumber );
 				} else {
 					G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i due to more survivors!\n", level.roundNumber, -1, TEAM_BLUE, 7, TeamName(TEAM_BLUE), level.roundNumber );
@@ -303,7 +303,7 @@ void CheckElimination(void) {
 				//Red team has more health
 				trap_SendServerCommand( -1, "print \"Red team has more health left!\n\"");
 				AddTeamScore(level.intermission_origin,TEAM_RED,1);
-				if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+				if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 					G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i due to more health left!\n", level.roundNumber, TEAM_RED, 3, TeamName(TEAM_RED), level.roundNumber );
 				} else {
 					G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i due to more health left!\n", level.roundNumber, -1, TEAM_RED, 8, TeamName(TEAM_RED), level.roundNumber );
@@ -314,7 +314,7 @@ void CheckElimination(void) {
 				//Blue team has more health
 				trap_SendServerCommand( -1, "print \"Blue team has more health left!\n\"");
 				AddTeamScore(level.intermission_origin,TEAM_BLUE,1);
-				if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+				if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 					G_LogPrintf( "ELIMINATION: %i %i %i: %s wins round %i due to more health left!\n", level.roundNumber, TEAM_BLUE, 3, TeamName(TEAM_BLUE), level.roundNumber );
 				} else {
 					G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s wins round %i due to more health left!\n", level.roundNumber, -1, TEAM_BLUE, 8, TeamName(TEAM_BLUE), level.roundNumber );
@@ -322,7 +322,7 @@ void CheckElimination(void) {
 			}
 		}
 		//Draw
-		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+		if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 			G_LogPrintf( "ELIMINATION: %i %i %i: Round %i ended in a draw!\n", level.roundNumber, -1, 4, level.roundNumber );
 		} else {
 			G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: Round %i ended in a draw!\n", level.roundNumber, -1, -1, 9, level.roundNumber );
@@ -396,7 +396,7 @@ void CheckLMS(void) {
 		return;
 	}
 	
-	if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
+	if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 		return;
 	}
 	

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -251,7 +251,7 @@ int Pickup_Weapon (gentity_t *ent, gentity_t *other)
 		}
 
 		// dropped items and teamplay weapons always have full ammo
-		if (!(ent->flags & FL_DROPPED_ITEM) && G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+		if (!(ent->flags & FL_DROPPED_ITEM) && G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			// respawning rules
 			// drop the quantity if the already have over the minimum
 			if ( other->client->ps.ammo[ ent->item->giTag ] < quantity ) {
@@ -272,7 +272,7 @@ int Pickup_Weapon (gentity_t *ent, gentity_t *other)
 		other->client->ps.ammo[ent->item->giTag] = -1; // unlimited ammo
 
 	// team deathmatch has slow weapon respawns
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 		return g_weaponTeamRespawn.integer;
 	}
 
@@ -431,17 +431,17 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace)
 
 	//instant gib
 	if ((g_instantgib.integer || g_rockets.integer ||
-			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) ||
+			G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) ||
 			g_elimination_allgametypes.integer) &&
 			ent->item->giType != IT_TEAM)
 		return;
 
 	//Cannot touch flag before round starts
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) && level.roundNumber != level.roundNumberStarted)
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) && level.roundNumber != level.roundNumberStarted)
 		return;
 
 	//Cannot take ctf elimination oneway
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) &&
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) &&
 				g_elimination_ctf_oneway.integer!=0 &&
 				((other->client->sess.sessionTeam==TEAM_BLUE && (level.eliminationSides+level.roundNumber)%2 == 0 ) ||
 				(other->client->sess.sessionTeam==TEAM_RED && (level.eliminationSides+level.roundNumber)%2 != 0 ) ))
@@ -461,7 +461,7 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace)
 	}
 
 	//In double DD we cannot "pick up" a flag we already got
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		if( strequals(ent->classname, "team_CTF_redflag") ) {
 			if(other->client->sess.sessionTeam == level.pointStatusA) {
 				return;
@@ -636,7 +636,7 @@ gentity_t *LaunchItem( gitem_t *item, vec3_t origin, vec3_t velocity )
 	dropped->s.eFlags |= EF_BOUNCE_HALF;
 	if ((G_UsesTeamFlags(g_gametype.integer,g_subgametype.integer) ||
 			G_UsesTheWhiteFlag(g_gametype.integer,g_subgametype.integer) ||
-			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) &&
+			G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) &&
 			item->giType == IT_TEAM) { // Special case for CTF flags
 		dropped->think = Team_DroppedFlagThink;
 		dropped->nextthink = level.time + 30000;
@@ -778,7 +778,7 @@ void G_CheckTeamItems( void )
 
 	if( (G_UsesTeamFlags(g_gametype.integer,g_subgametype.integer) &&
 			!G_UsesTheWhiteFlag(g_gametype.integer,g_subgametype.integer)) ||
-			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+			G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		gitem_t	*item;
 
 		// check for the two flags
@@ -791,7 +791,7 @@ void G_CheckTeamItems( void )
 			G_Printf( S_COLOR_YELLOW "WARNING: No team_CTF_blueflag in map\n" );
 		}
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
 		gitem_t	*item;
 
 		// check for all three flags
@@ -888,12 +888,12 @@ void ClearRegisteredItems( void )
 	if (g_grapple.integer) {
 		RegisterItem( BG_FindItemForWeapon( WP_GRAPPLING_HOOK ) );
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		RegisterItem( BG_FindItem( "Red Cube" ) );
 		RegisterItem( BG_FindItem( "Blue Cube" ) );
 	}
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		RegisterItem( BG_FindItem( "Point A (Blue)" ) );
 		RegisterItem( BG_FindItem( "Point A (Red)" ) );
 		RegisterItem( BG_FindItem( "Point A (White)" ) );
@@ -902,13 +902,13 @@ void ClearRegisteredItems( void )
 		RegisterItem( BG_FindItem( "Point B (White)" ) );
 	}
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		RegisterItem( BG_FindItem( "Neutral domination point" ) );
 		RegisterItem( BG_FindItem( "Red domination point" ) );
 		RegisterItem( BG_FindItem( "Blue domination point" ) );
 	}
 
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
 		RegisterItem(BG_FindItem("Neutral Flag") );
 	}
 
@@ -1004,12 +1004,12 @@ void G_SpawnItem (gentity_t *ent, gitem_t *item)
 
 	if ((G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && !G_UsesTeamFlags(g_gametype.integer,g_subgametype.integer)) ||
 	        (item->giType != IT_TEAM && (g_instantgib.integer || g_rockets.integer || g_elimination_allgametypes.integer ||
-			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)))) {
+			G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)))) {
 		ent->s.eFlags |= EF_NODRAW; //Invisible in elimination
 		ent->r.svFlags |= SVF_NOCLIENT;  //Don't broadcast
 	}
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D) &&
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D) &&
 			(strequals(ent->classname, "team_CTF_redflag") || strequals(ent->classname, "team_CTF_blueflag") ||
 			strequals(ent->classname, "team_CTF_neutralflag") || item->giType == IT_PERSISTANT_POWERUP)) {
 		ent->s.eFlags |= EF_NODRAW; //Don't draw the flag models/persistant powerups
@@ -1019,7 +1019,7 @@ void G_SpawnItem (gentity_t *ent, gitem_t *item)
 		ent->s.eFlags |= EF_NODRAW; // Don't draw the flag in CTF_elimination
 	}
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION) &&
 			(strequals(ent->classname, "team_CTF_redflag") || strequals(ent->classname, "team_CTF_blueflag"))) {
 		ent->s.eFlags |= EF_NODRAW; // Don't draw the flag colored flags in possession
 	}

--- a/code/game/g_killspree.c
+++ b/code/game/g_killspree.c
@@ -286,7 +286,7 @@ void G_RunStreakLogic( gentity_t *attacker, gentity_t *victim )
 		&& ( attacker != victim ) ) {
 
 		//Check the gametype--If FFA enabled, everybody's on the same team. 
-		if(G_IsATeamGametype(g_gametype.integer)) {
+		if(G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 			//If they are on the same team we don't want to count it towards a killing spree. 
 			if( OnSameTeam( victim, attacker ) ) {
 				return;

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1031,6 +1031,7 @@ extern	gentity_t		g_entities[MAX_GENTITIES];
 
 //CVARS 
 extern vmCvar_t g_gametype;
+extern vmCvar_t g_subgametype;
 extern vmCvar_t g_dedicated;
 extern vmCvar_t g_cheats;
 extern vmCvar_t g_maxclients;			// allow this many total, including spectators
@@ -1427,8 +1428,9 @@ void MapInfoPrint(mapinfo_result_t *info);
 void monster_die (gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, int mod);
 
 /* Neon_Knight: Useful check in order to have code consistency. */
-qboolean G_IsATeamGametype(int check);	/* Whether the gametype is team-based or not.*/
-qboolean G_UsesTeamFlags(int check);	/* Whether the gametype uses the red and blue flags. */
-qboolean G_UsesTheWhiteFlag(int check);	/* Whether the gametype uses the neutral flag. */
-qboolean G_IsARoundBasedGametype(int check);	/* Whether the gametype uses the neutral flag. */
+qboolean G_IsATeamGametype(int gametype, int subgametype);	/* Whether the gametype is team-based or not.*/
+qboolean G_UsesTeamFlags(int gametype, int subgametype);	/* Whether the gametype uses the red and blue flags. */
+qboolean G_UsesTheWhiteFlag(int gametype, int subgametype);	/* Whether the gametype uses the neutral flag. */
+qboolean G_IsARoundBasedGametype(int gametype, int subgametype);	/* Whether the gametype is round-based. */
+qboolean G_SingleGametypeCheck(int gametype, int subgametype, int check);	/* Whether the game takes place in a particular gametype. */
 /* /Neon_Knight */

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1432,5 +1432,5 @@ qboolean G_IsATeamGametype(int gametype, int subgametype);	/* Whether the gamety
 qboolean G_UsesTeamFlags(int gametype, int subgametype);	/* Whether the gametype uses the red and blue flags. */
 qboolean G_UsesTheWhiteFlag(int gametype, int subgametype);	/* Whether the gametype uses the neutral flag. */
 qboolean G_IsARoundBasedGametype(int gametype, int subgametype);	/* Whether the gametype is round-based. */
-qboolean G_SingleGametypeCheck(int gametype, int subgametype, int check);	/* Whether the game takes place in a particular gametype. */
+qboolean G_IsGametype(int gametype, int subgametype, int check);	/* Whether the game takes place in a particular gametype. */
 /* /Neon_Knight */

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -815,10 +815,10 @@ void G_InitGame( int levelTime, int randomSeed, int restart )
 			g_elimination_ctf_oneway.integer = 0;
 			g_elimination_lockspectator.integer = 0;
 		}
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF) ||
-				G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF) ||
-				G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK) ||
-				G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF) ||
+				G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF) ||
+				G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK) ||
+				G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 			g_runes.integer = 1;
 		}
 		else {
@@ -920,7 +920,7 @@ void G_InitGame( int levelTime, int randomSeed, int restart )
 	G_FindTeams();
 
 	// make sure we have flags for CTF, etc
-	if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) && !G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+	if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) && !G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 		G_CheckTeamItems();
 	}
 
@@ -957,10 +957,10 @@ void G_InitGame( int levelTime, int randomSeed, int restart )
 	level.teamSize = 0;
 	level.hadBots = qfalse;
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D))
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D))
 		Team_SpawnDoubleDominationPoints();
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		level.dom_scoreGiven = 0;
 		for(i=0; i<MAX_DOMINATION_POINTS; i++)
 			level.pointStatusDom[i] = TEAM_NONE;
@@ -1481,43 +1481,43 @@ static void SendVictoryChallenge( void )
 	if(level.max_humanplayers < 2 || level.hadBots)
 		return;
 
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_FFA)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_FFA)) {
 		award = GAMETYPES_FFA_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 		award = GAMETYPES_TOURNEY_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 		award = GAMETYPES_TDM_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
 		award = GAMETYPES_CTF_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
 		award = GAMETYPES_1FCTF_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		award = GAMETYPES_HARVESTER_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		award = GAMETYPES_OVERLOAD_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) {
 		award = GAMETYPES_ELIMINATION_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 		award = GAMETYPES_CTF_ELIMINATION_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_LMS)) {
 		award = GAMETYPES_LMS_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		award = GAMETYPES_DD_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		award = GAMETYPES_DOM_WINS;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
 		award = GAMETYPES_POS_WINS;
 	}
 	else {
@@ -2224,7 +2224,7 @@ void CheckExitRules( void )
 
 	if ( g_capturelimit.integer ) {
 		if ( G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) &&
-				!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM) ) {
+				!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM) ) {
 			if ( level.teamScores[TEAM_RED] >= g_capturelimit.integer ) {
 				trap_SendServerCommand( -1, "print \"Red hit the capturelimit.\n\"" );
 				LogExit( "Capturelimit hit." );
@@ -2976,13 +2976,13 @@ qboolean G_IsARoundBasedGametype(int gametype, int subgametype) {
 }
 /*
 ===================
-G_SingleGametypeCheck
+G_IsGametype
 
 Checks if the game takes place in a particular gametype.
 Replaces all direct gametype calls.
 ===================
  */
-qboolean G_SingleGametypeCheck(int gametype, int subgametype, int check) {
+qboolean G_IsGametype(int gametype, int subgametype, int check) {
 	if (gametype != GT_SINGLE_PLAYER && gametype == check) {
 		return qtrue;
 	}

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -794,7 +794,7 @@ void G_InitGame( int levelTime, int randomSeed, int restart )
 			g_cubeTimeout.integer = 30;
 			g_harvesterFromBodies.integer = 30;
 		}
-		if (g_subgametype.integer == GT_ELIMINATION || g_subgametype.integer == GT_CTF_ELIMINATION || g_subgametype.integer == GT_LMS) {
+		if (G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer)) {
 			g_elimination_selfdamage.integer = 0;
 			g_elimination_startHealth.integer = 200;
 			g_elimination_startArmor.integer = 150;
@@ -815,7 +815,10 @@ void G_InitGame( int levelTime, int randomSeed, int restart )
 			g_elimination_ctf_oneway.integer = 0;
 			g_elimination_lockspectator.integer = 0;
 		}
-		if (g_subgametype.integer == GT_CTF || g_subgametype.integer == GT_1FCTF || g_subgametype.integer == GT_HARVESTER || g_subgametype.integer == GT_OBELISK) {
+		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF) ||
+				G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF) ||
+				G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK) ||
+				G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 			g_runes.integer = 1;
 		}
 		else {
@@ -925,11 +928,12 @@ void G_InitGame( int levelTime, int randomSeed, int restart )
 
 	G_Printf ("-----------------------------------\n");
 
-	if((g_gametype.integer == GT_SINGLE_PLAYER && (g_subgametype.integer == GT_FFA ||
-			g_subgametype.integer == GT_TEAM || g_subgametype.integer == GT_TOURNAMENT ||
-			g_subgametype.integer == GT_LMS || g_subgametype.integer == GT_POSSESSION)) ||
-			trap_Cvar_VariableIntegerValue( "com_buildScript" ) ) {
-		G_ModelIndex( SP_PODIUM_MODEL );
+	// The first if is necessary to block everything that isn't SP. And to avoid writing too many comparisons.
+	if (g_gametype.integer == GT_SINGLE_PLAYER) {
+		if(!G_IsATeamGametype(g_gametype.integer,g_subgametype.integer) ||
+				trap_Cvar_VariableIntegerValue( "com_buildScript" )) {
+			G_ModelIndex( SP_PODIUM_MODEL );
+		}
 	}
 
 	if ( trap_Cvar_VariableIntegerValue( "bot_enable" ) ) {

--- a/code/game/g_misc.c
+++ b/code/game/g_misc.c
@@ -572,7 +572,7 @@ int MinSpawnpointCount(void) {
 	if(!G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		return countFfaSpawnpoints();
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		return countDdSpawnpoints();
 	}
 	return countCtfSpawnpoints();

--- a/code/game/g_misc.c
+++ b/code/game/g_misc.c
@@ -569,10 +569,10 @@ static int countCtfSpawnpoints(void) {
 }
 
 int MinSpawnpointCount(void) {
-	if(!G_IsATeamGametype(g_gametype.integer)) {
+	if(!G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		return countFfaSpawnpoints();
 	}
-	if(g_gametype.integer == GT_DOUBLE_D ) {
+	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		return countDdSpawnpoints();
 	}
 	return countCtfSpawnpoints();

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -191,8 +191,8 @@ static void ProximityMine_Activate( gentity_t *ent )
 		}
 	}
 
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER) ||
-			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER) ||
+			G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		switch (ent->s.generic1) {
 		case TEAM_RED:
 			c = "team_redobelisk";

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -142,7 +142,7 @@ void ProximityMine_Trigger( gentity_t *trigger, gentity_t *other, trace_t *trace
 	}
 
 
-	if (G_IsATeamGametype(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		// don't trigger same team mines
 		if (trigger->parent->s.generic1 == other->client->sess.sessionTeam) {
 			return;
@@ -178,7 +178,7 @@ static void ProximityMine_Activate( gentity_t *ent )
 	qboolean        nearFlag = qfalse;
 
 	// find the flag
-	if (G_UsesTeamFlags(g_gametype.integer)) {
+	if (G_UsesTeamFlags(g_gametype.integer,g_subgametype.integer)) {
 		switch (ent->s.generic1) {
 			case TEAM_RED:
 				c = "team_CTF_redflag";
@@ -191,7 +191,8 @@ static void ProximityMine_Activate( gentity_t *ent )
 		}
 	}
 
-	if (g_gametype.integer == GT_HARVESTER || g_gametype.integer == GT_OBELISK) {
+	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER) ||
+			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		switch (ent->s.generic1) {
 		case TEAM_RED:
 			c = "team_redobelisk";

--- a/code/game/g_mover.c
+++ b/code/game/g_mover.c
@@ -1004,7 +1004,7 @@ void SP_func_door (gentity_t *ent)
 		ent->wait = 99999999;
 
 
-	if (G_IsARoundBasedGametype(g_gametype.integer) && G_IsATeamGametype(g_gametype.integer)) {
+	if (G_IsARoundBasedGametype(g_gametype.integer,g_subgametype.integer) && G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		char*	value;
 		//Classic part to make the
 		if ( strequals(ent->targetname, ELIMINATION_ACTIVE_TARGETNAME ) ) {

--- a/code/game/g_rankings.c
+++ b/code/game/g_rankings.c
@@ -105,7 +105,7 @@ void G_RankRunFrame()
 				break;
 			case QGR_STATUS_ACTIVE:
 				if( (ent->client->sess.sessionTeam == TEAM_SPECTATOR || (client->isEliminated)) &&
-					!(G_IsATeamGametype(g_gametype.integer)) )
+					!(G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) )
 				{
 					SetTeam( ent, "free" );
 				}

--- a/code/game/g_session.c
+++ b/code/game/g_session.c
@@ -131,7 +131,7 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
 			// a willing spectator, not a waiting-in-line
 			sess->sessionTeam = TEAM_SPECTATOR;
 		} else {
-			if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
+			if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 				// if the game is full, go into a waiting mode
 				if ( level.numNonSpectatorClients >= 2 ) {
 					sess->sessionTeam = TEAM_SPECTATOR;

--- a/code/game/g_session.c
+++ b/code/game/g_session.c
@@ -118,7 +118,7 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
 	}
 
 	// initial team determination
-	if (G_IsATeamGametype(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		// always spawn as spectator in team games
 		sess->sessionTeam = TEAM_SPECTATOR;
 		sess->spectatorState = SPECTATOR_FREE;
@@ -131,26 +131,20 @@ void G_InitSessionData( gclient_t *client, char *userinfo ) {
 			// a willing spectator, not a waiting-in-line
 			sess->sessionTeam = TEAM_SPECTATOR;
 		} else {
-			switch ( g_gametype.integer ) {
-			default:
-			case GT_FFA:
-			case GT_LMS:
-			case GT_SINGLE_PLAYER:
-				if ( g_maxGameClients.integer > 0 && 
-					level.numNonSpectatorClients >= g_maxGameClients.integer ) {
-					sess->sessionTeam = TEAM_SPECTATOR;
-				} else {
-					sess->sessionTeam = TEAM_FREE;
-				}
-				break;
-			case GT_TOURNAMENT:
+			if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TOURNAMENT)) {
 				// if the game is full, go into a waiting mode
 				if ( level.numNonSpectatorClients >= 2 ) {
 					sess->sessionTeam = TEAM_SPECTATOR;
 				} else {
 					sess->sessionTeam = TEAM_FREE;
 				}
-				break;
+			} else {
+				if ( g_maxGameClients.integer > 0 && 
+					level.numNonSpectatorClients >= g_maxGameClients.integer ) {
+					sess->sessionTeam = TEAM_SPECTATOR;
+				} else {
+					sess->sessionTeam = TEAM_FREE;
+				}
 			}
 		}
 		sess->spectatorState = SPECTATOR_FREE;

--- a/code/game/g_spawn.c
+++ b/code/game/g_spawn.c
@@ -452,7 +452,7 @@ void G_SpawnGEntityFromSpawnVars( void ) {
 		}
 	}
 	// check for "notteam" flag
-	if (G_IsATeamGametype(g_gametype.integer)) {
+	if (G_IsATeamGametype(g_gametype.integer,g_subgametype.integer)) {
 		G_SpawnInt( "notteam", "0", &i );
 		if ( i ) {
 			G_FreeEntity( ent );

--- a/code/game/g_team.c
+++ b/code/game/g_team.c
@@ -54,7 +54,7 @@ void Team_InitGame( void )
 	memset(&teamgame, 0, sizeof teamgame);
 
 	if((G_UsesTeamFlags(g_gametype.integer,g_subgametype.integer) && !G_UsesTheWhiteFlag(g_gametype.integer,g_subgametype.integer)) ||
-			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+			G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		teamgame.redStatus = -1; // Invalid to force update
 		Team_SetFlagStatus( TEAM_RED, FLAG_ATBASE );
 		teamgame.blueStatus = -1; // Invalid to force update
@@ -62,7 +62,7 @@ void Team_InitGame( void )
 		ddA = NULL;
 		ddB = NULL;
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		dominationPointsSpawned = qfalse;
 	}
 	else if (G_UsesTheWhiteFlag(g_gametype.integer,g_subgametype.integer)) {
@@ -174,7 +174,7 @@ void AddTeamScore(vec3_t origin, int team, int score)
 	gentity_t	*te;
 
 
-	if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
+	if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		te = G_TempEntity(origin, EV_GLOBAL_TEAM_SOUND );
 		te->r.svFlags |= SVF_BROADCAST;
 
@@ -277,7 +277,7 @@ void Team_SetFlagStatus( int team, flagStatus_t status )
 			st[1] = ctfFlagStatusRemap[teamgame.blueStatus];
 			st[2] = 0;
 		}
-		else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+		else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 			st[0] = oneFlagStatusRemap[teamgame.redStatus];
 			st[1] = oneFlagStatusRemap[teamgame.blueStatus];
 			st[2] = 0;
@@ -409,16 +409,16 @@ void Team_FragBonuses(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker
 
 	// did the attacker frag the flag carrier?
 	tokens = 0;
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		tokens = targ->client->ps.generic1;
 	}
 	if (targ->client->ps.powerups[enemy_flag_pw]) {
 		attacker->client->pers.teamState.lastfraggedcarrier = level.time;
-		if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
+		if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
 			AddScore(attacker, targ->r.currentOrigin, CTF_FRAG_CARRIER_BONUS);
 		}
 		attacker->client->pers.teamState.fragcarrier++;
-		if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
+		if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
 			PrintMsg(NULL, "%s" S_COLOR_WHITE " fragged %s's flag carrier!\n",
 			         attacker->client->pers.netname, TeamName(team));
 		}
@@ -427,13 +427,13 @@ void Team_FragBonuses(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker
 			         attacker->client->pers.netname);
 			G_LogPrintf("POS: %i %i: %s^7 fragged the carrier\n", attacker->s.number, 2, attacker->client->pers.netname);
 		}
-		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
+		if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
 			G_LogPrintf( "CTF: %i %i %i: %s fragged %s's flag carrier!\n", attacker->client->ps.clientNum, team, 3, attacker->client->pers.netname, TeamName(team) );
 		}
-		else if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+		else if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 			G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s fragged %s's flag carrier!\n", level.roundNumber, attacker->client->ps.clientNum, team, 3, attacker->client->pers.netname, TeamName(team) );
 		}
-		else if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
+		else if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
 			G_LogPrintf( "1fCTF: %i %i %i: %s fragged %s's flag carrier!\n", attacker->client->ps.clientNum, team, 3, attacker->client->pers.netname, TeamName(team) );
 		}
 
@@ -493,7 +493,7 @@ void Team_FragBonuses(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker
 		return;
 	}
 //We place the Double Domination bonus test here! This appears to be the best place to place them.
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		if(attacker->client->sess.sessionTeam == level.pointStatusA ) { //Attack must defend point A
 			//See how close attacker and target was to Point A:
 			VectorSubtract(targ->r.currentOrigin, ddA->r.currentOrigin, v1);
@@ -572,7 +572,7 @@ void Team_FragBonuses(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker
 
 	// we have to find the flag and carrier entities
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		// find the team obelisk
 		switch (attacker->client->sess.sessionTeam) {
 		case TEAM_RED:
@@ -586,7 +586,7 @@ void Team_FragBonuses(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker
 		}
 
 	}
-	else if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	else if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		// find the center obelisk
 		c = "team_neutralobelisk";
 	}
@@ -630,8 +630,8 @@ void Team_FragBonuses(gentity_t *targ, gentity_t *inflictor, gentity_t *attacker
 	        ( VectorLength(v2) < CTF_TARGET_PROTECT_RADIUS &&
 	          trap_InPVS(flag->r.currentOrigin, attacker->r.currentOrigin ) ) ) &&
 	        attacker->client->sess.sessionTeam != targ->client->sess.sessionTeam &&
-			!(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) &&
-	        (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) || !g_elimination_ctf_oneway.integer ||
+			!(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) &&
+	        (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION) || !g_elimination_ctf_oneway.integer ||
 	         ((level.eliminationSides+level.roundNumber)%2 == 0 && attacker->client->sess.sessionTeam == TEAM_BLUE ) ||
 	         ((level.eliminationSides+level.roundNumber)%2 == 1 && attacker->client->sess.sessionTeam == TEAM_RED ) ) ) {
 
@@ -700,7 +700,7 @@ void Team_CheckHurtCarrier(gentity_t *targ, gentity_t *attacker)
 		flag_pw = PW_REDFLAG;
 	}
 
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
 		flag_pw = PW_NEUTRALFLAG;
 	}
 
@@ -965,7 +965,7 @@ void Team_ReturnFlagSound( gentity_t *ent, int team )
 	//See if we are during CTF_ELIMINATION warmup
 	if((level.time <= level.roundStartTime &&
 			level.time > level.roundStartTime - 1000 * g_elimination_activewarmup.integer) &&
-			G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+			G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 		return;
 	}
 
@@ -994,7 +994,7 @@ void Team_TakeFlagSound( gentity_t *ent, int team )
 	case TEAM_RED:
 		if( teamgame.blueStatus != FLAG_ATBASE ) {
 			if (teamgame.blueTakenTime > level.time - 10000 &&
-					G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION))
+					G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION))
 				return;
 		}
 		teamgame.blueTakenTime = level.time;
@@ -1002,7 +1002,7 @@ void Team_TakeFlagSound( gentity_t *ent, int team )
 
 	case TEAM_BLUE:	// CTF
 		if( teamgame.redStatus != FLAG_ATBASE ) {
-			if (teamgame.redTakenTime > level.time - 10000 && !G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION))
+			if (teamgame.redTakenTime > level.time - 10000 && !G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION))
 				return;
 		}
 		teamgame.redTakenTime = level.time;
@@ -1043,16 +1043,16 @@ void Team_ReturnFlag( int team )
 	Team_ReturnFlagSound(Team_ResetFlag(team), team);
 	if( team == TEAM_FREE ) {
 		PrintMsg(NULL, "The flag has returned!\n" );
-		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
+		if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
 			G_LogPrintf( "1FCTF: %i %i %i: The flag was returned!\n", -1, -1, 2 );
 		}
 	}
 	else {
 		PrintMsg(NULL, "The %s flag has returned!\n", TeamName(team));
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
 			G_LogPrintf( "CTF: %i %i %i: The %s flag was returned!\n", -1, team, 2, TeamName(team) );
 		}
-		else if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+		else if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 			G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: The %s flag was returned!\n", level.roundNumber, -1, team, 2, TeamName(team) );
 		}
 	}
@@ -1278,10 +1278,10 @@ int Team_TouchOurFlag( gentity_t *ent, gentity_t *other, int team )
 			PrintMsg( NULL, "%s" S_COLOR_WHITE " returned the %s flag!\n",
 			          cl->pers.netname, TeamName(team));
 			AddScore(other, ent->r.currentOrigin, CTF_RECOVERY_BONUS);
-			if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
+			if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
 				G_LogPrintf( "CTF: %i %i %i: %s returned the %s flag!\n", cl->ps.clientNum, team, 2, cl->pers.netname, TeamName(team) );
 			}
-			else if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+			else if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 				G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s returned the %s flag!\n", level.roundNumber, cl->ps.clientNum, team, 2, cl->pers.netname, TeamName(team) );
 			}
 			other->client->pers.teamState.flagrecovery++;
@@ -1297,16 +1297,16 @@ int Team_TouchOurFlag( gentity_t *ent, gentity_t *other, int team )
 	if (!cl->ps.powerups[enemy_flag]) {
 		return 0; // We don't have the flag
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
 		PrintMsg( NULL, "%s" S_COLOR_WHITE " captured the flag!\n", cl->pers.netname );
 		G_LogPrintf( "1FCTF: %i %i %i: %s captured the flag!\n", cl->ps.clientNum, -1, 1, cl->pers.netname );
 	}
 	else {
 		PrintMsg( NULL, "%s" S_COLOR_WHITE " captured the %s flag!\n", cl->pers.netname, TeamName(OtherTeam(team)));
-		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
+		if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
 			G_LogPrintf( "CTF: %i %i %i: %s captured the %s flag!\n", cl->ps.clientNum, OtherTeam(team), 1, cl->pers.netname, TeamName(OtherTeam(team)) );
 		}
-		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+		if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 			G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s captured the %s flag!\n", level.roundNumber, cl->ps.clientNum, OtherTeam(team), 1, cl->pers.netname, TeamName(OtherTeam(team)) );
 		}
 	}
@@ -1320,7 +1320,7 @@ int Team_TouchOurFlag( gentity_t *ent, gentity_t *other, int team )
 	AddTeamScore(ent->s.pos.trBase, other->client->sess.sessionTeam, 1);
 	Team_ForceGesture(other->client->sess.sessionTeam);
 	//If CTF Elimination, stop the round:
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 		EndEliminationRound();
 	}
 
@@ -1397,7 +1397,7 @@ int Team_TouchEnemyFlag( gentity_t *ent, gentity_t *other, int team )
 {
 	gclient_t *cl = other->client;
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
 		PrintMsg (NULL, "%s" S_COLOR_WHITE " got the flag!\n", other->client->pers.netname );
 		G_LogPrintf( "1FCTF: %i %i %i: %s got the flag!\n", cl->ps.clientNum, team, 0, cl->pers.netname);
 
@@ -1414,10 +1414,10 @@ int Team_TouchEnemyFlag( gentity_t *ent, gentity_t *other, int team )
 		PrintMsg (NULL, "%s" S_COLOR_WHITE " got the %s flag!\n",
 		          other->client->pers.netname, TeamName(team));
 
-		if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
+		if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF)) {
 			G_LogPrintf( "CTF: %i %i %i: %s got the %s flag!\n", cl->ps.clientNum, team, 0, cl->pers.netname, TeamName(team));
 		}
-		else if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
+		else if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_CTF_ELIMINATION)) {
 			G_LogPrintf( "CTF_ELIMINATION: %i %i %i %i: %s got the %s flag!\n", level.roundNumber, cl->ps.clientNum, team, 0, cl->pers.netname, TeamName(team));
 		}
 
@@ -1443,13 +1443,13 @@ int Pickup_Team( gentity_t *ent, gentity_t *other )
 	int team;
 	gclient_t *cl = other->client;
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		// there are no team items that can be picked up in obelisk
 		G_FreeEntity( ent );
 		return 0;
 	}
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		// the only team items that can be picked up in harvester are the cubes
 		if( ent->spawnflags != cl->sess.sessionTeam ) {
 			cl->ps.generic1 += 1; //Skull pickedup
@@ -1465,7 +1465,7 @@ int Pickup_Team( gentity_t *ent, gentity_t *other )
 		G_FreeEntity( ent ); //Destory skull
 		return 0;
 	}
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOMINATION)) {
 		Team_Dom_TakePoint(ent, cl->sess.sessionTeam,cl->ps.clientNum);
 		return 0;
 	}
@@ -1483,10 +1483,10 @@ int Pickup_Team( gentity_t *ent, gentity_t *other )
 		PrintMsg ( other, "Don't know what team the flag is on.\n");
 		return 0;
 	}
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_POSSESSION)) {
 		return Possession_TouchFlag( other );
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_1FCTF)) {
 		if( team == TEAM_FREE ) {
 			return Team_TouchEnemyFlag( ent, other, cl->sess.sessionTeam );
 		}
@@ -1495,7 +1495,7 @@ int Pickup_Team( gentity_t *ent, gentity_t *other )
 		}
 		return 0;
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_DOUBLE_D)) {
 		return Team_TouchDoubleDominationPoint( ent, other, team );
 	}
 	// GT_CTF
@@ -1631,7 +1631,7 @@ gentity_t *SelectRandomTeamSpawnPoint( int teamstate, team_t team )
 	gentity_t	*spots[MAX_TEAM_SPAWN_POINTS];
 	char		*classname;
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) { //change sides every round
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_ELIMINATION)) { //change sides every round
 		if((level.roundNumber+level.eliminationSides)%2==1) {
 			if(team == TEAM_RED) {
 				team = TEAM_BLUE;
@@ -2230,7 +2230,7 @@ static gentity_t *SpawnObelisk( vec3_t origin, vec3_t mins, vec3_t maxs, int tea
 	ent->s.eType = ET_GENERAL;
 	ent->flags = FL_NO_KNOCKBACK;
 
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		ent->r.contents = CONTENTS_SOLID;
 		ent->takedamage = qtrue;
 		ent->health = g_obeliskHealth.integer;
@@ -2239,7 +2239,7 @@ static gentity_t *SpawnObelisk( vec3_t origin, vec3_t mins, vec3_t maxs, int tea
 		ent->think = ObeliskRegen;
 		ent->nextthink = level.time + g_obeliskRegenPeriod.integer * 1000;
 	}
-	if(G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	if(G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		ent->r.contents = CONTENTS_TRIGGER;
 		ent->touch = ObeliskTouch;
 	}
@@ -2296,20 +2296,20 @@ void SP_team_redobelisk( gentity_t *ent )
 {
 	gentity_t *obelisk;
 
-	if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER) &&
-			!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER) &&
+			!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		G_FreeEntity(ent);
 		return;
 	}
 	ObeliskInit( ent );
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		obelisk = SpawnObelisk( ent->s.origin, ent->r.mins, ent->r.maxs, TEAM_RED );
 		obelisk->activator = ent;
 		// initial obelisk health value
 		ent->s.modelindex2 = 0xff;
 		ent->s.frame = 0;
 	}
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		obelisk = SpawnObelisk( ent->s.origin, ent->r.mins, ent->r.maxs, TEAM_RED );
 		obelisk->activator = ent;
 	}
@@ -2323,20 +2323,20 @@ void SP_team_blueobelisk( gentity_t *ent )
 {
 	gentity_t *obelisk;
 
-	if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER) &&
-			!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER) &&
+			!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		G_FreeEntity(ent);
 		return;
 	}
 	ObeliskInit( ent );
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_OBELISK)) {
 		obelisk = SpawnObelisk( ent->s.origin, ent->r.mins, ent->r.maxs, TEAM_BLUE );
 		obelisk->activator = ent;
 		// initial obelisk health value
 		ent->s.modelindex2 = 0xff;
 		ent->s.frame = 0;
 	}
-	if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		obelisk = SpawnObelisk( ent->s.origin, ent->r.mins, ent->r.maxs, TEAM_BLUE );
 		obelisk->activator = ent;
 	}
@@ -2348,7 +2348,7 @@ void SP_team_blueobelisk( gentity_t *ent )
 */
 void SP_team_neutralobelisk( gentity_t *ent )
 {
-	if (!G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
+	if (!G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_HARVESTER)) {
 		G_FreeEntity(ent);
 		return;
 	}

--- a/code/game/g_weapon.c
+++ b/code/game/g_weapon.c
@@ -969,7 +969,7 @@ void FireWeapon( gentity_t *ent )
 		weapon_supershotgun_fire( ent );
 		break;
 	case WP_MACHINEGUN:
-		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
+		if (G_IsGametype(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			Bullet_Fire( ent, MACHINEGUN_SPREAD, MACHINEGUN_DAMAGE );
 		}
 		else {

--- a/code/game/g_weapon.c
+++ b/code/game/g_weapon.c
@@ -969,7 +969,7 @@ void FireWeapon( gentity_t *ent )
 		weapon_supershotgun_fire( ent );
 		break;
 	case WP_MACHINEGUN:
-		if ( g_gametype.integer != GT_TEAM ) {
+		if (G_SingleGametypeCheck(g_gametype.integer,g_subgametype.integer,GT_TEAM)) {
 			Bullet_Fire( ent, MACHINEGUN_SPREAD, MACHINEGUN_DAMAGE );
 		}
 		else {

--- a/code/q3_ui/ui_addbots.c
+++ b/code/q3_ui/ui_addbots.c
@@ -259,11 +259,13 @@ static void UI_AddBotsMenu_Init( void ) {
 	int		n;
 	int		y;
 	int		gametype;
+	int		subgametype;
 	int		count;
 	char	info[MAX_INFO_STRING];
 
 	trap_GetConfigString(CS_SERVERINFO, info, MAX_INFO_STRING);   
 	gametype = atoi( Info_ValueForKey( info,"g_gametype" ) );
+	subgametype = atoi( Info_ValueForKey( info,"g_subgametype" ) );
 
 	memset( &addBotsMenuInfo, 0 ,sizeof(addBotsMenuInfo) );
 	addBotsMenuInfo.menu.draw = UI_AddBotsMenu_Draw;
@@ -333,7 +335,7 @@ static void UI_AddBotsMenu_Init( void ) {
 	addBotsMenuInfo.team.generic.y			= y;
 	addBotsMenuInfo.team.generic.name		= "Team: ";
 	addBotsMenuInfo.team.generic.id			= ID_TEAM;
-	if(UI_IsATeamGametype(gametype)) {
+	if(UI_IsATeamGametype(gametype,subgametype)) {
 		addBotsMenuInfo.team.itemnames		= teamNames2;
 	}
 	else {

--- a/code/q3_ui/ui_ingame.c
+++ b/code/q3_ui/ui_ingame.c
@@ -238,7 +238,7 @@ void InGame_MenuInit( void ) {
 	s_ingame.teamorders.string				= "TEAM ORDERS";
 	s_ingame.teamorders.color				= color_red;
 	s_ingame.teamorders.style				= UI_CENTER|UI_SMALLFONT;
-	if(!UI_SP_IsATeamGametype(gametype,subgametype)) {
+	if(!UI_IsATeamGametype(gametype,subgametype)) {
 		s_ingame.teamorders.generic.flags |= QMF_GRAYED;
 	}
 	else {

--- a/code/q3_ui/ui_ingame.c
+++ b/code/q3_ui/ui_ingame.c
@@ -168,12 +168,14 @@ void InGame_MenuInit( void ) {
 	char	info[MAX_INFO_STRING];
 	int		team;
 	int		gametype;
+	int		subgametype;
 
 	memset( &s_ingame, 0 ,sizeof(ingamemenu_t) );
 
 	InGame_Cache();
 	
 	gametype = trap_Cvar_VariableValue("g_gametype");
+	subgametype = trap_Cvar_VariableValue("g_subgametype");
 
 	s_ingame.menu.wrapAround = qtrue;
 	s_ingame.menu.fullscreen = qfalse;
@@ -236,7 +238,7 @@ void InGame_MenuInit( void ) {
 	s_ingame.teamorders.string				= "TEAM ORDERS";
 	s_ingame.teamorders.color				= color_red;
 	s_ingame.teamorders.style				= UI_CENTER|UI_SMALLFONT;
-	if(!UI_IsATeamGametype(gametype)) {
+	if(!UI_SP_IsATeamGametype(gametype,subgametype)) {
 		s_ingame.teamorders.generic.flags |= QMF_GRAYED;
 	}
 	else {

--- a/code/q3_ui/ui_local.h
+++ b/code/q3_ui/ui_local.h
@@ -904,5 +904,5 @@ qboolean UI_IsATeamGametype(int gametype, int subgametype);	/* SP: Whether the g
 qboolean UI_UsesTeamFlags(int gametype, int subgametype);	/* SP: Whether the gametype uses the red and blue flags. */
 qboolean UI_UsesTheWhiteFlag(int gametype, int subgametype);	/* SP: Whether the gametype uses the neutral flag. */
 qboolean UI_IsARoundBasedGametype(int gametype, int subgametype);	/* SP: Whether the gametype is round-based. */
-qboolean UI_SingleGametypeCheck(int gametype, int subgametype, int check);	/* SP: Whether the game takes place in a particular gametype. */
+qboolean UI_IsGametype(int gametype, int subgametype, int check);	/* SP: Whether the game takes place in a particular gametype. */
 /* /Neon_Knight */

--- a/code/q3_ui/ui_local.h
+++ b/code/q3_ui/ui_local.h
@@ -900,13 +900,9 @@ void UI_RankStatusMenu( void );
 #endif
 
 /* Neon_Knight: Useful check in order to have code consistency. */
-qboolean UI_SP_IsATeamGametype(int gametype, int subgametype);	/* SP: Whether the gametype is team-based or not.*/
-qboolean UI_SP_UsesTeamFlags(int gametype, int subgametype);	/* SP: Whether the gametype uses the red and blue flags. */
-qboolean UI_SP_UsesTheWhiteFlag(int gametype, int subgametype);	/* SP: Whether the gametype uses the neutral flag. */
-qboolean UI_SP_IsARoundBasedGametype(int gametype, int subgametype);	/* SP: Whether the gametype is round-based. */
-qboolean UI_SP_SingleGametypeCheck(int gametype, int subgametype, int check);	/* SP: Whether the game takes place in a particular gametype. */
-qboolean UI_IsATeamGametype(int gametype);	/* MP: Whether the gametype is team-based or not.*/
-qboolean UI_UsesTeamFlags(int gametype);	/* MP: Whether the gametype uses the red and blue flags. */
-qboolean UI_UsesTheWhiteFlag(int gametype);	/* MP: Whether the gametype uses the neutral flag. */
-qboolean UI_IsARoundBasedGametype(int gametype);	/* MP: Whether the gametype is round-based. */
+qboolean UI_IsATeamGametype(int gametype, int subgametype);	/* SP: Whether the gametype is team-based or not.*/
+qboolean UI_UsesTeamFlags(int gametype, int subgametype);	/* SP: Whether the gametype uses the red and blue flags. */
+qboolean UI_UsesTheWhiteFlag(int gametype, int subgametype);	/* SP: Whether the gametype uses the neutral flag. */
+qboolean UI_IsARoundBasedGametype(int gametype, int subgametype);	/* SP: Whether the gametype is round-based. */
+qboolean UI_SingleGametypeCheck(int gametype, int subgametype, int check);	/* SP: Whether the game takes place in a particular gametype. */
 /* /Neon_Knight */

--- a/code/q3_ui/ui_local.h
+++ b/code/q3_ui/ui_local.h
@@ -900,8 +900,13 @@ void UI_RankStatusMenu( void );
 #endif
 
 /* Neon_Knight: Useful check in order to have code consistency. */
-qboolean UI_IsATeamGametype(int check);	/* Whether the gametype is team-based or not.*/
-qboolean UI_UsesTeamFlags(int check);	/* Whether the gametype uses the red and blue flags. */
-qboolean UI_UsesTheWhiteFlag(int check);	/* Whether the gametype uses the neutral flag. */
-qboolean UI_IsARoundBasedGametype(int check);	/* Whether the gametype uses the neutral flag. */
+qboolean UI_SP_IsATeamGametype(int gametype, int subgametype);	/* SP: Whether the gametype is team-based or not.*/
+qboolean UI_SP_UsesTeamFlags(int gametype, int subgametype);	/* SP: Whether the gametype uses the red and blue flags. */
+qboolean UI_SP_UsesTheWhiteFlag(int gametype, int subgametype);	/* SP: Whether the gametype uses the neutral flag. */
+qboolean UI_SP_IsARoundBasedGametype(int gametype, int subgametype);	/* SP: Whether the gametype is round-based. */
+qboolean UI_SP_SingleGametypeCheck(int gametype, int subgametype, int check);	/* SP: Whether the game takes place in a particular gametype. */
+qboolean UI_IsATeamGametype(int gametype);	/* MP: Whether the gametype is team-based or not.*/
+qboolean UI_UsesTeamFlags(int gametype);	/* MP: Whether the gametype uses the red and blue flags. */
+qboolean UI_UsesTheWhiteFlag(int gametype);	/* MP: Whether the gametype uses the neutral flag. */
+qboolean UI_IsARoundBasedGametype(int gametype);	/* MP: Whether the gametype is round-based. */
 /* /Neon_Knight */

--- a/code/q3_ui/ui_main.c
+++ b/code/q3_ui/ui_main.c
@@ -319,12 +319,12 @@ void UI_SetDefaultCvar(const char* cvar, const char* value) {
 /* Neon_Knight: Useful check in order to have code consistency. */
 /*
 ===================
-UI_SP_IsATeamGametype
+UI_IsATeamGametype
 
 Checks if the gametype is a team-based game.
 ===================
  */
-qboolean UI_SP_IsATeamGametype(int gametype, int subgametype) {
+qboolean UI_IsATeamGametype(int gametype, int subgametype) {
 	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_IS_A_TEAM_GAME(gametype)) {
 		return qtrue;
 	}
@@ -335,12 +335,12 @@ qboolean UI_SP_IsATeamGametype(int gametype, int subgametype) {
 }
 /*
 ===================
-UI_SP_UsesTeamFlags
+UI_UsesTeamFlags
 
 Checks if the gametype makes use of the red and blue flags.
 ===================
  */
-qboolean UI_SP_UsesTeamFlags(int gametype, int subgametype) {
+qboolean UI_UsesTeamFlags(int gametype, int subgametype) {
 	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_USES_RED_AND_BLUE_FLAG(gametype)) {
 		return qtrue;
 	}
@@ -351,12 +351,12 @@ qboolean UI_SP_UsesTeamFlags(int gametype, int subgametype) {
 }
 /*
 ===================
-UI_SP_UsesTheWhiteFlag
+UI_UsesTheWhiteFlag
 
 Checks if the gametype makes use of the neutral flag.
 ===================
  */
-qboolean UI_SP_UsesTheWhiteFlag(int gametype, int subgametype) {
+qboolean UI_UsesTheWhiteFlag(int gametype, int subgametype) {
 	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_USES_WHITE_FLAG(gametype)) {
 		return qtrue;
 	}
@@ -367,12 +367,12 @@ qboolean UI_SP_UsesTheWhiteFlag(int gametype, int subgametype) {
 }
 /*
 ===================
-UI_SP_IsARoundBasedGametype
+UI_IsARoundBasedGametype
 
 Checks if the gametype has a round-based system.
 ===================
  */
-qboolean UI_SP_IsARoundBasedGametype(int gametype, int subgametype) {
+qboolean UI_IsARoundBasedGametype(int gametype, int subgametype) {
 	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_IS_ROUND_BASED(gametype)) {
 		return qtrue;
 	}
@@ -383,13 +383,13 @@ qboolean UI_SP_IsARoundBasedGametype(int gametype, int subgametype) {
 }
 /*
 ===================
-UI_SP_SingleGametypeCheck
+UI_SingleGametypeCheck
 
 Checks if the game takes place in a particular gametype.
 Replaces all direct gametype calls.
 ===================
  */
-qboolean UI_SP_SingleGametypeCheck(int gametype, int subgametype, int check) {
+qboolean UI_SingleGametypeCheck(int gametype, int subgametype, int check) {
 	if (gametype != GT_SINGLE_PLAYER && gametype == check) {
 		return qtrue;
 	}
@@ -397,45 +397,5 @@ qboolean UI_SP_SingleGametypeCheck(int gametype, int subgametype, int check) {
 		return qtrue;
 	}
 	return qfalse;
-}
-/*
-===================
-UI_IsATeamGametype
-
-Checks if the gametype is a team-based game.
-===================
- */
-qboolean UI_IsATeamGametype(int gametype) {
-	return GAMETYPE_IS_A_TEAM_GAME(gametype);
-}
-/*
-===================
-UI_UsesTeamFlags
-
-Checks if the gametype makes use of the red and blue flags.
-===================
- */
-qboolean UI_UsesTeamFlags(int gametype) {
-	return GAMETYPE_USES_RED_AND_BLUE_FLAG(gametype);
-}
-/*
-===================
-UI_UsesTheWhiteFlag
-
-Checks if the gametype makes use of the neutral flag.
-===================
- */
-qboolean UI_UsesTheWhiteFlag(int gametype) {
-	return GAMETYPE_USES_WHITE_FLAG(gametype);
-}
-/*
-===================
-UI_IsARoundBasedGametype
-
-Checks if the gametype has a round-based system.
-===================
- */
-qboolean UI_IsARoundBasedGametype(int gametype) {
-	return GAMETYPE_IS_ROUND_BASED(gametype);
 }
 /* /Neon_Knight */

--- a/code/q3_ui/ui_main.c
+++ b/code/q3_ui/ui_main.c
@@ -383,13 +383,13 @@ qboolean UI_IsARoundBasedGametype(int gametype, int subgametype) {
 }
 /*
 ===================
-UI_SingleGametypeCheck
+UI_IsGametype
 
 Checks if the game takes place in a particular gametype.
 Replaces all direct gametype calls.
 ===================
  */
-qboolean UI_SingleGametypeCheck(int gametype, int subgametype, int check) {
+qboolean UI_IsGametype(int gametype, int subgametype, int check) {
 	if (gametype != GT_SINGLE_PLAYER && gametype == check) {
 		return qtrue;
 	}

--- a/code/q3_ui/ui_main.c
+++ b/code/q3_ui/ui_main.c
@@ -319,13 +319,94 @@ void UI_SetDefaultCvar(const char* cvar, const char* value) {
 /* Neon_Knight: Useful check in order to have code consistency. */
 /*
 ===================
+UI_SP_IsATeamGametype
+
+Checks if the gametype is a team-based game.
+===================
+ */
+qboolean UI_SP_IsATeamGametype(int gametype, int subgametype) {
+	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_IS_A_TEAM_GAME(gametype)) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && GAMETYPE_IS_A_TEAM_GAME(subgametype)) {
+		return qtrue;
+	}
+	return qfalse;
+}
+/*
+===================
+UI_SP_UsesTeamFlags
+
+Checks if the gametype makes use of the red and blue flags.
+===================
+ */
+qboolean UI_SP_UsesTeamFlags(int gametype, int subgametype) {
+	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_USES_RED_AND_BLUE_FLAG(gametype)) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && GAMETYPE_USES_RED_AND_BLUE_FLAG(subgametype)) {
+		return qtrue;
+	}
+	return qfalse;
+}
+/*
+===================
+UI_SP_UsesTheWhiteFlag
+
+Checks if the gametype makes use of the neutral flag.
+===================
+ */
+qboolean UI_SP_UsesTheWhiteFlag(int gametype, int subgametype) {
+	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_USES_WHITE_FLAG(gametype)) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && GAMETYPE_USES_WHITE_FLAG(subgametype)) {
+		return qtrue;
+	}
+	return qfalse;
+}
+/*
+===================
+UI_SP_IsARoundBasedGametype
+
+Checks if the gametype has a round-based system.
+===================
+ */
+qboolean UI_SP_IsARoundBasedGametype(int gametype, int subgametype) {
+	if (gametype != GT_SINGLE_PLAYER && GAMETYPE_IS_ROUND_BASED(gametype)) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && GAMETYPE_IS_ROUND_BASED(subgametype)) {
+		return qtrue;
+	}
+	return qfalse;
+}
+/*
+===================
+UI_SP_SingleGametypeCheck
+
+Checks if the game takes place in a particular gametype.
+Replaces all direct gametype calls.
+===================
+ */
+qboolean UI_SP_SingleGametypeCheck(int gametype, int subgametype, int check) {
+	if (gametype != GT_SINGLE_PLAYER && gametype == check) {
+		return qtrue;
+	}
+	else if (gametype == GT_SINGLE_PLAYER && subgametype != GT_SINGLE_PLAYER && subgametype == check) {
+		return qtrue;
+	}
+	return qfalse;
+}
+/*
+===================
 UI_IsATeamGametype
 
 Checks if the gametype is a team-based game.
 ===================
  */
-qboolean UI_IsATeamGametype(int check) {
-	return GAMETYPE_IS_A_TEAM_GAME(check);
+qboolean UI_IsATeamGametype(int gametype) {
+	return GAMETYPE_IS_A_TEAM_GAME(gametype);
 }
 /*
 ===================
@@ -334,8 +415,8 @@ UI_UsesTeamFlags
 Checks if the gametype makes use of the red and blue flags.
 ===================
  */
-qboolean UI_UsesTeamFlags(int check) {
-	return GAMETYPE_USES_RED_AND_BLUE_FLAG(check);
+qboolean UI_UsesTeamFlags(int gametype) {
+	return GAMETYPE_USES_RED_AND_BLUE_FLAG(gametype);
 }
 /*
 ===================
@@ -344,8 +425,8 @@ UI_UsesTheWhiteFlag
 Checks if the gametype makes use of the neutral flag.
 ===================
  */
-qboolean UI_UsesTheWhiteFlag(int check) {
-	return GAMETYPE_USES_WHITE_FLAG(check);
+qboolean UI_UsesTheWhiteFlag(int gametype) {
+	return GAMETYPE_USES_WHITE_FLAG(gametype);
 }
 /*
 ===================
@@ -354,7 +435,7 @@ UI_IsARoundBasedGametype
 Checks if the gametype has a round-based system.
 ===================
  */
-qboolean UI_IsARoundBasedGametype(int check) {
-	return GAMETYPE_IS_ROUND_BASED(check);
+qboolean UI_IsARoundBasedGametype(int gametype) {
+	return GAMETYPE_IS_ROUND_BASED(gametype);
 }
 /* /Neon_Knight */

--- a/code/q3_ui/ui_startserver.c
+++ b/code/q3_ui/ui_startserver.c
@@ -1349,7 +1349,7 @@ static void ServerOptions_InitBotNames( void ) {
 		Q_strncpyz( s_serveroptions.playerNameBuffers[1], "gargoyle", 16 );
 		Q_strncpyz( s_serveroptions.playerNameBuffers[2], "kyonshi", 16 );
 		Q_strncpyz( s_serveroptions.playerNameBuffers[3], "grism", 16 );
-		if( !UI_SingleGametypeCheck(s_serveroptions.gametype,s_serveroptions.subgametype,GT_TEAM) && mapinfo.minTeamSize < 4 ) {
+		if( !UI_IsGametype(s_serveroptions.gametype,s_serveroptions.subgametype,GT_TEAM) && mapinfo.minTeamSize < 4 ) {
 			s_serveroptions.playerType[3].curvalue = 2;
 		}
 		Q_strncpyz( s_serveroptions.playerNameBuffers[4], "merman", 16 );
@@ -1362,7 +1362,7 @@ static void ServerOptions_InitBotNames( void ) {
 		Q_strncpyz( s_serveroptions.playerNameBuffers[7], "assassin", 16 );
 		Q_strncpyz( s_serveroptions.playerNameBuffers[8], "grunt", 16 );
 		Q_strncpyz( s_serveroptions.playerNameBuffers[9], "skelebot", 16 );
-		if( !UI_SingleGametypeCheck(s_serveroptions.gametype,s_serveroptions.subgametype,GT_TEAM) && mapinfo.minTeamSize < 4 ) {
+		if( !UI_IsGametype(s_serveroptions.gametype,s_serveroptions.subgametype,GT_TEAM) && mapinfo.minTeamSize < 4 ) {
 			s_serveroptions.playerType[9].curvalue = 2;
 		}
 		else {
@@ -1672,7 +1672,7 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 		s_serveroptions.fraglimit.field.widthInChars = 3;
 		s_serveroptions.fraglimit.field.maxchars     = 3;
 	}
-	else if (UI_SingleGametypeCheck(s_serveroptions.gametype,s_serveroptions.subgametype,GT_POSSESSION)) {
+	else if (UI_IsGametype(s_serveroptions.gametype,s_serveroptions.subgametype,GT_POSSESSION)) {
 		s_serveroptions.fraglimit.generic.type       = MTYPE_FIELD;
 		s_serveroptions.fraglimit.generic.name       = "Seconds to win:";
 		s_serveroptions.fraglimit.generic.flags      = QMF_NUMBERSONLY|QMF_PULSEIFFOCUS|QMF_SMALLFONT;
@@ -1713,7 +1713,7 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 		s_serveroptions.friendlyfire.generic.name	  = "Friendly Fire:";
 	}
 
-	if(UI_SingleGametypeCheck(s_serveroptions.gametype,s_serveroptions.subgametype,GT_CTF_ELIMINATION)) {
+	if(UI_IsGametype(s_serveroptions.gametype,s_serveroptions.subgametype,GT_CTF_ELIMINATION)) {
 		y += BIGCHAR_HEIGHT+2;
 		s_serveroptions.oneway.generic.type			= MTYPE_RADIOBUTTON;
 		s_serveroptions.oneway.generic.flags			= QMF_PULSEIFFOCUS|QMF_SMALLFONT;
@@ -1749,7 +1749,7 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 	s_serveroptions.rockets.generic.name			= "All rockets:";
 	s_serveroptions.rockets.generic.statusbar  = ServerOptions_StatusBar_Allrockets;
 
-	if(UI_SingleGametypeCheck(s_serveroptions.gametype,s_serveroptions.subgametype,GT_LMS)) {
+	if(UI_IsGametype(s_serveroptions.gametype,s_serveroptions.subgametype,GT_LMS)) {
 		y += BIGCHAR_HEIGHT+2;
 		s_serveroptions.lmsMode.generic.type			= MTYPE_SPINCONTROL;
 		s_serveroptions.lmsMode.generic.flags			= QMF_PULSEIFFOCUS|QMF_SMALLFONT;
@@ -1901,10 +1901,10 @@ static void ServerOptions_MenuInit( qboolean multiplayer ) {
 	Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.pure );
 	Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.instantgib );
 	Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.rockets );
-	if(UI_SingleGametypeCheck(s_serveroptions.gametype,s_serveroptions.subgametype,GT_LMS)) {
+	if(UI_IsGametype(s_serveroptions.gametype,s_serveroptions.subgametype,GT_LMS)) {
 		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.lmsMode );
 	}
-	if(UI_SingleGametypeCheck(s_serveroptions.gametype,s_serveroptions.subgametype,GT_CTF_ELIMINATION)) {
+	if(UI_IsGametype(s_serveroptions.gametype,s_serveroptions.subgametype,GT_CTF_ELIMINATION)) {
 		Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.oneway );
 	}
 	Menu_AddItem( &s_serveroptions.menu, &s_serveroptions.pmove );

--- a/code/q3_ui/ui_team.c
+++ b/code/q3_ui/ui_team.c
@@ -168,7 +168,11 @@ void TeamMain_MenuInit( void ) {
 	subgametype = atoi( Info_ValueForKey( info,"g_subgametype" ) );
 			      
 	// set initial states
+<<<<<<< HEAD
 	if(UI_SP_IsATeamGametype(gametype,subgametype)) {
+=======
+	if(UI_IsATeamGametype(gametype,subgametype)) {
+>>>>>>> GT_SINGLE_PLAYER subgametype support: allows classic UI to play SP missions in gametypes other than FFA.
 		s_teammain.joingame.string = "AUTO JOIN GAME";
 	} else {
 		s_teammain.joinred.generic.flags  |= QMF_GRAYED;

--- a/code/q3_ui/ui_team.c
+++ b/code/q3_ui/ui_team.c
@@ -168,11 +168,7 @@ void TeamMain_MenuInit( void ) {
 	subgametype = atoi( Info_ValueForKey( info,"g_subgametype" ) );
 			      
 	// set initial states
-<<<<<<< HEAD
-	if(UI_SP_IsATeamGametype(gametype,subgametype)) {
-=======
 	if(UI_IsATeamGametype(gametype,subgametype)) {
->>>>>>> GT_SINGLE_PLAYER subgametype support: allows classic UI to play SP missions in gametypes other than FFA.
 		s_teammain.joingame.string = "AUTO JOIN GAME";
 	} else {
 		s_teammain.joinred.generic.flags  |= QMF_GRAYED;

--- a/code/q3_ui/ui_team.c
+++ b/code/q3_ui/ui_team.c
@@ -99,6 +99,7 @@ TeamMain_MenuInit
 void TeamMain_MenuInit( void ) {
 	int		y;
 	int		gametype;
+	int		subgametype;
 	char	info[MAX_INFO_STRING];
 
 	memset( &s_teammain, 0, sizeof(s_teammain) );
@@ -164,30 +165,14 @@ void TeamMain_MenuInit( void ) {
 
 	trap_GetConfigString(CS_SERVERINFO, info, MAX_INFO_STRING);   
 	gametype = atoi( Info_ValueForKey( info,"g_gametype" ) );
+	subgametype = atoi( Info_ValueForKey( info,"g_subgametype" ) );
 			      
 	// set initial states
-	switch( gametype ) {
-	case GT_SINGLE_PLAYER:
-	case GT_FFA:
-	case GT_LMS:
-	case GT_POSSESSION:
-	case GT_TOURNAMENT:
+	if(UI_SP_IsATeamGametype(gametype,subgametype)) {
+		s_teammain.joingame.string = "AUTO JOIN GAME";
+	} else {
 		s_teammain.joinred.generic.flags  |= QMF_GRAYED;
 		s_teammain.joinblue.generic.flags |= QMF_GRAYED;
-		break;
-
-	default:
-	case GT_TEAM:
-	case GT_CTF:
-	case GT_1FCTF:
-	case GT_OBELISK:
-	case GT_HARVESTER:
-	case GT_ELIMINATION:
-	case GT_CTF_ELIMINATION:
-	case GT_DOUBLE_D:
-	case GT_DOMINATION:
-		s_teammain.joingame.string           = "AUTO JOIN GAME";
-		break;
 	}
 
 	Menu_AddItem( &s_teammain.menu, (void*) &s_teammain.frame );

--- a/code/q3_ui/ui_teamorders.c
+++ b/code/q3_ui/ui_teamorders.c
@@ -366,11 +366,11 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 				UI_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_CTF1F_ORDERS );
 		}
-		if( UI_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_HARVESTER) ||
-				UI_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_OBELISK) ) {
+		if( UI_IsGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_HARVESTER) ||
+				UI_IsGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_OBELISK) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_BASE_ORDERS );
 		}
-		if( UI_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_DOUBLE_D) ) {
+		if( UI_IsGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_DOUBLE_D) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_DD_ORDERS );
 		}
 		else {

--- a/code/q3_ui/ui_teamorders.c
+++ b/code/q3_ui/ui_teamorders.c
@@ -350,7 +350,11 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 	int		selection;
 	char	message[256];
 
+<<<<<<< HEAD
 	if (event != QM_ACTIVATED || !UI_SP_IsATeamGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype))
+=======
+	if (event != QM_ACTIVATED || !UI_IsATeamGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype))
+>>>>>>> GT_SINGLE_PLAYER subgametype support: allows classic UI to play SP missions in gametypes other than FFA.
 		return;
 
 	id = ((menulist_s *)ptr)->generic.id;
@@ -358,6 +362,7 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 
 	if( id == ID_LIST_BOTS ) {
 		teamOrdersMenuInfo.selectedBot = selection;
+<<<<<<< HEAD
 		if( UI_SP_UsesTeamFlags(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) &&
 				!UI_SP_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_CTF_ORDERS );
@@ -371,6 +376,21 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 			UI_TeamOrdersMenu_SetList( ID_LIST_BASE_ORDERS );
 		}
 		if( UI_SP_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_DOUBLE_D) ) {
+=======
+		if( UI_UsesTeamFlags(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) &&
+				!UI_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
+			UI_TeamOrdersMenu_SetList( ID_LIST_CTF_ORDERS );
+		}
+		if( UI_UsesTeamFlags(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) &&
+				UI_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
+			UI_TeamOrdersMenu_SetList( ID_LIST_CTF1F_ORDERS );
+		}
+		if( UI_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_HARVESTER) ||
+				UI_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_OBELISK) ) {
+			UI_TeamOrdersMenu_SetList( ID_LIST_BASE_ORDERS );
+		}
+		if( UI_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_DOUBLE_D) ) {
+>>>>>>> GT_SINGLE_PLAYER subgametype support: allows classic UI to play SP missions in gametypes other than FFA.
 			UI_TeamOrdersMenu_SetList( ID_LIST_DD_ORDERS );
 		}
 		else {
@@ -555,7 +575,8 @@ void UI_TeamOrdersMenu_f( void )
 	// make sure it's a team game
 	trap_GetConfigString( CS_SERVERINFO, info, sizeof(info) );
 	teamOrdersMenuInfo.gametype = atoi( Info_ValueForKey( info, "g_gametype" ) );
-	if(!UI_IsATeamGametype(teamOrdersMenuInfo.gametype)) {
+	teamOrdersMenuInfo.subgametype = atoi( Info_ValueForKey( info, "g_subgametype" ) );
+	if(!UI_IsATeamGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype)) {
 		return;
 	}
 

--- a/code/q3_ui/ui_teamorders.c
+++ b/code/q3_ui/ui_teamorders.c
@@ -55,6 +55,7 @@ typedef struct {
 	menubitmap_s	back;
 
 	int				gametype;
+	int				subgametype;
 	int				numBots;
 	int				selectedBot;
 	char			*bots[9];
@@ -349,7 +350,7 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 	int		selection;
 	char	message[256];
 
-	if (event != QM_ACTIVATED || !UI_IsATeamGametype(teamOrdersMenuInfo.gametype))
+	if (event != QM_ACTIVATED || !UI_SP_IsATeamGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype))
 		return;
 
 	id = ((menulist_s *)ptr)->generic.id;
@@ -357,16 +358,19 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 
 	if( id == ID_LIST_BOTS ) {
 		teamOrdersMenuInfo.selectedBot = selection;
-		if( UI_UsesTeamFlags(teamOrdersMenuInfo.gametype) && !UI_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype) ) {
+		if( UI_SP_UsesTeamFlags(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) &&
+				!UI_SP_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_CTF_ORDERS );
 		}
-		if( UI_UsesTeamFlags(teamOrdersMenuInfo.gametype) && UI_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype) ) {
+		if( UI_SP_UsesTeamFlags(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) &&
+				UI_SP_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_CTF1F_ORDERS );
 		}
-		if( teamOrdersMenuInfo.gametype == GT_HARVESTER || teamOrdersMenuInfo.gametype == GT_OBELISK ) {
+		if( UI_SP_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_HARVESTER) ||
+				UI_SP_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_OBELISK) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_BASE_ORDERS );
 		}
-		if( teamOrdersMenuInfo.gametype == GT_DOUBLE_D ) {
+		if( UI_SP_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_DOUBLE_D) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_DD_ORDERS );
 		}
 		else {
@@ -424,6 +428,7 @@ static void UI_TeamOrdersMenu_BuildBotList( void )
 	trap_GetConfigString( CS_SERVERINFO, info, sizeof(info) );
 	numPlayers = atoi( Info_ValueForKey( info, "sv_maxclients" ) );
 	teamOrdersMenuInfo.gametype = atoi( Info_ValueForKey( info, "g_gametype" ) );
+	teamOrdersMenuInfo.subgametype = atoi( Info_ValueForKey( info, "g_subgametype" ) );
 
 	trap_GetConfigString( CS_PLAYERS + cs.clientNum, info, MAX_INFO_STRING );
 	playerTeam = *Info_ValueForKey( info, "t" );

--- a/code/q3_ui/ui_teamorders.c
+++ b/code/q3_ui/ui_teamorders.c
@@ -350,11 +350,7 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 	int		selection;
 	char	message[256];
 
-<<<<<<< HEAD
-	if (event != QM_ACTIVATED || !UI_SP_IsATeamGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype))
-=======
 	if (event != QM_ACTIVATED || !UI_IsATeamGametype(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype))
->>>>>>> GT_SINGLE_PLAYER subgametype support: allows classic UI to play SP missions in gametypes other than FFA.
 		return;
 
 	id = ((menulist_s *)ptr)->generic.id;
@@ -362,21 +358,6 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 
 	if( id == ID_LIST_BOTS ) {
 		teamOrdersMenuInfo.selectedBot = selection;
-<<<<<<< HEAD
-		if( UI_SP_UsesTeamFlags(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) &&
-				!UI_SP_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
-			UI_TeamOrdersMenu_SetList( ID_LIST_CTF_ORDERS );
-		}
-		if( UI_SP_UsesTeamFlags(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) &&
-				UI_SP_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
-			UI_TeamOrdersMenu_SetList( ID_LIST_CTF1F_ORDERS );
-		}
-		if( UI_SP_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_HARVESTER) ||
-				UI_SP_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_OBELISK) ) {
-			UI_TeamOrdersMenu_SetList( ID_LIST_BASE_ORDERS );
-		}
-		if( UI_SP_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_DOUBLE_D) ) {
-=======
 		if( UI_UsesTeamFlags(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) &&
 				!UI_UsesTheWhiteFlag(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype) ) {
 			UI_TeamOrdersMenu_SetList( ID_LIST_CTF_ORDERS );
@@ -390,7 +371,6 @@ static void UI_TeamOrdersMenu_ListEvent( void *ptr, int event )
 			UI_TeamOrdersMenu_SetList( ID_LIST_BASE_ORDERS );
 		}
 		if( UI_SingleGametypeCheck(teamOrdersMenuInfo.gametype,teamOrdersMenuInfo.subgametype,GT_DOUBLE_D) ) {
->>>>>>> GT_SINGLE_PLAYER subgametype support: allows classic UI to play SP missions in gametypes other than FFA.
 			UI_TeamOrdersMenu_SetList( ID_LIST_DD_ORDERS );
 		}
 		else {

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -109,7 +109,6 @@ extern vmCvar_t ui_gameType;
 extern vmCvar_t ui_netGameType;
 extern vmCvar_t ui_actualNetGameType;
 extern vmCvar_t ui_joinGameType;
-extern vmCvar_t ui_subGameType;
 extern vmCvar_t ui_netSource;
 extern vmCvar_t ui_serverFilterType;
 extern vmCvar_t ui_dedicated;
@@ -1317,8 +1316,8 @@ typedef struct postGameInfo_s {
 #endif
 
 /* Neon_Knight: Useful check in order to have code consistency. */
-qboolean UI_IsATeamGametype(int gametype);	/* Whether the gametype is team-based or not.*/
-qboolean UI_UsesTeamFlags(int gametype);	/* Whether the gametype uses the red and blue flags. */
-qboolean UI_UsesTheWhiteFlag(int gametype);	/* Whether the gametype uses the neutral flag. */
-qboolean UI_IsARoundBasedGametype(int gametype);	/* Whether the gametype is round-based. */
+qboolean UI_IsATeamGametype(int check);	/* Whether the gametype is team-based or not.*/
+qboolean UI_UsesTeamFlags(int check);	/* Whether the gametype uses the red and blue flags. */
+qboolean UI_UsesTheWhiteFlag(int check);	/* Whether the gametype uses the neutral flag. */
+qboolean UI_IsARoundBasedGametype(int check);	/* Whether the gametype uses the neutral flag. */
 /* /Neon_Knight */

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -1316,8 +1316,8 @@ typedef struct postGameInfo_s {
 #endif
 
 /* Neon_Knight: Useful check in order to have code consistency. */
-qboolean UI_IsATeamGametype(int check);	/* Whether the gametype is team-based or not.*/
-qboolean UI_UsesTeamFlags(int check);	/* Whether the gametype uses the red and blue flags. */
-qboolean UI_UsesTheWhiteFlag(int check);	/* Whether the gametype uses the neutral flag. */
-qboolean UI_IsARoundBasedGametype(int check);	/* Whether the gametype uses the neutral flag. */
+qboolean UI_IsATeamGametype(int gametype);	/* Whether the gametype is team-based or not.*/
+qboolean UI_UsesTeamFlags(int gametype);	/* Whether the gametype uses the red and blue flags. */
+qboolean UI_UsesTheWhiteFlag(int gametype);	/* Whether the gametype uses the neutral flag. */
+qboolean UI_IsARoundBasedGametype(int gametype);	/* Whether the gametype is round-based. */
 /* /Neon_Knight */

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -109,6 +109,7 @@ extern vmCvar_t ui_gameType;
 extern vmCvar_t ui_netGameType;
 extern vmCvar_t ui_actualNetGameType;
 extern vmCvar_t ui_joinGameType;
+extern vmCvar_t ui_subGameType;
 extern vmCvar_t ui_netSource;
 extern vmCvar_t ui_serverFilterType;
 extern vmCvar_t ui_dedicated;

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -7532,10 +7532,11 @@ static void UI_StartServerRefresh(qboolean full)
 UI_IsATeamGametype
 
 Checks if the gametype is a team-based game.
+(UI_IsATeamGame(check,qtrue))
 ===================
  */
-qboolean UI_IsATeamGametype(int gametype) {
-	return GAMETYPE_IS_A_TEAM_GAME(gametype);
+qboolean UI_IsATeamGametype(int check) {
+	return GAMETYPE_IS_A_TEAM_GAME(check);
 }
 /*
 ===================
@@ -7544,8 +7545,8 @@ UI_UsesTeamFlags
 Checks if the gametype makes use of the red and blue flags.
 ===================
  */
-qboolean UI_UsesTeamFlags(int gametype) {
-	return GAMETYPE_USES_RED_AND_BLUE_FLAG(gametype);
+qboolean UI_UsesTeamFlags(int check) {
+	return GAMETYPE_USES_RED_AND_BLUE_FLAG(check);
 }
 /*
 ===================
@@ -7554,8 +7555,8 @@ UI_UsesTheWhiteFlag
 Checks if the gametype makes use of the neutral flag.
 ===================
  */
-qboolean UI_UsesTheWhiteFlag(int gametype) {
-	return GAMETYPE_USES_WHITE_FLAG(gametype);
+qboolean UI_UsesTheWhiteFlag(int check) {
+	return GAMETYPE_USES_WHITE_FLAG(check);
 }
 /*
 ===================
@@ -7564,7 +7565,7 @@ UI_IsARoundBasedGametype
 Checks if the gametype has a round-based system.
 ===================
  */
-qboolean UI_IsARoundBasedGametype(int gametype) {
-	return GAMETYPE_IS_ROUND_BASED(gametype);
+qboolean UI_IsARoundBasedGametype(int check) {
+	return GAMETYPE_IS_ROUND_BASED(check);
 }
 /* /Neon_Knight */

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -7532,11 +7532,10 @@ static void UI_StartServerRefresh(qboolean full)
 UI_IsATeamGametype
 
 Checks if the gametype is a team-based game.
-(UI_IsATeamGame(check,qtrue))
 ===================
  */
-qboolean UI_IsATeamGametype(int check) {
-	return GAMETYPE_IS_A_TEAM_GAME(check);
+qboolean UI_IsATeamGametype(int gametype) {
+	return GAMETYPE_IS_A_TEAM_GAME(gametype);
 }
 /*
 ===================
@@ -7545,8 +7544,8 @@ UI_UsesTeamFlags
 Checks if the gametype makes use of the red and blue flags.
 ===================
  */
-qboolean UI_UsesTeamFlags(int check) {
-	return GAMETYPE_USES_RED_AND_BLUE_FLAG(check);
+qboolean UI_UsesTeamFlags(int gametype) {
+	return GAMETYPE_USES_RED_AND_BLUE_FLAG(gametype);
 }
 /*
 ===================
@@ -7555,8 +7554,8 @@ UI_UsesTheWhiteFlag
 Checks if the gametype makes use of the neutral flag.
 ===================
  */
-qboolean UI_UsesTheWhiteFlag(int check) {
-	return GAMETYPE_USES_WHITE_FLAG(check);
+qboolean UI_UsesTheWhiteFlag(int gametype) {
+	return GAMETYPE_USES_WHITE_FLAG(gametype);
 }
 /*
 ===================
@@ -7565,7 +7564,7 @@ UI_IsARoundBasedGametype
 Checks if the gametype has a round-based system.
 ===================
  */
-qboolean UI_IsARoundBasedGametype(int check) {
-	return GAMETYPE_IS_ROUND_BASED(check);
+qboolean UI_IsARoundBasedGametype(int gametype) {
+	return GAMETYPE_IS_ROUND_BASED(gametype);
 }
 /* /Neon_Knight */


### PR DESCRIPTION
Well, what the title says. A test pk3 with a custom arenas.txt for testing will come soon, once I finish polishing the edges and figuring out some things.

Basically this allows the SP to be played in other gamemodes other than FFA. What this should do is generate a tier for every gametype in a similar manner to "Training" (placed at the beginning) and "Final" (placed at the end). New .arena/arenas.txt keys include:

* **sptype:** Takes the values FreeForAll, TeamDeathmatch, Tournament, CaptureTheFlag, OneFlagCTF, Harvester, Overload, Elimination, CTFElimination, LastManStanding, DoubleDomination, SingleDomination and Possession.
* **bluebots:** Bots which will spawn in the blue team. [TBI]
* **redbots:** Bots which will spawn in the red team. [TBI]
* **capturelimit:** Capture limit, properly implemented. [TBI]