### PR TITLE
Fix: Fragment of CG_DrawInformation in cg_info.c was not accounting for TDM.

### DIFF
--- a/code/cgame/cg_info.c
+++ b/code/cgame/cg_info.c
@@ -292,7 +292,8 @@ void CG_DrawInformation( void ) {
 		y += PROP_HEIGHT;
 	}
 
-	if (!CG_IsATeamGametype(cgs.gametype)) {
+	/* Fraglimits are restricted to non-team-based games and Team Deathmatch */
+	if (!CG_IsATeamGametype(cgs.gametype) || cgs.gametype == GT_TEAM ) {
 		value = atoi( Info_ValueForKey( info, "fraglimit" ) );
 		if ( value ) {
 			UI_DrawProportionalString( 320, y, va( "fraglimit %i", value ),
@@ -300,8 +301,7 @@ void CG_DrawInformation( void ) {
 			y += PROP_HEIGHT;
 		}
 	}
-
-	if (CG_IsATeamGametype(cgs.gametype) && cgs.gametype != GT_TEAM) {
+	else {
 		value = atoi( Info_ValueForKey( info, "capturelimit" ) );
 		if ( value ) {
 			UI_DrawProportionalString( 320, y, va( "capturelimit %i", value ),


### PR DESCRIPTION
This small change allows Team Deathmatch games to be accounted for fraglimits.

I thought on also considering Domination and Possession for fraglimits, solely because they also have high pointlimits.