### PR TITLE
Fix: cg_weaponBarStyle with value outside of range now displays default weapon bar.

### DIFF
--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -2300,8 +2300,7 @@ void CG_DrawWeaponSelect( void )
 	}
 
 	switch(cg_weaponBarStyle.integer) {
-	case 0:
-		CG_DrawWeaponBar0(count,bits);
+	case -1: // Don't display the weapon bar.
 		break;
 	case 1:
 		CG_DrawWeaponBar1(count,bits);
@@ -2324,6 +2323,9 @@ void CG_DrawWeaponSelect( void )
 	case 7:
 		CG_DrawWeaponBar7(count,bits, color);
 		break;
+	default: // Default weapon bar (0)
+		CG_DrawWeaponBar0(count,bits);
+		break;
 	}
 	trap_R_SetColor(NULL);
 	return;
@@ -2332,6 +2334,7 @@ void CG_DrawWeaponSelect( void )
 /*
 ===============
 CG_DrawWeaponBar0
+Default weapon bar. Displays only if a weapon has ammo or not (marked with an X).
 ===============
 */
 
@@ -2378,6 +2381,7 @@ void CG_DrawWeaponBar0(int count, int bits)
 /*
 ===============
 CG_DrawWeaponBar1
+Displays ammo left for the weapon below it with a bar.
 ===============
 */
 
@@ -2501,6 +2505,8 @@ void CG_DrawWeaponBar1(int count, int bits)
 /*
 ===============
 CG_DrawWeaponBar2
+Displays weapons in the left side of the screen with a number showing remaining ammo.
+Weapons with less than 10 ammo units have a red-ish background.
 ===============
 */
 
@@ -2583,6 +2589,8 @@ void CG_DrawWeaponBar2(int count, int bits, float *color)
 /*
 ===============
 CG_DrawWeaponBar3
+Same as 2, but displays ammo left at the right of the number as a bar.
+Weapons with less than 10 ammo units have a red-ish background and don't display the bar.
 ===============
 */
 
@@ -2729,6 +2737,7 @@ void CG_DrawWeaponBar3(int count, int bits, float *color)
 /*
 ===============
 CG_DrawWeaponBar4
+Apparently same as 2, even if the code is different. Weird.
 ===============
 */
 
@@ -2842,6 +2851,8 @@ void CG_DrawWeaponBar4(int count, int bits, float *color)
 /*
 ===============
 CG_DrawWeaponBar5
+Weapons have a blue background and a number representing ammo.
+Less than 10 ammo units have a red-ish background.
 ===============
 */
 
@@ -2921,6 +2932,7 @@ void CG_DrawWeaponBar5(int count, int bits, float *color)
 /*
 ===============
 CG_DrawWeaponBar6
+Same as 5, but also displays a bar, except when there's no ammo.
 ===============
 */
 
@@ -3066,6 +3078,7 @@ void CG_DrawWeaponBar6(int count, int bits, float *color)
 /*
 ===============
 CG_DrawWeaponBar7
+Apparently same as 5, even if the code is different. Weird.
 ===============
 */
 


### PR DESCRIPTION
Previously it would hide the weapon bar completely.