### PR TITLE
Fix: Randomly, manually added bots now are properly assigned a team, depending on the gamemode.

### DIFF
--- a/code/game/g_bot.c
+++ b/code/game/g_bot.c
@@ -324,9 +324,27 @@ G_AddRandomBot
 void G_AddRandomBot( int team ) {
 	char	*teamstr;
 
-	if (team == TEAM_RED) teamstr = "red";
-	else if (team == TEAM_BLUE) teamstr = "blue";
-	else teamstr = "free";
+	if (G_IsATeamGametype(g_gametype.integer)) {
+		// Team games will throw bots in one of two teams (red or blue).
+		if (team == TEAM_RED) {
+			teamstr = "red";
+		}
+		else if (team == TEAM_BLUE) {
+			teamstr = "blue";
+		}
+		// If no team is specified, a coin is tossed.
+		else {
+			if (rand() % 10 > 5) {
+				teamstr = "red";
+			}
+			else {
+				teamstr = "blue";
+			}
+		}
+	} else {
+		// Non-team games have only one team: free.
+		teamstr = "free";
+	}
 	trap_SendConsoleCommand( EXEC_INSERT, va("addbot random %i %s %i\n", g_spSkill.integer, teamstr, 0) );
 }
 


### PR DESCRIPTION
Short description of the bug as seen in [the Bugs page in OA Wiki](https://openarena.fandom.com/wiki/Bugs):

> Manually adding bots, specifying their team (or using !putteam admin command), may lead to strange behaviours, where a bot appears of a team (in its color and in the score table), for example red, but acts like a player of the other team, for example blue, attacking red players, sending "team chat" messages to the blue team, and capturing the red flag (scoring for the blue team).

Also [related forum post](http://openarena.ws/board/index.php?topic=3578.msg36081#msg36081).

**[Test pk3](https://www.dropbox.com/s/6ecds06sgt58g8i/z_oax_v2.pk3?dl=0)**