### PR TITLE
Cleanup of unused cvars in MPUI/UI3

### DIFF
--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -32,39 +32,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // global display context
 
-extern vmCvar_t ui_ffa_fraglimit;
-extern vmCvar_t ui_ffa_timelimit;
-extern vmCvar_t ui_tourney_fraglimit;
-extern vmCvar_t ui_tourney_timelimit;
-extern vmCvar_t ui_team_fraglimit;
-extern vmCvar_t ui_team_timelimit;
-extern vmCvar_t ui_team_friendly;
-extern vmCvar_t ui_ctf_capturelimit;
-extern vmCvar_t ui_ctf_timelimit;
-extern vmCvar_t ui_ctf_friendly;
-extern vmCvar_t ui_1fctf_capturelimit;
-extern vmCvar_t ui_1fctf_timelimit;
-extern vmCvar_t ui_1fctf_friendly;
-extern vmCvar_t ui_overload_capturelimit;
-extern vmCvar_t ui_overload_timelimit;
-extern vmCvar_t ui_overload_friendly;
-extern vmCvar_t ui_harvester_capturelimit;
-extern vmCvar_t ui_harvester_timelimit;
-extern vmCvar_t ui_harvester_friendly;
-extern vmCvar_t ui_elimination_capturelimit;
-extern vmCvar_t ui_elimination_timelimit;
-extern vmCvar_t ui_ctf_elimination_capturelimit;
-extern vmCvar_t ui_ctf_elimination_timelimit;
-extern vmCvar_t ui_lms_fraglimit;
-extern vmCvar_t ui_lms_timelimit;
-extern vmCvar_t ui_dd_capturelimit;
-extern vmCvar_t ui_dd_timelimit;
-extern vmCvar_t ui_dd_friendly;
-extern vmCvar_t ui_dom_capturelimit;
-extern vmCvar_t ui_dom_timelimit;
-extern vmCvar_t ui_dom_friendly;
-extern vmCvar_t ui_pos_scorelimit;
-extern vmCvar_t ui_pos_timelimit;
 extern vmCvar_t ui_arenasFile;
 extern vmCvar_t ui_botsFile;
 extern vmCvar_t ui_spScores1;

--- a/code/ui/ui_main.c
+++ b/code/ui/ui_main.c
@@ -7005,39 +7005,6 @@ typedef struct {
 	int			cvarFlags;
 } cvarTable_t;
 
-vmCvar_t ui_ffa_fraglimit;
-vmCvar_t ui_ffa_timelimit;
-vmCvar_t ui_tourney_fraglimit;
-vmCvar_t ui_tourney_timelimit;
-vmCvar_t ui_team_fraglimit;
-vmCvar_t ui_team_timelimit;
-vmCvar_t ui_team_friendly;
-vmCvar_t ui_ctf_capturelimit;
-vmCvar_t ui_ctf_timelimit;
-vmCvar_t ui_ctf_friendly;
-vmCvar_t ui_1fctf_capturelimit;
-vmCvar_t ui_1fctf_timelimit;
-vmCvar_t ui_1fctf_friendly;
-vmCvar_t ui_overload_capturelimit;
-vmCvar_t ui_overload_timelimit;
-vmCvar_t ui_overload_friendly;
-vmCvar_t ui_harvester_capturelimit;
-vmCvar_t ui_harvester_timelimit;
-vmCvar_t ui_harvester_friendly;
-vmCvar_t ui_elimination_capturelimit;
-vmCvar_t ui_elimination_timelimit;
-vmCvar_t ui_ctf_elimination_capturelimit;
-vmCvar_t ui_ctf_elimination_timelimit;
-vmCvar_t ui_lms_fraglimit;
-vmCvar_t ui_lms_timelimit;
-vmCvar_t ui_dd_capturelimit;
-vmCvar_t ui_dd_timelimit;
-vmCvar_t ui_dd_friendly;
-vmCvar_t ui_dom_capturelimit;
-vmCvar_t ui_dom_timelimit;
-vmCvar_t ui_dom_friendly;
-vmCvar_t ui_pos_scorelimit;
-vmCvar_t ui_pos_timelimit;
 vmCvar_t ui_arenasFile;
 vmCvar_t ui_botsFile;
 vmCvar_t ui_spScores1;
@@ -7170,52 +7137,6 @@ vmCvar_t ui_developer;
 
 // bk001129 - made static to avoid aliasing
 static cvarTable_t		cvarTable[] = {
-	{ &ui_ffa_fraglimit, "ui_ffa_fraglimit", "20", CVAR_ARCHIVE },
-	{ &ui_ffa_timelimit, "ui_ffa_timelimit", "0", CVAR_ARCHIVE },
-
-	{ &ui_tourney_fraglimit, "ui_tourney_fraglimit", "0", CVAR_ARCHIVE },
-	{ &ui_tourney_timelimit, "ui_tourney_timelimit", "15", CVAR_ARCHIVE },
-
-	{ &ui_team_fraglimit, "ui_team_fraglimit", "0", CVAR_ARCHIVE },
-	{ &ui_team_timelimit, "ui_team_timelimit", "20", CVAR_ARCHIVE },
-	{ &ui_team_friendly, "ui_team_friendly",  "1", CVAR_ARCHIVE },
-
-	{ &ui_ctf_capturelimit, "ui_ctf_capturelimit", "8", CVAR_ARCHIVE },
-	{ &ui_ctf_timelimit, "ui_ctf_timelimit", "30", CVAR_ARCHIVE },
-	{ &ui_ctf_friendly, "ui_ctf_friendly",  "0", CVAR_ARCHIVE },
-
-	{ &ui_1fctf_capturelimit, "ui_1fctf_capturelimit", "8", CVAR_ARCHIVE },
-	{ &ui_1fctf_timelimit, "ui_1fctf_timelimit", "30", CVAR_ARCHIVE },
-	{ &ui_1fctf_friendly, "ui_1fctf_friendly",  "0", CVAR_ARCHIVE },
-
-	{ &ui_overload_capturelimit, "ui_overload_capturelimit", "8", CVAR_ARCHIVE },
-	{ &ui_overload_timelimit, "ui_overload_timelimit", "30", CVAR_ARCHIVE },
-	{ &ui_overload_friendly, "ui_overload_friendly",  "0", CVAR_ARCHIVE },
-
-	{ &ui_harvester_capturelimit, "ui_harvester_capturelimit", "20", CVAR_ARCHIVE },
-	{ &ui_harvester_timelimit, "ui_harvester_timelimit", "30", CVAR_ARCHIVE },
-	{ &ui_harvester_friendly, "ui_harvester_friendly",  "0", CVAR_ARCHIVE },
-
-	{ &ui_elimination_capturelimit, "ui_elimination_capturelimit", "8", CVAR_ARCHIVE },
-	{ &ui_elimination_timelimit, "ui_elimination_timelimit", "20", CVAR_ARCHIVE },
-
-	{ &ui_ctf_elimination_capturelimit, "ui_ctf_elimination_capturelimit", "8", CVAR_ARCHIVE },
-	{ &ui_ctf_elimination_timelimit, "ui_ctf_elimination_timelimit", "30", CVAR_ARCHIVE },
-
-	{ &ui_lms_fraglimit, "ui_lms_fraglimit", "20", CVAR_ARCHIVE },
-	{ &ui_lms_timelimit, "ui_lms_timelimit", "0", CVAR_ARCHIVE },
-
-	{ &ui_dd_capturelimit, "ui_dd_capturelimit", "8", CVAR_ARCHIVE },
-	{ &ui_dd_timelimit, "ui_dd_timelimit", "30", CVAR_ARCHIVE },
-	{ &ui_dd_friendly, "ui_dd_friendly",  "0", CVAR_ARCHIVE },
-
-	{ &ui_dom_capturelimit, "ui_dom_capturelimit", "500", CVAR_ARCHIVE },
-	{ &ui_dom_timelimit, "ui_dom_timelimit", "30", CVAR_ARCHIVE },
-	{ &ui_dom_friendly, "ui_dom_friendly",  "0", CVAR_ARCHIVE },
-
-	{ &ui_pos_scorelimit, "ui_pos_scorelimit", "120", CVAR_ARCHIVE },
-	{ &ui_pos_timelimit, "ui_pos_timelimit", "20", CVAR_ARCHIVE },
-
 	{ &ui_arenasFile, "g_arenasFile", "", CVAR_INIT|CVAR_ROM },
 	{ &ui_botsFile, "g_botsFile", "", CVAR_INIT|CVAR_ROM },
 	{ &ui_spScores1, "g_spScores1", "", CVAR_ARCHIVE | CVAR_ROM },


### PR DESCRIPTION
These cvars weren't used anywhere in the code of MPUI/UI3 (they originated in q3_ui). Deleting them for the moment.