### PR TITLE
Fix: CTF Flags won't be drawn anymore in Harvester/Overload

### DIFF
--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -1006,6 +1006,11 @@ void G_SpawnItem (gentity_t *ent, gitem_t *item)
 		ent->s.eFlags |= EF_NODRAW; //Don't draw the flag models/persistant powerups
 	}
 
+	if( (g_gametype.integer == GT_HARVESTER || g_gametype.integer == GT_OBELISK) &&
+			(strequals(ent->classname, "team_CTF_redflag") || strequals(ent->classname, "team_CTF_blueflag") ) ) {
+		ent->s.eFlags |= EF_NODRAW; // Don't draw the team flags in Harvester/Overload
+	}
+
 	if( !G_UsesTheWhiteFlag(g_gametype.integer) && strequals(ent->classname, "team_CTF_neutralflag")) {
 		ent->s.eFlags |= EF_NODRAW; // Don't draw the flag in CTF_elimination
 	}


### PR DESCRIPTION
This PR only affects the team flags. The neutral flag/skull receptacle works well.

Here's how it looks in vanilla 0.8.8:
![shot0002](https://user-images.githubusercontent.com/20754036/226099897-0c0efaeb-6eca-46f1-980a-0dbc7a83933e.jpg)

Here's how it looks in latest OAX:
![shot0001](https://user-images.githubusercontent.com/20754036/226099902-949f882e-a3df-4d91-8dbc-28dc4dbe7df7.jpg)

And here's how it looks with this fix:
![shot0004](https://user-images.githubusercontent.com/20754036/226099925-05b6cf6b-52f4-4494-a3ca-626488f12550.jpg)
