### PR TITLE
Regression Fix: Obelisk bases are now drawn outside Harvester/Overload.

### DIFF
--- a/code/game/g_team.c
+++ b/code/game/g_team.c
@@ -2297,7 +2297,7 @@ void SP_team_redobelisk( gentity_t *ent )
 {
 	gentity_t *obelisk;
 
-	if (g_gametype.integer != GT_HARVESTER && g_gametype.integer != GT_OBELISK) {
+	if (!G_UsesTeamFlags(g_gametype.integer) && g_gametype.integer != GT_HARVESTER && g_gametype.integer != GT_OBELISK) {
 		G_FreeEntity(ent);
 		return;
 	}
@@ -2323,7 +2323,7 @@ void SP_team_blueobelisk( gentity_t *ent )
 {
 	gentity_t *obelisk;
 
-	if (g_gametype.integer != GT_HARVESTER && g_gametype.integer != GT_OBELISK) {
+	if (!G_UsesTeamFlags(g_gametype.integer) && g_gametype.integer != GT_HARVESTER && g_gametype.integer != GT_OBELISK) {
 		G_FreeEntity(ent);
 		return;
 	}
@@ -2347,7 +2347,7 @@ void SP_team_blueobelisk( gentity_t *ent )
 */
 void SP_team_neutralobelisk( gentity_t *ent )
 {
-	if (g_gametype.integer != GT_HARVESTER) {
+	if (!G_UsesTheWhiteFlag(g_gametype.integer) && g_gametype.integer != GT_HARVESTER) {
 		G_FreeEntity(ent);
 		return;
 	}


### PR DESCRIPTION
Useful for CTF maps that use them as flag bases. Plus, [the official Q3TA editing manual](https://icculus.org/gtkradiant/documentation/Team_Arena_Mapping_Help/pages/ta_game_types.html) recommends doing so, so there's no point in not drawing them outside of Harv/Over.

Using [this map](https://www.moddb.com/games/openarena/addons/oac-hydro3-a2) for testing.

Here's how it looks in vanilla, mod-less 0.8.8:
![shot0000](https://user-images.githubusercontent.com/20754036/226097406-df300227-6b18-4504-8f84-6d6790fac708.jpg)

Here's how it looks in current OAX:
![shot0001](https://user-images.githubusercontent.com/20754036/226097432-06689ac6-e53c-44ab-933f-043908b1bcb4.jpg)

And here, how it looks with the fixed version:
![shot0000](https://user-images.githubusercontent.com/20754036/226097752-88b374a1-9d50-48a3-9ea7-d5cd56f495ff.jpg)
