### PR TITLE
[MPUI/UI3] ui/menudef.h: Remaining gametype-specific ownerdraws

### DIFF
--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -1129,22 +1129,16 @@ qboolean CG_OwnerDrawVisible(int flags)
 		if( cgs.gametype == GT_HARVESTER ) {
 			return qtrue;
 		}
-		else {
-			return qfalse;
-		}
 	}
 
 	if (flags & CG_SHOW_ONEFLAG) {
 		if( cgs.gametype == GT_1FCTF ) {
 			return qtrue;
 		}
-		else {
-			return qfalse;
-		}
 	}
 
 	if (flags & CG_SHOW_CTF) {
-		if(CG_UsesTeamFlags(cgs.gametype) && !CG_UsesTheWhiteFlag(cgs.gametype)) {
+		if( cgs.gametype == GT_CTF ) {
 			return qtrue;
 		}
 	}
@@ -1152,9 +1146,6 @@ qboolean CG_OwnerDrawVisible(int flags)
 	if (flags & CG_SHOW_OBELISK) {
 		if( cgs.gametype == GT_OBELISK ) {
 			return qtrue;
-		}
-		else {
-			return qfalse;
 		}
 	}
 
@@ -1190,6 +1181,56 @@ qboolean CG_OwnerDrawVisible(int flags)
 			return qtrue;
 		}
 	}
+
+	if (flags & CG_SHOW_FREEFORALL) {
+		if( cgs.gametype == GT_FFA ) {
+			return qtrue;
+		}
+	}
+
+	if (flags & CG_SHOW_TEAMDEATHMATCH) {
+		if( cgs.gametype == GT_TEAM ) {
+			return qtrue;
+		}
+	}
+
+	if (flags & CG_SHOW_ELIMINATION) {
+		if( cgs.gametype == GT_ELIMINATION ) {
+			return qtrue;
+		}
+	}
+
+	if (flags & CG_SHOW_CTFELIMINATION) {
+		if( cgs.gametype == GT_CTF_ELIMINATION ) {
+			return qtrue;
+		}
+	}
+
+	if (flags & CG_SHOW_LASTMANSTANDING) {
+		if( cgs.gametype == GT_LMS ) {
+			return qtrue;
+		}
+	}
+
+	if (flags & CG_SHOW_DOUBLEDOMINATION) {
+		if( cgs.gametype == GT_DOUBLE_D ) {
+			return qtrue;
+		}
+	}
+
+	if (flags & CG_SHOW_DOMINATION) {
+		if( cgs.gametype == GT_DOMINATION ) {
+			return qtrue;
+		}
+	}
+
+	if (flags & CG_SHOW_POSSESSION) {
+		if( cgs.gametype == GT_POSSESSION ) {
+			return qtrue;
+		}
+	}
+
+	// End
 	return qfalse;
 }
 

--- a/ui/menudef.h
+++ b/ui/menudef.h
@@ -127,6 +127,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define CG_SHOW_OTHERTEAMHASFLAG          0x00020000
 #define CG_SHOW_YOURTEAMHASENEMYFLAG      0x00040000
 #define CG_SHOW_ANYNONTEAMGAME            0x00080000
+#define CG_SHOW_FREEFORALL                0x00100000
+#define CG_SHOW_TEAMDEATHMATCH            0x00200000
+#define CG_SHOW_ELIMINATION               0x00400000
+#define CG_SHOW_CTFELIMINATION            0x00800000
+#define CG_SHOW_LASTMANSTANDING           0x01000000
+#define CG_SHOW_DOUBLEDOMINATION          0x02000000
+#define CG_SHOW_DOMINATION                0x04000000
+#define CG_SHOW_POSSESSION                0x08000000
 #define CG_SHOW_2DONLY										0x10000000
 
 


### PR DESCRIPTION
CG_SHOW_FREEFORALL - Shows a menu item if gametype is Free For All.
CG_SHOW_TEAMDEATHMATCH - Shows a menu item if gametype is Team Deathmatch.
CG_SHOW_ELIMINATION - Shows a menu item if gametype is Elimination.
CG_SHOW_CTFELIMINATION - Shows a menu item if gametype is CTF Elimination.
CG_SHOW_LASTMANSTANDING - Shows a menu item if gametype is Last Man Standing.
CG_SHOW_DOUBLEDOMINATION - Shows a menu item if gametype is Double Domination.
CG_SHOW_DOMINATION - Shows a menu item if gametype is Domination.
CG_SHOW_POSSESSION - Shows a menu item if gametype is Possession.