### PR TITLE
New helper function: G_IsANoPickupsMode (game)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Tons of other bug fixes.
 
 ### Extended version
+* New helper function: `G_IsANoPickupsMode()`, returns true if the mode doesn't allow pickups.
 * New cvars that replace `g_rockets`: `g_weaponArena` and `g_weaponArenaWeapon`.
   * `g_weaponArena` enables the "Weapon Arena" mode, which is the old g_rockets, but with any other weapon. `g_weaponArena 2` adds the Grappling Hook to the inventory.
   * `g_weaponArenaWeapon` controls, via specific strings, which weapon it's spawned with its ammo boxes. The weapon cannot be picked up via menu, only (for now) via console. The full string list can be locate [here](https://github.com/OpenArena/gamecode/pull/171).

--- a/code/game/ai_main.c
+++ b/code/game/ai_main.c
@@ -187,7 +187,7 @@ int BotAI_GetEntityState( int entityNum, entityState_t *state ) {
 	memset( state, 0, sizeof(entityState_t) );
 	if (!ent->inuse) return qfalse;
 	if (!ent->r.linked) return qfalse;
-	if ( !(G_IsARoundBasedGametype(g_gametype.integer) ||g_instantgib.integer || g_weaponArena.integer || g_elimination_allgametypes.integer)
+	if ( !(G_IsARoundBasedGametype(g_gametype.integer) || G_IsANoPickupsMode())
 	       && (ent->r.svFlags & SVF_NOCLIENT) ) {
 		return qfalse;
 	}
@@ -1535,7 +1535,7 @@ int BotAIStartFrame(int time) {
 				trap_BotLibUpdateEntity(i, NULL);
 				continue;
 			}
-			if ( !(G_IsARoundBasedGametype(g_gametype.integer) ||g_instantgib.integer || g_weaponArena.integer || g_elimination_allgametypes.integer)
+			if ( !(G_IsARoundBasedGametype(g_gametype.integer) || G_IsANoPickupsMode())
 				   && ent->r.svFlags & SVF_NOCLIENT) {
 				trap_BotLibUpdateEntity(i, NULL);
 				continue;

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -133,7 +133,7 @@ void TossClientItems( gentity_t *self )
 		}
 	}
 
-	if (g_instantgib.integer || g_weaponArena.integer || g_gametype.integer == GT_CTF_ELIMINATION || g_elimination_allgametypes.integer) {
+	if (g_gametype.integer == GT_CTF_ELIMINATION || G_IsANoPickupsMode()) {
 		//Nothing!
 	}
 	else if ( weapon > WP_MACHINEGUN && weapon != WP_GRAPPLING_HOOK &&

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -430,8 +430,8 @@ void Touch_Item (gentity_t *ent, gentity_t *other, trace_t *trace)
 	qboolean	predict;
 
 	//instant gib
-	if ((g_instantgib.integer || g_weaponArena.integer || g_gametype.integer == GT_CTF_ELIMINATION || g_elimination_allgametypes.integer)
-	        && ent->item->giType != IT_TEAM)
+	if ((g_gametype.integer == GT_CTF_ELIMINATION || G_IsANoPickupsMode())
+			&& ent->item->giType != IT_TEAM)
 		return;
 
 	//Cannot touch flag before round starts
@@ -741,7 +741,7 @@ void FinishSpawningItem( gentity_t *ent )
 
 
 	// powerups don't spawn in for a while (but not in elimination)
-	if(!G_IsARoundBasedGametype(g_gametype.integer) && !g_instantgib.integer && !g_elimination_allgametypes.integer && !g_weaponArena.integer )
+	if(!G_IsARoundBasedGametype(g_gametype.integer) && !G_IsANoPickupsMode() )
 		if ( ent->item->giType == IT_POWERUP ) {
 			float	respawn;
 
@@ -996,7 +996,7 @@ void G_SpawnItem (gentity_t *ent, gitem_t *item)
 	ent->physicsBounce = 0.50;		// items are bouncy
 
 	if (g_gametype.integer == GT_ELIMINATION || g_gametype.integer == GT_LMS ||
-	        ( item->giType != IT_TEAM && (g_instantgib.integer || g_weaponArena.integer || g_elimination_allgametypes.integer || g_gametype.integer==GT_CTF_ELIMINATION) ) ) {
+	        ( item->giType != IT_TEAM && (G_IsANoPickupsMode() || g_gametype.integer==GT_CTF_ELIMINATION) ) ) {
 		ent->s.eFlags |= EF_NODRAW; //Invisible in elimination
 		ent->r.svFlags |= SVF_NOCLIENT;  //Don't broadcast
 	}

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1434,4 +1434,5 @@ qboolean G_UsesTeamFlags(int check);	/* Whether the gametype uses the red and bl
 qboolean G_UsesTheWhiteFlag(int check);	/* Whether the gametype uses the neutral flag. */
 qboolean G_IsARoundBasedGametype(int check);	/* Whether the gametype uses the neutral flag. */
 int G_GetWeaponArena(char* cvarWaString);	/* Takes a string and returns the value of a weapon. */
+qboolean G_IsANoPickupsMode(void);	/* Returns true if the match has a "no pickups" rule. */
 /* /Neon_Knight */

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -2927,4 +2927,26 @@ int G_GetWeaponArena(char* cvarWaString) {
 		return WP_CHAINGUN;
 	return WP_GAUNTLET;
 }
+/*
+===================
+G_IsANoPickupsMode
+
+Returns true if the match has a "no pickups" rule.
+===================
+ */
+qboolean G_IsANoPickupsMode(void) {
+	// In Instagib mode, no pickups
+	if (g_instantgib.integer) {
+		return qtrue;
+	}
+	// In Weapon Arena mode, no pickups
+	if (g_weaponArena.integer) {
+		return qtrue;
+	}
+	// In Elimination mode for non-round-based modes, no pickups
+	if (g_elimination_allgametypes.integer) {
+		return qtrue;
+	}
+	return qfalse;
+}
 /* /Neon_Knight */


### PR DESCRIPTION
Returns true if the gamemode doesn't allow pickups.

Currently it only checks for Instagib, Weapon Arena (f.k.a. "All Rockets") and Elimination All Gametypes. It doesn't check for round-based matches because it's not always the case (see: Elimination CTF, where you need the flags as pickups).