### PR TITLE
Removed unused comparison in bg_public.h

### DIFF
--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -138,11 +138,7 @@ typedef enum {
 #define GAMETYPE_IS_A_TEAM_GAME(gametype) (gametype != GT_FFA && gametype != GT_TOURNAMENT && gametype != GT_SINGLE_PLAYER && gametype != GT_LMS && gametype != GT_POSSESSION)
 #define GAMETYPE_USES_RED_AND_BLUE_FLAG(gametype) (gametype == GT_CTF || gametype == GT_1FCTF || gametype == GT_CTF_ELIMINATION)
 #define GAMETYPE_USES_WHITE_FLAG(gametype) (gametype == GT_1FCTF || gametype == GT_POSSESSION)
-/*
- Returns true for round based games like (CTF)Elimination and LMS
- */
 #define GAMETYPE_IS_ROUND_BASED(gametype) (gametype == GT_ELIMINATION || gametype == GT_CTF_ELIMINATION || gametype == GT_LMS)
-#define GAMETYPE_USES_OBELISKS(gametype) (gametype == GT_HARVESTER || gametype == GT_OBELISK)
 /*
  Score limits
  */


### PR DESCRIPTION
The comparison originally checked for obelisks. Since obelisks worked differently for Harvester and Overload, and no other mode used them, it's now an useless define.