### PR TITLE
"Classic Mode"-related changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   * `cg_weaponBarStyle` added to "Game Options" as, well, "Weapon Bar Style".
   * `g_ddCaptureTime` and `g_ddRespawnDelay` were added for Double Domination matches.
   * `cg_obituaryOutput` can now be configured in "Game Options" as "Death Messages".
+  * New option in Skirmish/Create Server, "Weapon Ruleset", allows picking up one of five weapon rulesets: All Weapons (Standard) -default-, Instantgib, Single Weapon Arena, Classic Mode -replaces NG, CG, PL, Kami, Invul and Runes with equivalents- and All Weapons (Elimination).
 * Now it's possible to compile OAX on Mac (thanks EddieBrrrock!)
 * AI enhancements:
   * Holdable (Personal Teleporter/Medkit/Kamikaze/Invulnerability) handling.

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -1819,17 +1819,20 @@ void ClientSpawn(gentity_t *ent) {
 			client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_BFG );
 			client->ps.ammo[WP_BFG] = g_elimination_bfg.integer;
 		}
-		if (g_elimination_nail.integer > 0) {
-			client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_NAILGUN );
-			client->ps.ammo[WP_NAILGUN] = g_elimination_nail.integer;
-		}
-		if (g_elimination_mine.integer > 0) {
-			client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_PROX_LAUNCHER );
-			client->ps.ammo[WP_PROX_LAUNCHER] = g_elimination_mine.integer;
-		}
-		if (g_elimination_chain.integer > 0) {
-			client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_CHAINGUN );
-			client->ps.ammo[WP_CHAINGUN] = g_elimination_chain.integer;
+		// Classic Mode On prevents the TA weapons from being added to the inventory.
+		if (g_classicMode.integer <= 0) {
+			if (g_elimination_nail.integer > 0) {
+				client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_NAILGUN );
+				client->ps.ammo[WP_NAILGUN] = g_elimination_nail.integer;
+			}
+			if (g_elimination_mine.integer > 0) {
+				client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_PROX_LAUNCHER );
+				client->ps.ammo[WP_PROX_LAUNCHER] = g_elimination_mine.integer;
+			}
+			if (g_elimination_chain.integer > 0) {
+				client->ps.stats[STAT_WEAPONS] |= ( 1 << WP_CHAINGUN );
+				client->ps.ammo[WP_CHAINGUN] = g_elimination_chain.integer;
+			}
 		}
 
 		ent->health = client->ps.stats[STAT_ARMOR] = g_elimination_startArmor.integer; //client->ps.stats[STAT_MAX_HEALTH]*2;

--- a/code/game/g_spawn.c
+++ b/code/game/g_spawn.c
@@ -294,7 +294,7 @@ qboolean G_CallSpawn( gentity_t *ent ) {
 	char cvarname[128];
 	char itemname[128];
 
-	// Neon_Knight: In CTF, outside of Arena mode, these items replace the TA items and weapons.
+	// Neon_Knight: In Classic mode, these items replace the TA items and weapons.
 	if (g_classicMode.integer > 0) {
 		if (strequals(ent->classname, "weapon_nailgun")) {
 			Com_sprintf(itemname, sizeof(itemname), "weapon_shotgun");

--- a/code/q3_ui/ui_startserver.c
+++ b/code/q3_ui/ui_startserver.c
@@ -889,7 +889,7 @@ static const char *weaponArenaWeapon_list[] = {
 };
 
 static const char *weaponMode_list[] = {
-	"All Weapons (Classic)",
+	"All Weapons (Standard)",
 	"Instantgib",
 	"Single Weapon Arena",
 	"Classic Arena",
@@ -1474,7 +1474,7 @@ static void ServerOptions_StatusBar_WeaponMode( void* ptr ) {
 				UI_DrawString( 320, 460, "Players will spawn with all weapons.", UI_CENTER|UI_SMALLFONT, colorWhite );
 			}
 			else {
-				UI_DrawString( 320, 440, "All Weapons (Classic): No pickups removed.", UI_CENTER|UI_SMALLFONT, colorWhite );
+				UI_DrawString( 320, 440, "All Weapons (Standard): No pickups removed.", UI_CENTER|UI_SMALLFONT, colorWhite );
 				UI_DrawString( 320, 460, "Players spawn with Gauntlet and Machinegun.", UI_CENTER|UI_SMALLFONT, colorWhite );
 			}
 			break;


### PR DESCRIPTION
* Skirmish/Create Server: "All Weapons (Classic)" renamed to "All Weapons (Standard)" to prevent confusion with "Classic Arena".
* "Classic Arena" now prevents NG, CG and PL to be spawned in Elimination matches.