### PR TITLE
Restoring original behavior of CG_CheckOrderPending

### DIFF
--- a/code/cgame/cg_newdraw.c
+++ b/code/cgame/cg_newdraw.c
@@ -60,7 +60,7 @@ void CG_SetPrintString(int type, const char *p)
 
 void CG_CheckOrderPending(void)
 {
-	if (CG_IsADMBasedGametype(cgs.gametype)) {
+	if (CG_IsADMBasedGametype(cgs.gametype) || cgs.gametype == GT_TEAM) {
 		return;
 	}
 	if (cgs.orderPending) {


### PR DESCRIPTION
In the original code, the comparison was `cgs.gametype >= GT_CTF` i.e. it only applied to CTF, 1FCTF, Harv and Over. Here it's also useful for the round modes and DD/DOM.