### PR TITLE
Restored behavior of CG_ParseWarmup to that of the old game.

### DIFF
--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -400,7 +400,7 @@ static void CG_ParseWarmup( void ) {
 
 	} else if ( warmup > 0 && cg.warmup <= 0 ) {
 #ifdef MISSIONPACK
-		if (CG_IsATeamGametype(cgs.gametype)) {
+		if (CG_IsATeamGametype(cgs.gametype) && cgs.gametype != GT_TEAM) {
 			trap_S_StartLocalSound( cgs.media.countPrepareTeamSound, CHAN_ANNOUNCER );
 		} else
 #endif


### PR DESCRIPTION
The old comparison was `(cgs.gametype >= GT_CTF && cgs.gametype <= GT_HARVESTER)`, which means "all gametypes with a base". Here, we're extending it so it works with round-based gamemodes and both variants of Domination.