### PR TITLE
CG_EntityEvent: Rewritten some cases inside EV_GLOBAL_TEAM_SOUND so they don't play the wrong sound in the wrong gamemode.

### DIFF
--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -1262,65 +1262,86 @@ void CG_EntityEvent(centity_t *cent, vec3_t position) {
 			DEBUGNAME("EV_GLOBAL_TEAM_SOUND");
 			switch (es->eventParm) {
 				case GTS_RED_CAPTURE: // CTF: red team captured the blue flag, 1FCTF: red team captured the neutral flag
-					if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED)
+					if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
 						CG_AddBufferedSound(cgs.media.captureYourTeamSound);
-					else
+					}
+					else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
 						CG_AddBufferedSound(cgs.media.captureOpponentSound);
+					}
+					/* else {
+						CG_AddBufferedSound(cgs.media.captureRedTeamBlueFlag); // "The Red Team Captured The Blue Flag"
+					} */
 					break;
 				case GTS_BLUE_CAPTURE: // CTF: blue team captured the red flag, 1FCTF: blue team captured the neutral flag
-					if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE)
+					if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
 						CG_AddBufferedSound(cgs.media.captureYourTeamSound);
-					else
+					}
+					else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
 						CG_AddBufferedSound(cgs.media.captureOpponentSound);
+					}
+					/* else {
+						CG_AddBufferedSound(cgs.media.captureBlueTeamRedFlag); // "The Blue Team Captured The Red Flag"
+					} */
 					break;
 				case GTS_RED_RETURN: // CTF: blue flag returned, 1FCTF: never used
-					if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED)
+					if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
 						CG_AddBufferedSound(cgs.media.returnYourTeamSound);
-					else
+					}
+					else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
 						CG_AddBufferedSound(cgs.media.returnOpponentSound);
-					//
+					}
 					CG_AddBufferedSound(cgs.media.blueFlagReturnedSound);
 					break;
 				case GTS_BLUE_RETURN: // CTF red flag returned, 1FCTF: neutral flag returned
-					if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE)
+					if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
 						CG_AddBufferedSound(cgs.media.returnYourTeamSound);
-					else
+					}
+					else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
 						CG_AddBufferedSound(cgs.media.returnOpponentSound);
+					}
 					//
 					CG_AddBufferedSound(cgs.media.redFlagReturnedSound);
 					break;
 
 				case GTS_RED_TAKEN: // CTF: red team took blue flag, 1FCTF: blue team took the neutral flag
 					// if this player picked up the flag then a sound is played in CG_CheckLocalSounds
-					if (cg.snap->ps.powerups[PW_BLUEFLAG] || cg.snap->ps.powerups[PW_NEUTRALFLAG]) {
-					} else {
+					if (CG_UsesTeamFlags(cgs.gametype) && !cg.snap->ps.powerups[PW_BLUEFLAG] && !cg.snap->ps.powerups[PW_NEUTRALFLAG]) {
 						if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
-							if (CG_IsATeamGametype(cgs.gametype) && CG_UsesTheWhiteFlag(cgs.gametype))
+							if (CG_UsesTheWhiteFlag(cgs.gametype)) {
 								CG_AddBufferedSound(cgs.media.yourTeamTookTheFlagSound);
-							else
+							}
+							else {
 								CG_AddBufferedSound(cgs.media.enemyTookYourFlagSound);
-						} else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
-							if (CG_IsATeamGametype(cgs.gametype) && CG_UsesTheWhiteFlag(cgs.gametype))
+							}
+						}
+						else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
+							if (CG_UsesTheWhiteFlag(cgs.gametype)) {
 								CG_AddBufferedSound(cgs.media.enemyTookTheFlagSound);
-							else
+							}
+							else {
 								CG_AddBufferedSound(cgs.media.yourTeamTookEnemyFlagSound);
+							}
 						}
 					}
 					break;
 				case GTS_BLUE_TAKEN: // CTF: blue team took the red flag, 1FCTF red team took the neutral flag
 					// if this player picked up the flag then a sound is played in CG_CheckLocalSounds
-					if (cg.snap->ps.powerups[PW_REDFLAG] || cg.snap->ps.powerups[PW_NEUTRALFLAG]) {
-					} else {
+					if (CG_UsesTeamFlags(cgs.gametype) && !cg.snap->ps.powerups[PW_REDFLAG] && !cg.snap->ps.powerups[PW_NEUTRALFLAG]) {
 						if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_RED) {
-							if (CG_IsATeamGametype(cgs.gametype) && CG_UsesTheWhiteFlag(cgs.gametype))
+							if (CG_UsesTheWhiteFlag(cgs.gametype)) {
 								CG_AddBufferedSound(cgs.media.yourTeamTookTheFlagSound);
-							else
+							}
+							else {
 								CG_AddBufferedSound(cgs.media.enemyTookYourFlagSound);
-						} else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
-							if (CG_IsATeamGametype(cgs.gametype) && CG_UsesTheWhiteFlag(cgs.gametype))
+							}
+						}
+						else if (cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE) {
+							if (CG_UsesTheWhiteFlag(cgs.gametype)) {
 								CG_AddBufferedSound(cgs.media.enemyTookTheFlagSound);
-							else
+							}
+							else {
 								CG_AddBufferedSound(cgs.media.yourTeamTookEnemyFlagSound);
+							}
 						}
 					}
 					break;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -811,7 +811,6 @@ static void CG_RegisterSounds(void) {
 	// Sago: Makes perfect sense: Load team game stuff if the gametype is a teamgame and not an exception (like GT_LMS)
 	if (CG_IsATeamGametype(cgs.gametype) || cg_buildScript.integer) {
 
-		cgs.media.captureAwardSound = trap_S_RegisterSound("sound/teamplay/flagcapture_yourteam.wav", qtrue);
 		cgs.media.redLeadsSound = trap_S_RegisterSound("sound/feedback/redleads.wav", qtrue);
 		cgs.media.blueLeadsSound = trap_S_RegisterSound("sound/feedback/blueleads.wav", qtrue);
 		cgs.media.teamsTiedSound = trap_S_RegisterSound("sound/feedback/teamstied.wav", qtrue);
@@ -820,27 +819,32 @@ static void CG_RegisterSounds(void) {
 		cgs.media.redScoredSound = trap_S_RegisterSound("sound/teamplay/voc_red_scores.wav", qtrue);
 		cgs.media.blueScoredSound = trap_S_RegisterSound("sound/teamplay/voc_blue_scores.wav", qtrue);
 
-		cgs.media.captureYourTeamSound = trap_S_RegisterSound("sound/teamplay/flagcapture_yourteam.wav", qtrue);
-		cgs.media.captureOpponentSound = trap_S_RegisterSound("sound/teamplay/flagcapture_opponent.wav", qtrue);
+		if (CG_UsesTeamFlags(cgs.gametype) || cg_buildScript.integer) {
+			cgs.media.youHaveFlagSound = trap_S_RegisterSound("sound/teamplay/voc_you_flag.wav", qtrue);
+			cgs.media.captureAwardSound = trap_S_RegisterSound("sound/teamplay/flagcapture_yourteam.wav", qtrue);
 
-		cgs.media.returnYourTeamSound = trap_S_RegisterSound("sound/teamplay/flagreturn_yourteam.wav", qtrue);
-		cgs.media.returnOpponentSound = trap_S_RegisterSound("sound/teamplay/flagreturn_opponent.wav", qtrue);
+			if (CG_UsesTheWhiteFlag(cgs.gametype)) {
+				// FIXME: get a replacement for this sound ?
+				cgs.media.neutralFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/flagreturn_opponent.wav", qtrue);
+				cgs.media.yourTeamTookTheFlagSound = trap_S_RegisterSound("sound/teamplay/voc_team_1flag.wav", qtrue);
+				cgs.media.enemyTookTheFlagSound = trap_S_RegisterSound("sound/teamplay/voc_enemy_1flag.wav", qtrue);
+			}
+			else {
+				cgs.media.redFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/voc_red_returned.wav", qtrue);
+				cgs.media.blueFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/voc_blue_returned.wav", qtrue);
 
-		cgs.media.takenYourTeamSound = trap_S_RegisterSound("sound/teamplay/flagtaken_yourteam.wav", qtrue);
-		cgs.media.takenOpponentSound = trap_S_RegisterSound("sound/teamplay/flagtaken_opponent.wav", qtrue);
+				cgs.media.enemyTookYourFlagSound = trap_S_RegisterSound("sound/teamplay/voc_enemy_flag.wav", qtrue);
+				cgs.media.yourTeamTookEnemyFlagSound = trap_S_RegisterSound("sound/teamplay/voc_team_flag.wav", qtrue);
 
-		if ((CG_UsesTeamFlags(cgs.gametype) && !CG_UsesTheWhiteFlag(cgs.gametype)) || cg_buildScript.integer) {
-			cgs.media.redFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/voc_red_returned.wav", qtrue);
-			cgs.media.blueFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/voc_blue_returned.wav", qtrue);
-			cgs.media.enemyTookYourFlagSound = trap_S_RegisterSound("sound/teamplay/voc_enemy_flag.wav", qtrue);
-			cgs.media.yourTeamTookEnemyFlagSound = trap_S_RegisterSound("sound/teamplay/voc_team_flag.wav", qtrue);
-		}
+				cgs.media.captureYourTeamSound = trap_S_RegisterSound("sound/teamplay/flagcapture_yourteam.wav", qtrue);
+				cgs.media.captureOpponentSound = trap_S_RegisterSound("sound/teamplay/flagcapture_opponent.wav", qtrue);
 
-		if (CG_UsesTheWhiteFlag(cgs.gametype) || cg_buildScript.integer) {
-			// FIXME: get a replacement for this sound ?
-			cgs.media.neutralFlagReturnedSound = trap_S_RegisterSound("sound/teamplay/flagreturn_opponent.wav", qtrue);
-			cgs.media.yourTeamTookTheFlagSound = trap_S_RegisterSound("sound/teamplay/voc_team_1flag.wav", qtrue);
-			cgs.media.enemyTookTheFlagSound = trap_S_RegisterSound("sound/teamplay/voc_enemy_1flag.wav", qtrue);
+				cgs.media.returnYourTeamSound = trap_S_RegisterSound("sound/teamplay/flagreturn_yourteam.wav", qtrue);
+				cgs.media.returnOpponentSound = trap_S_RegisterSound("sound/teamplay/flagreturn_opponent.wav", qtrue);
+
+				cgs.media.takenYourTeamSound = trap_S_RegisterSound("sound/teamplay/flagtaken_yourteam.wav", qtrue);
+				cgs.media.takenOpponentSound = trap_S_RegisterSound("sound/teamplay/flagtaken_opponent.wav", qtrue);
+			}
 		}
 
 		if (cgs.gametype == GT_OBELISK || cg_buildScript.integer) {
@@ -854,11 +858,7 @@ static void CG_RegisterSounds(void) {
 		}
 	}
 
-
-	if (CG_UsesTeamFlags(cgs.gametype) || CG_UsesTheWhiteFlag(cgs.gametype) || cg_buildScript.integer) {
-		cgs.media.youHaveFlagSound = trap_S_RegisterSound("sound/teamplay/voc_you_flag.wav", qtrue);
-		cgs.media.holyShitSound = trap_S_RegisterSound("sound/feedback/voc_holyshit.wav", qtrue);
-	}
+	cgs.media.holyShitSound = trap_S_RegisterSound("sound/feedback/voc_holyshit.wav", qtrue);
 
 	cgs.media.tracerSound = trap_S_RegisterSound("sound/weapons/machinegun/buletby1.wav", qfalse);
 	cgs.media.selectSound = trap_S_RegisterSound("sound/weapons/change.wav", qfalse);


### PR DESCRIPTION
Surely will be available in today's (or tomorrow's) nightly build.

Testing:
* Open a CTF/eCTF match with all 12 bots in any supported map. Pay attention to the announcer:
  * _"Your team has the enemy flag"_ should play whenever any of your attacking bots has your team's flag.
  * _"The enemy has your flag"_ should play whenever any of the enemy bots has your team's flag.
* Now open a 1FCTF match, also with 12 bots in any supported map. Pay again attention to the announcer:
  * _"Your team has the flag"_ whenever any bot of your team has the neutral flag.
  * _"The enemy has the flag"_ whenever any bot of the enemy team has the neutral flag.
* Open a match in any other gamemode. Pay attention if the above announcements play. If not, there's no problem. If they do, there _is_ a problem and needs to be solved. Pay attention in which moment it plays.